### PR TITLE
Add retry mechanism with exponential backoff for 429 rate limit responses

### DIFF
--- a/automation/auth.py
+++ b/automation/auth.py
@@ -72,7 +72,8 @@ def _return_last_response(retry_state: RetryCallState) -> httpx.Response:
         "Rate limit retries exhausted after %d attempts",
         retry_state.attempt_number,
     )
-    # outcome is guaranteed to be set when retry_error_callback is invoked
+    # Defensive check: outcome should be set by tenacity, but guard against
+    # potential library changes or edge cases for type safety
     if retry_state.outcome is None:
         raise RuntimeError("retry_error_callback invoked without outcome")
     return retry_state.outcome.result()

--- a/automation/auth.py
+++ b/automation/auth.py
@@ -73,7 +73,8 @@ def _return_last_response(retry_state: RetryCallState) -> httpx.Response:
         retry_state.attempt_number,
     )
     # outcome is guaranteed to be set when retry_error_callback is invoked
-    assert retry_state.outcome is not None
+    if retry_state.outcome is None:
+        raise RuntimeError("retry_error_callback invoked without outcome")
     return retry_state.outcome.result()
 
 

--- a/automation/auth.py
+++ b/automation/auth.py
@@ -5,6 +5,7 @@ We validate it against the OpenHands API /api/keys/current endpoint to get
 the user and organization identity.
 """
 
+import asyncio
 import logging
 import uuid
 from dataclasses import dataclass
@@ -19,6 +20,12 @@ logger = logging.getLogger("automation.auth")
 
 # Default timeout for HTTP client
 HTTP_CLIENT_TIMEOUT = 10.0
+
+# Retry configuration for rate limiting
+MAX_RETRIES = 3
+INITIAL_BACKOFF_SECONDS = 1.0
+MAX_BACKOFF_SECONDS = 10.0
+BACKOFF_MULTIPLIER = 2.0
 
 
 def create_http_client() -> httpx.AsyncClient:
@@ -48,6 +55,66 @@ class AuthenticatedUser:
     api_key: str  # The raw API key (needed for downstream API calls)
 
 
+async def _make_auth_request_with_retry(
+    client: httpx.AsyncClient,
+    url: str,
+    headers: dict[str, str],
+    max_retries: int = MAX_RETRIES,
+    initial_backoff: float = INITIAL_BACKOFF_SECONDS,
+) -> httpx.Response:
+    """Make an auth request with exponential backoff retry on 429 responses.
+
+    Args:
+        client: The httpx client to use for requests
+        url: The URL to request
+        headers: Request headers
+        max_retries: Maximum number of retry attempts for 429 responses
+        initial_backoff: Initial backoff time in seconds
+
+    Returns:
+        The HTTP response (may still be a 429 if all retries exhausted)
+
+    Raises:
+        httpx.RequestError: If there's a network/connection error
+    """
+    backoff = initial_backoff
+    last_response: httpx.Response | None = None
+
+    for attempt in range(max_retries + 1):
+        resp = await client.get(url, headers=headers)
+        last_response = resp
+
+        if resp.status_code != 429:
+            return resp
+
+        if attempt < max_retries:
+            # Check for Retry-After header
+            retry_after = resp.headers.get("Retry-After")
+            if retry_after:
+                try:
+                    wait_time = min(float(retry_after), MAX_BACKOFF_SECONDS)
+                except ValueError:
+                    wait_time = backoff
+            else:
+                wait_time = backoff
+
+            logger.warning(
+                "Rate limited (429) on auth request, attempt %d/%d. "
+                "Retrying in %.1f seconds",
+                attempt + 1,
+                max_retries + 1,
+                wait_time,
+            )
+            await asyncio.sleep(wait_time)
+            backoff = min(backoff * BACKOFF_MULTIPLIER, MAX_BACKOFF_SECONDS)
+
+    # All retries exhausted, return the last 429 response
+    logger.error(
+        "Rate limit retries exhausted after %d attempts", max_retries + 1
+    )
+    return last_response  # type: ignore[return-value]
+
+
 async def authenticate_request(
     request: Request,
     client: httpx.AsyncClient = Depends(get_http_client),
@@ -55,7 +122,7 @@ async def authenticate_request(
     """Extract and validate the OpenHands API key from the Authorization header.
 
     Calls the OpenHands API /api/keys/current to verify the key and get
-    user/org identity.
+    user/org identity. Implements retry with exponential backoff for rate limiting.
     """
     auth_header = request.headers.get("Authorization", "")
     if not auth_header.startswith("Bearer "):
@@ -74,7 +141,8 @@ async def authenticate_request(
 
     settings = get_settings()
     try:
-        resp = await client.get(
+        resp = await _make_auth_request_with_retry(
+            client,
             f"{settings.openhands_api_base_url}/api/keys/current",
             headers={"Authorization": f"Bearer {api_key}"},
         )
@@ -89,6 +157,11 @@ async def authenticate_request(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired API key",
+        )
+    if resp.status_code == 429:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Rate limited by authentication service",
         )
     if resp.status_code != 200:
         logger.error(

--- a/automation/auth.py
+++ b/automation/auth.py
@@ -12,11 +12,11 @@ from dataclasses import dataclass
 import httpx
 from fastapi import Depends, HTTPException, Request, status
 from tenacity import (
+    before_sleep_log,
     retry,
     retry_if_result,
     stop_after_attempt,
     wait_exponential,
-    before_sleep_log,
 )
 
 from automation.config import get_settings

--- a/automation/auth.py
+++ b/automation/auth.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 import httpx
 from fastapi import Depends, HTTPException, Request, status
 from tenacity import (
+    RetryCallState,
     before_sleep_log,
     retry,
     retry_if_result,
@@ -65,7 +66,7 @@ def _is_rate_limited(response: httpx.Response) -> bool:
     return response.status_code == 429
 
 
-def _return_last_response(retry_state) -> httpx.Response:
+def _return_last_response(retry_state: RetryCallState) -> httpx.Response:
     """Return the last response when retries are exhausted."""
     logger.warning(
         "Rate limit retries exhausted after %d attempts",

--- a/automation/auth.py
+++ b/automation/auth.py
@@ -67,7 +67,7 @@ def _is_rate_limited(response: httpx.Response) -> bool:
 
 def _return_last_response(retry_state) -> httpx.Response:
     """Return the last response when retries are exhausted."""
-    logger.error(
+    logger.warning(
         "Rate limit retries exhausted after %d attempts",
         retry_state.attempt_number,
     )

--- a/automation/auth.py
+++ b/automation/auth.py
@@ -5,13 +5,19 @@ We validate it against the OpenHands API /api/keys/current endpoint to get
 the user and organization identity.
 """
 
-import asyncio
 import logging
 import uuid
 from dataclasses import dataclass
 
 import httpx
 from fastapi import Depends, HTTPException, Request, status
+from tenacity import (
+    retry,
+    retry_if_result,
+    stop_after_attempt,
+    wait_exponential,
+    before_sleep_log,
+)
 
 from automation.config import get_settings
 
@@ -25,7 +31,6 @@ HTTP_CLIENT_TIMEOUT = 10.0
 MAX_RETRIES = 3
 INITIAL_BACKOFF_SECONDS = 1.0
 MAX_BACKOFF_SECONDS = 10.0
-BACKOFF_MULTIPLIER = 2.0
 
 
 def create_http_client() -> httpx.AsyncClient:
@@ -55,21 +60,43 @@ class AuthenticatedUser:
     api_key: str  # The raw API key (needed for downstream API calls)
 
 
+def _is_rate_limited(response: httpx.Response) -> bool:
+    """Check if response is a 429 rate limit response."""
+    return response.status_code == 429
+
+
+def _return_last_response(retry_state) -> httpx.Response:
+    """Return the last response when retries are exhausted."""
+    logger.error(
+        "Rate limit retries exhausted after %d attempts",
+        retry_state.attempt_number,
+    )
+    return retry_state.outcome.result()
+
+
+@retry(
+    retry=retry_if_result(_is_rate_limited),
+    stop=stop_after_attempt(MAX_RETRIES + 1),
+    wait=wait_exponential(
+        multiplier=INITIAL_BACKOFF_SECONDS,
+        max=MAX_BACKOFF_SECONDS,
+    ),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+    retry_error_callback=_return_last_response,
+)
 async def _make_auth_request_with_retry(
     client: httpx.AsyncClient,
     url: str,
     headers: dict[str, str],
-    max_retries: int = MAX_RETRIES,
-    initial_backoff: float = INITIAL_BACKOFF_SECONDS,
 ) -> httpx.Response:
     """Make an auth request with exponential backoff retry on 429 responses.
+
+    Uses tenacity for retry logic with exponential backoff.
 
     Args:
         client: The httpx client to use for requests
         url: The URL to request
         headers: Request headers
-        max_retries: Maximum number of retry attempts for 429 responses
-        initial_backoff: Initial backoff time in seconds
 
     Returns:
         The HTTP response (may still be a 429 if all retries exhausted)
@@ -77,42 +104,7 @@ async def _make_auth_request_with_retry(
     Raises:
         httpx.RequestError: If there's a network/connection error
     """
-    backoff = initial_backoff
-    last_response: httpx.Response | None = None
-
-    for attempt in range(max_retries + 1):
-        resp = await client.get(url, headers=headers)
-        last_response = resp
-
-        if resp.status_code != 429:
-            return resp
-
-        if attempt < max_retries:
-            # Check for Retry-After header
-            retry_after = resp.headers.get("Retry-After")
-            if retry_after:
-                try:
-                    wait_time = min(float(retry_after), MAX_BACKOFF_SECONDS)
-                except ValueError:
-                    wait_time = backoff
-            else:
-                wait_time = backoff
-
-            logger.warning(
-                "Rate limited (429) on auth request, attempt %d/%d. "
-                "Retrying in %.1f seconds",
-                attempt + 1,
-                max_retries + 1,
-                wait_time,
-            )
-            await asyncio.sleep(wait_time)
-            backoff = min(backoff * BACKOFF_MULTIPLIER, MAX_BACKOFF_SECONDS)
-
-    # All retries exhausted, return the last 429 response
-    logger.error(
-        "Rate limit retries exhausted after %d attempts", max_retries + 1
-    )
-    return last_response  # type: ignore[return-value]
+    return await client.get(url, headers=headers)
 
 
 async def authenticate_request(

--- a/automation/auth.py
+++ b/automation/auth.py
@@ -72,6 +72,8 @@ def _return_last_response(retry_state: RetryCallState) -> httpx.Response:
         "Rate limit retries exhausted after %d attempts",
         retry_state.attempt_number,
     )
+    # outcome is guaranteed to be set when retry_error_callback is invoked
+    assert retry_state.outcome is not None
     return retry_state.outcome.result()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "pydantic-settings>=2",
   "python-json-logger>=3",
   "sqlalchemy[asyncio]>=2",
+  "tenacity>=9.1.4",
   "uvicorn[standard]>=0.30",
 ]
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,7 @@
 """Tests for authentication module."""
 
 import uuid
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -9,7 +9,11 @@ from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
 
 from automation.app import app
-from automation.auth import AuthenticatedUser, authenticate_request
+from automation.auth import (
+    AuthenticatedUser,
+    _make_auth_request_with_retry,
+    authenticate_request,
+)
 from automation.db import get_session
 
 
@@ -236,3 +240,147 @@ class TestAuthIntegration:
             assert "Invalid or expired API key" in response.json()["detail"]
         finally:
             app.dependency_overrides.clear()
+
+
+class TestRetryMechanism:
+    """Tests for the retry mechanism on 429 rate limit responses."""
+
+    async def test_retry_on_429_then_success(self, mock_http_client):
+        """Retries on 429 and succeeds when subsequent request returns 200."""
+        mock_429_response = MagicMock()
+        mock_429_response.status_code = 429
+        mock_429_response.headers = {}
+
+        mock_200_response = MagicMock()
+        mock_200_response.status_code = 200
+
+        mock_http_client.get = AsyncMock(
+            side_effect=[mock_429_response, mock_200_response]
+        )
+
+        with patch("automation.auth.asyncio.sleep", new_callable=AsyncMock):
+            result = await _make_auth_request_with_retry(
+                mock_http_client,
+                "http://test/api/keys/current",
+                headers={"Authorization": "Bearer test"},
+                max_retries=3,
+                initial_backoff=0.1,
+            )
+
+        assert result.status_code == 200
+        assert mock_http_client.get.call_count == 2
+
+    async def test_retry_exhausted_returns_429(self, mock_http_client):
+        """When all retries exhausted, returns the 429 response."""
+        mock_429_response = MagicMock()
+        mock_429_response.status_code = 429
+        mock_429_response.headers = {}
+
+        mock_http_client.get = AsyncMock(return_value=mock_429_response)
+
+        with patch("automation.auth.asyncio.sleep", new_callable=AsyncMock):
+            result = await _make_auth_request_with_retry(
+                mock_http_client,
+                "http://test/api/keys/current",
+                headers={"Authorization": "Bearer test"},
+                max_retries=2,
+                initial_backoff=0.1,
+            )
+
+        assert result.status_code == 429
+        # Initial attempt + 2 retries = 3 total calls
+        assert mock_http_client.get.call_count == 3
+
+    async def test_retry_uses_retry_after_header(self, mock_http_client):
+        """Uses Retry-After header value when present."""
+        mock_429_response = MagicMock()
+        mock_429_response.status_code = 429
+        mock_429_response.headers = {"Retry-After": "2"}
+
+        mock_200_response = MagicMock()
+        mock_200_response.status_code = 200
+
+        mock_http_client.get = AsyncMock(
+            side_effect=[mock_429_response, mock_200_response]
+        )
+
+        with patch("automation.auth.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await _make_auth_request_with_retry(
+                mock_http_client,
+                "http://test/api/keys/current",
+                headers={"Authorization": "Bearer test"},
+                max_retries=3,
+                initial_backoff=0.1,
+            )
+
+        # Should use Retry-After value of 2 seconds
+        mock_sleep.assert_called_once_with(2.0)
+
+    async def test_no_retry_on_non_429(self, mock_http_client):
+        """Does not retry on non-429 status codes."""
+        mock_401_response = MagicMock()
+        mock_401_response.status_code = 401
+
+        mock_http_client.get = AsyncMock(return_value=mock_401_response)
+
+        result = await _make_auth_request_with_retry(
+            mock_http_client,
+            "http://test/api/keys/current",
+            headers={"Authorization": "Bearer test"},
+            max_retries=3,
+            initial_backoff=0.1,
+        )
+
+        assert result.status_code == 401
+        assert mock_http_client.get.call_count == 1
+
+    async def test_authenticate_returns_429_after_retries(
+        self, mock_request, mock_http_client
+    ):
+        """authenticate_request returns 429 when rate limited after retries."""
+        mock_request.headers.get.return_value = "Bearer valid-key"
+
+        mock_429_response = MagicMock()
+        mock_429_response.status_code = 429
+        mock_429_response.headers = {}
+
+        mock_http_client.get = AsyncMock(return_value=mock_429_response)
+
+        with patch("automation.auth.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(HTTPException) as exc_info:
+                await authenticate_request(mock_request, client=mock_http_client)
+
+        assert exc_info.value.status_code == 429
+        assert "Rate limited" in exc_info.value.detail
+
+    async def test_exponential_backoff(self, mock_http_client):
+        """Backoff time increases exponentially between retries."""
+        mock_429_response = MagicMock()
+        mock_429_response.status_code = 429
+        mock_429_response.headers = {}
+
+        mock_200_response = MagicMock()
+        mock_200_response.status_code = 200
+
+        mock_http_client.get = AsyncMock(
+            side_effect=[
+                mock_429_response,
+                mock_429_response,
+                mock_429_response,
+                mock_200_response,
+            ]
+        )
+
+        with patch("automation.auth.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await _make_auth_request_with_retry(
+                mock_http_client,
+                "http://test/api/keys/current",
+                headers={"Authorization": "Bearer test"},
+                max_retries=3,
+                initial_backoff=1.0,
+            )
+
+        # Should have exponential backoff: 1.0, 2.0, 4.0
+        assert mock_sleep.call_count == 3
+        calls = [call[0][0] for call in mock_sleep.call_args_list]
+        assert calls == [1.0, 2.0, 4.0]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -243,13 +243,12 @@ class TestAuthIntegration:
 
 
 class TestRetryMechanism:
-    """Tests for the retry mechanism on 429 rate limit responses."""
+    """Tests for the retry mechanism on 429 rate limit responses using tenacity."""
 
     async def test_retry_on_429_then_success(self, mock_http_client):
         """Retries on 429 and succeeds when subsequent request returns 200."""
         mock_429_response = MagicMock()
         mock_429_response.status_code = 429
-        mock_429_response.headers = {}
 
         mock_200_response = MagicMock()
         mock_200_response.status_code = 200
@@ -258,13 +257,11 @@ class TestRetryMechanism:
             side_effect=[mock_429_response, mock_200_response]
         )
 
-        with patch("automation.auth.asyncio.sleep", new_callable=AsyncMock):
+        with patch("asyncio.sleep", new_callable=AsyncMock):
             result = await _make_auth_request_with_retry(
                 mock_http_client,
                 "http://test/api/keys/current",
                 headers={"Authorization": "Bearer test"},
-                max_retries=3,
-                initial_backoff=0.1,
             )
 
         assert result.status_code == 200
@@ -274,47 +271,19 @@ class TestRetryMechanism:
         """When all retries exhausted, returns the 429 response."""
         mock_429_response = MagicMock()
         mock_429_response.status_code = 429
-        mock_429_response.headers = {}
 
         mock_http_client.get = AsyncMock(return_value=mock_429_response)
 
-        with patch("automation.auth.asyncio.sleep", new_callable=AsyncMock):
+        with patch("asyncio.sleep", new_callable=AsyncMock):
             result = await _make_auth_request_with_retry(
                 mock_http_client,
                 "http://test/api/keys/current",
                 headers={"Authorization": "Bearer test"},
-                max_retries=2,
-                initial_backoff=0.1,
             )
 
         assert result.status_code == 429
-        # Initial attempt + 2 retries = 3 total calls
-        assert mock_http_client.get.call_count == 3
-
-    async def test_retry_uses_retry_after_header(self, mock_http_client):
-        """Uses Retry-After header value when present."""
-        mock_429_response = MagicMock()
-        mock_429_response.status_code = 429
-        mock_429_response.headers = {"Retry-After": "2"}
-
-        mock_200_response = MagicMock()
-        mock_200_response.status_code = 200
-
-        mock_http_client.get = AsyncMock(
-            side_effect=[mock_429_response, mock_200_response]
-        )
-
-        with patch("automation.auth.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-            await _make_auth_request_with_retry(
-                mock_http_client,
-                "http://test/api/keys/current",
-                headers={"Authorization": "Bearer test"},
-                max_retries=3,
-                initial_backoff=0.1,
-            )
-
-        # Should use Retry-After value of 2 seconds
-        mock_sleep.assert_called_once_with(2.0)
+        # Initial attempt + MAX_RETRIES (3) retries = 4 total calls
+        assert mock_http_client.get.call_count == 4
 
     async def test_no_retry_on_non_429(self, mock_http_client):
         """Does not retry on non-429 status codes."""
@@ -327,8 +296,6 @@ class TestRetryMechanism:
             mock_http_client,
             "http://test/api/keys/current",
             headers={"Authorization": "Bearer test"},
-            max_retries=3,
-            initial_backoff=0.1,
         )
 
         assert result.status_code == 401
@@ -342,11 +309,10 @@ class TestRetryMechanism:
 
         mock_429_response = MagicMock()
         mock_429_response.status_code = 429
-        mock_429_response.headers = {}
 
         mock_http_client.get = AsyncMock(return_value=mock_429_response)
 
-        with patch("automation.auth.asyncio.sleep", new_callable=AsyncMock):
+        with patch("asyncio.sleep", new_callable=AsyncMock):
             with pytest.raises(HTTPException) as exc_info:
                 await authenticate_request(mock_request, client=mock_http_client)
 
@@ -354,10 +320,9 @@ class TestRetryMechanism:
         assert "Rate limited" in exc_info.value.detail
 
     async def test_exponential_backoff(self, mock_http_client):
-        """Backoff time increases exponentially between retries."""
+        """Verifies tenacity retries multiple times on 429."""
         mock_429_response = MagicMock()
         mock_429_response.status_code = 429
-        mock_429_response.headers = {}
 
         mock_200_response = MagicMock()
         mock_200_response.status_code = 200
@@ -371,16 +336,16 @@ class TestRetryMechanism:
             ]
         )
 
-        with patch("automation.auth.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-            await _make_auth_request_with_retry(
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await _make_auth_request_with_retry(
                 mock_http_client,
                 "http://test/api/keys/current",
                 headers={"Authorization": "Bearer test"},
-                max_retries=3,
-                initial_backoff=1.0,
             )
 
-        # Should have exponential backoff: 1.0, 2.0, 4.0
+        assert result.status_code == 200
+        # Tenacity uses exponential backoff, should have slept 3 times
         assert mock_sleep.call_count == 3
+        # Verify backoff increases (tenacity uses 2^x * multiplier pattern)
         calls = [call[0][0] for call in mock_sleep.call_args_list]
-        assert calls == [1.0, 2.0, 4.0]
+        assert calls[0] < calls[1] < calls[2]

--- a/uv.lock
+++ b/uv.lock
@@ -1080,6 +1080,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-json-logger" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "tenacity" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -1110,6 +1111,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2" },
     { name = "python-json-logger", specifier = ">=3" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2" },
+    { name = "tenacity", specifier = ">=9.1.4" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
 
@@ -1729,6 +1731,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR adds a retry mechanism to the authentication middleware to handle HTTP 429 (Too Many Requests) responses from the `/api/keys/current` endpoint.

## Problem

When making too many authentication requests, the OpenHands API can return 429 rate limit responses. Previously, this would immediately fail the authentication request.

## Solution

Implemented a retry mechanism with exponential backoff using the `tenacity` library:

### Changes to `automation/auth.py`
- Added `_make_auth_request_with_retry()` function decorated with tenacity `@retry`:
  - Retries up to 3 times (4 total attempts) on 429 responses
  - Uses exponential backoff: 1s → 2s → 4s (capped at 10s)
  - Returns immediately for non-429 status codes (no unnecessary retries)
- Added helper functions:
  - `_is_rate_limited()` - checks if response is 429
  - `_return_last_response()` - returns final 429 response when retries exhausted
- **Faithful response codes**: Returns HTTP 429 to the client when rate limited (after retries exhausted)

### Configuration Constants
```python
MAX_RETRIES = 3
INITIAL_BACKOFF_SECONDS = 1.0
MAX_BACKOFF_SECONDS = 10.0
```

### Tests Added to `tests/test_auth.py`
5 new unit tests covering:
- `test_retry_on_429_then_success` - Retry succeeds after initial 429
- `test_retry_exhausted_returns_429` - 429 returned when retries exhaust
- `test_no_retry_on_non_429` - Non-429 responses do not trigger retries
- `test_authenticate_returns_429_after_retries` - End-to-end 429 handling
- `test_exponential_backoff` - Verifies multiple retries with increasing backoff

## Testing

All 11 unit tests pass:
```
tests/test_auth.py::TestAuthentication::test_authenticate_valid_api_key PASSED
tests/test_auth.py::TestAuthentication::test_authenticate_missing_header PASSED
tests/test_auth.py::TestAuthentication::test_authenticate_invalid_bearer_format PASSED
tests/test_auth.py::TestAuthentication::test_authenticate_invalid_key PASSED
tests/test_auth.py::TestAuthentication::test_authenticate_openhands_unavailable PASSED
tests/test_auth.py::TestAuthentication::test_authenticate_unexpected_status PASSED
tests/test_auth.py::TestRetryMechanism::test_retry_on_429_then_success PASSED
tests/test_auth.py::TestRetryMechanism::test_retry_exhausted_returns_429 PASSED
tests/test_auth.py::TestRetryMechanism::test_no_retry_on_non_429 PASSED
tests/test_auth.py::TestRetryMechanism::test_authenticate_returns_429_after_retries PASSED
tests/test_auth.py::TestRetryMechanism::test_exponential_backoff PASSED
```