### PR TITLE
Add CI to trigger deploy preview for automation PRs

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -33,8 +33,6 @@ jobs:
         permissions:
             contents: read
             packages: write
-        outputs:
-            image_pushed: ${{ steps.build-push.outcome == 'success' }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -33,6 +33,8 @@ jobs:
         permissions:
             contents: read
             packages: write
+        outputs:
+            image_pushed: ${{ steps.build-push.outcome == 'success' }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -76,6 +78,7 @@ jobs:
                   DOCKER_METADATA_PR_HEAD_SHA: true
 
             - name: Build and push Docker image
+              id: build-push
               if: '!github.event.pull_request.head.repo.fork'
               uses: docker/build-push-action@v5
               with:
@@ -100,3 +103,21 @@ jobs:
                   push: false
                   tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.RELEVANT_SHA }}
                   platforms: linux/amd64
+
+    trigger-deploy-preview:
+        name: Trigger Deploy Preview
+        needs: ghcr_build
+        # Only trigger for PRs from non-fork repos after successful image push
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
+        runs-on: ubuntu-24.04
+        steps:
+            - name: Trigger deploy preview workflow
+              env:
+                  GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+              run: |
+                  gh workflow run trigger-deploy-preview.yml \
+                    --repo ${{ github.repository }} \
+                    --ref main \
+                    -f pr_number=${{ github.event.pull_request.number }} \
+                    -f head_sha=${{ env.RELEVANT_SHA }} \
+                    -f pr_title="${{ github.event.pull_request.title }}"

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -109,15 +109,10 @@ jobs:
         needs: ghcr_build
         # Only trigger for PRs from non-fork repos after successful image push
         if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
-        runs-on: ubuntu-24.04
-        steps:
-            - name: Trigger deploy preview workflow
-              env:
-                  GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
-              run: |
-                  gh workflow run trigger-deploy-preview.yml \
-                    --repo ${{ github.repository }} \
-                    --ref main \
-                    -f pr_number=${{ github.event.pull_request.number }} \
-                    -f head_sha=${{ env.RELEVANT_SHA }} \
-                    -f pr_title="${{ github.event.pull_request.title }}"
+        uses: ./.github/workflows/trigger-deploy-preview.yml
+        with:
+            pr_number: ${{ github.event.pull_request.number }}
+            head_sha: ${{ github.event.pull_request.head.sha }}
+            pr_title: ${{ github.event.pull_request.title }}
+        secrets:
+            ALLHANDS_BOT_GITHUB_PAT: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -76,7 +76,6 @@ jobs:
                   DOCKER_METADATA_PR_HEAD_SHA: true
 
             - name: Build and push Docker image
-              id: build-push
               if: '!github.event.pull_request.head.repo.fork'
               uses: docker/build-push-action@v5
               with:

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -105,7 +105,7 @@ jobs:
     trigger-deploy-preview:
         name: Trigger Deploy Preview
         needs: ghcr_build
-        # Only trigger for PRs from non-fork repos after successful image push
+        # Only trigger for PRs from non-fork repos (fork check mirrors the push condition in ghcr_build)
         if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         uses: ./.github/workflows/trigger-deploy-preview.yml
         with:

--- a/.github/workflows/trigger-deploy-preview.yml
+++ b/.github/workflows/trigger-deploy-preview.yml
@@ -58,8 +58,6 @@ jobs:
 
             - name: Update AUTOMATION_SHA and push
               id: deploy-pr
-              env:
-                  GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
               run: |
                   cd deploy-repo
                   BRANCH_NAME="au-pr-${{ inputs.pr_number }}"
@@ -165,11 +163,6 @@ jobs:
                       const deployPrUrl = process.env.DEPLOY_PR_URL;
                       const headSha = '${{ inputs.head_sha }}';
                       const hasChanges = process.env.HAS_CHANGES === 'true';
-
-                      if (!deployPrUrl) {
-                        console.log('No deploy PR URL available, skipping comment');
-                        return;
-                      }
 
                       const etTime = new Intl.DateTimeFormat('en-US', {
                         timeZone: 'America/New_York',

--- a/.github/workflows/trigger-deploy-preview.yml
+++ b/.github/workflows/trigger-deploy-preview.yml
@@ -7,15 +7,15 @@ on:
     workflow_call:
         inputs:
             pr_number:
-                description: 'The automation PR number'
+                description: The automation PR number
                 required: true
                 type: string
             head_sha:
-                description: 'The commit SHA to deploy'
+                description: The commit SHA to deploy
                 required: true
                 type: string
             pr_title:
-                description: 'The PR title'
+                description: The PR title
                 required: true
                 type: string
         secrets:

--- a/.github/workflows/trigger-deploy-preview.yml
+++ b/.github/workflows/trigger-deploy-preview.yml
@@ -4,7 +4,7 @@
 name: Trigger Deploy Preview
 
 on:
-    workflow_dispatch:
+    workflow_call:
         inputs:
             pr_number:
                 description: 'The automation PR number'
@@ -18,6 +18,9 @@ on:
                 description: 'The PR title'
                 required: true
                 type: string
+        secrets:
+            ALLHANDS_BOT_GITHUB_PAT:
+                required: true
 
 env:
     DEPLOY_REPO: OpenHands/deploy

--- a/.github/workflows/trigger-deploy-preview.yml
+++ b/.github/workflows/trigger-deploy-preview.yml
@@ -24,6 +24,7 @@ on:
 
 env:
     DEPLOY_REPO: OpenHands/deploy
+    BASE_BRANCH: automations-project
 
 jobs:
     trigger-deploy:
@@ -44,6 +45,7 @@ jobs:
               uses: actions/checkout@v4
               with:
                   repository: ${{ env.DEPLOY_REPO }}
+                  ref: ${{ env.BASE_BRANCH }}
                   token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
                   fetch-depth: 0
                   path: deploy-repo
@@ -58,6 +60,7 @@ jobs:
               run: |
                   cd deploy-repo
                   BRANCH_NAME="au-pr-${PR_NUMBER}"
+                  BASE_BRANCH="${{ env.BASE_BRANCH }}"
 
                   # Configure git
                   git config user.name "all-hands-bot"
@@ -68,9 +71,11 @@ jobs:
                     echo "Branch $BRANCH_NAME exists, checking it out"
                     git fetch origin "$BRANCH_NAME"
                     git checkout "$BRANCH_NAME"
-                    git pull origin "$BRANCH_NAME"
+                    # Rebase on top of base branch to get latest changes
+                    git fetch origin "$BASE_BRANCH"
+                    git rebase "origin/$BASE_BRANCH" || git rebase --abort
                   else
-                    echo "Creating new branch $BRANCH_NAME"
+                    echo "Creating new branch $BRANCH_NAME from $BASE_BRANCH"
                     git checkout -b "$BRANCH_NAME"
                   fi
 
@@ -119,14 +124,14 @@ jobs:
                   cd deploy-repo
 
                   # Check if PR already exists for this branch
-                  EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --json number,url --jq '.[0]')
+                  EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --base "${{ env.BASE_BRANCH }}" --json number,url --jq '.[0]')
 
                   if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
                     PR_URL=$(echo "$EXISTING_PR" | jq -r '.url')
                     echo "PR already exists: $PR_URL"
                     echo "deploy_pr_url=$PR_URL" >> $GITHUB_OUTPUT
                   else
-                    # Create new PR
+                    # Create new PR against automations-project branch
                     PR_URL=$(gh pr create \
                       --title "Preview: Automation PR #${PR_NUMBER}" \
                       --body "**Preview branch for Automation PR #${PR_NUMBER}**
@@ -138,7 +143,7 @@ jobs:
 
                   **Source PR:** https://github.com/${{ github.repository }}/pull/${PR_NUMBER}
                   **Source PR Title:** ${PR_TITLE}" \
-                      --base main \
+                      --base "${{ env.BASE_BRANCH }}" \
                       --head "$BRANCH_NAME")
 
                     echo "Created new PR: $PR_URL"
@@ -153,7 +158,7 @@ jobs:
                   BRANCH_NAME: ${{ steps.deploy-pr.outputs.branch_name }}
               run: |
                   cd deploy-repo
-                  EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --json url --jq '.[0].url')
+                  EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --base "${{ env.BASE_BRANCH }}" --json url --jq '.[0].url')
                   if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
                     echo "deploy_pr_url=$EXISTING_PR" >> $GITHUB_OUTPUT
                   fi

--- a/.github/workflows/trigger-deploy-preview.yml
+++ b/.github/workflows/trigger-deploy-preview.yml
@@ -1,0 +1,242 @@
+---
+# Workflow that creates/updates a deploy repo PR for automation PRs
+# Triggers after the Docker build completes successfully
+name: Trigger Deploy Preview
+
+on:
+    workflow_run:
+        workflows: [Docker]
+        types: [completed]
+
+env:
+    DEPLOY_REPO: OpenHands/deploy
+
+jobs:
+    trigger-deploy:
+        name: Create Deploy Preview PR
+        runs-on: ubuntu-24.04
+        # Only run on successful PR builds (not forks)
+        if: >
+            github.event.workflow_run.conclusion == 'success' &&
+            github.event.workflow_run.event == 'pull_request' &&
+            !github.event.workflow_run.head_repository.fork
+        permissions:
+            contents: read
+            pull-requests: write
+        steps:
+            - name: Get PR information
+              id: pr-info
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      // Get the PR associated with this workflow run
+                      const runId = context.payload.workflow_run.id;
+                      const headSha = context.payload.workflow_run.head_sha;
+                      const headBranch = context.payload.workflow_run.head_branch;
+
+                      // Find the PR for this branch
+                      const { data: pullRequests } = await github.rest.pulls.list({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        state: 'open',
+                        head: `${context.repo.owner}:${headBranch}`
+                      });
+
+                      if (pullRequests.length === 0) {
+                        core.setFailed('No open PR found for branch ' + headBranch);
+                        return;
+                      }
+
+                      const pr = pullRequests[0];
+                      core.setOutput('pr_number', pr.number);
+                      core.setOutput('head_sha', headSha);
+                      core.setOutput('head_branch', headBranch);
+                      core.setOutput('pr_title', pr.title);
+
+                      console.log(`Found PR #${pr.number} with SHA ${headSha}`);
+
+            - name: Checkout deploy repo
+              uses: actions/checkout@v4
+              with:
+                  repository: ${{ env.DEPLOY_REPO }}
+                  token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  fetch-depth: 0
+                  path: deploy-repo
+
+            - name: Check for existing branch and create/update PR
+              id: deploy-pr
+              env:
+                  GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
+                  HEAD_SHA: ${{ steps.pr-info.outputs.head_sha }}
+                  PR_TITLE: ${{ steps.pr-info.outputs.pr_title }}
+              run: |
+                  cd deploy-repo
+                  BRANCH_NAME="au-pr-${PR_NUMBER}"
+
+                  # Configure git
+                  git config user.name "all-hands-bot"
+                  git config user.email "all-hands-bot@all-hands.dev"
+
+                  # Check if branch exists on remote
+                  if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
+                    echo "Branch $BRANCH_NAME exists, checking it out"
+                    git fetch origin "$BRANCH_NAME"
+                    git checkout "$BRANCH_NAME"
+                    git pull origin "$BRANCH_NAME"
+                  else
+                    echo "Creating new branch $BRANCH_NAME"
+                    git checkout -b "$BRANCH_NAME"
+                  fi
+
+                  # Update AUTOMATION_SHA in deploy.yaml using yq
+                  echo "Updating AUTOMATION_SHA to $HEAD_SHA"
+                  if command -v yq &> /dev/null; then
+                    yq e -i ".env.AUTOMATION_SHA = \"$HEAD_SHA\"" .github/workflows/deploy.yaml
+                  else
+                    # Fallback to sed if yq is not available
+                    if grep -q "AUTOMATION_SHA:" .github/workflows/deploy.yaml; then
+                      sed -i "s/AUTOMATION_SHA: \"[a-f0-9]*\"/AUTOMATION_SHA: \"$HEAD_SHA\"/" .github/workflows/deploy.yaml
+                    else
+                      echo "Warning: AUTOMATION_SHA not found in deploy.yaml"
+                      exit 1
+                    fi
+                  fi
+
+                  # Check if there are changes
+                  if git diff --quiet; then
+                    echo "No changes to commit"
+                    echo "has_changes=false" >> $GITHUB_OUTPUT
+                  else
+                    echo "Changes detected, committing"
+                    git add .github/workflows/deploy.yaml
+                    git commit -m "Update AUTOMATION_SHA to ${HEAD_SHA}
+
+                  Automation PR: https://github.com/${{ github.repository }}/pull/${PR_NUMBER}
+                  Commit: ${HEAD_SHA}"
+
+                    git push origin "$BRANCH_NAME"
+                    echo "has_changes=true" >> $GITHUB_OUTPUT
+                  fi
+
+                  echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+            - name: Create or update deploy PR
+              if: steps.deploy-pr.outputs.has_changes == 'true'
+              id: create-pr
+              env:
+                  GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
+                  HEAD_SHA: ${{ steps.pr-info.outputs.head_sha }}
+                  PR_TITLE: ${{ steps.pr-info.outputs.pr_title }}
+                  BRANCH_NAME: ${{ steps.deploy-pr.outputs.branch_name }}
+              run: |
+                  cd deploy-repo
+
+                  # Check if PR already exists for this branch
+                  EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --json number,url --jq '.[0]')
+
+                  if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
+                    PR_URL=$(echo "$EXISTING_PR" | jq -r '.url')
+                    echo "PR already exists: $PR_URL"
+                    echo "deploy_pr_url=$PR_URL" >> $GITHUB_OUTPUT
+                  else
+                    # Create new PR
+                    PR_URL=$(gh pr create \
+                      --title "Preview: Automation PR #${PR_NUMBER}" \
+                      --body "**Preview branch for Automation PR #${PR_NUMBER}**
+
+                  This PR was automatically created to test automation changes.
+
+                  **Changes:**
+                  - \`AUTOMATION_SHA\` → \`${HEAD_SHA}\`
+
+                  **Source PR:** https://github.com/${{ github.repository }}/pull/${PR_NUMBER}
+                  **Source PR Title:** ${PR_TITLE}" \
+                      --base main \
+                      --head "$BRANCH_NAME")
+
+                    echo "Created new PR: $PR_URL"
+                    echo "deploy_pr_url=$PR_URL" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Get deploy PR URL for existing PR
+              if: steps.deploy-pr.outputs.has_changes != 'true'
+              id: get-existing-pr
+              env:
+                  GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  BRANCH_NAME: ${{ steps.deploy-pr.outputs.branch_name }}
+              run: |
+                  cd deploy-repo
+                  EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --json url --jq '.[0].url')
+                  if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
+                    echo "deploy_pr_url=$EXISTING_PR" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Comment on automation PR
+              uses: actions/github-script@v7
+              env:
+                  DEPLOY_PR_URL: ${{ steps.create-pr.outputs.deploy_pr_url || steps.get-existing-pr.outputs.deploy_pr_url }}
+                  PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
+                  HEAD_SHA: ${{ steps.pr-info.outputs.head_sha }}
+              with:
+                  script: |
+                      const prNumber = parseInt(process.env.PR_NUMBER);
+                      const deployPrUrl = process.env.DEPLOY_PR_URL;
+                      const headSha = process.env.HEAD_SHA;
+
+                      if (!deployPrUrl) {
+                        console.log('No deploy PR URL available, skipping comment');
+                        return;
+                      }
+
+                      const etTime = new Intl.DateTimeFormat('en-US', {
+                        timeZone: 'America/New_York',
+                        year: 'numeric',
+                        month: 'short',
+                        day: '2-digit',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                        second: '2-digit',
+                        hour12: true
+                      }).format(new Date());
+
+                      const commentBody = `🚀 **Deploy Preview PR Created/Updated**
+
+                      A deploy preview has been created/updated for this PR.
+
+                      **Deploy PR:** ${deployPrUrl}
+                      **Automation SHA:** \`${headSha}\`
+                      **Last updated:** ${etTime} ET
+
+                      Once the deploy PR's CI passes, the automation service will be deployed to the feature environment.`;
+
+                      // Find existing bot comment
+                      const { data: comments } = await github.rest.issues.listComments({
+                        issue_number: prNumber,
+                        owner: context.repo.owner,
+                        repo: context.repo.repo
+                      });
+
+                      const botComment = comments.find(comment =>
+                        comment.user.login === 'github-actions[bot]' &&
+                        comment.body.includes('Deploy Preview PR Created/Updated')
+                      );
+
+                      if (botComment) {
+                        await github.rest.issues.updateComment({
+                          comment_id: botComment.id,
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          body: commentBody
+                        });
+                        console.log('Updated existing comment');
+                      } else {
+                        await github.rest.issues.createComment({
+                          issue_number: prNumber,
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          body: commentBody
+                        });
+                        console.log('Created new comment');
+                      }

--- a/.github/workflows/trigger-deploy-preview.yml
+++ b/.github/workflows/trigger-deploy-preview.yml
@@ -1,12 +1,23 @@
 ---
 # Workflow that creates/updates a deploy repo PR for automation PRs
-# Triggers after the Docker build completes successfully
+# Called by ghcr-build.yml after Docker build completes successfully
 name: Trigger Deploy Preview
 
 on:
-    workflow_run:
-        workflows: [Docker]
-        types: [completed]
+    workflow_dispatch:
+        inputs:
+            pr_number:
+                description: 'The automation PR number'
+                required: true
+                type: string
+            head_sha:
+                description: 'The commit SHA to deploy'
+                required: true
+                type: string
+            pr_title:
+                description: 'The PR title'
+                required: true
+                type: string
 
 env:
     DEPLOY_REPO: OpenHands/deploy
@@ -15,45 +26,16 @@ jobs:
     trigger-deploy:
         name: Create Deploy Preview PR
         runs-on: ubuntu-24.04
-        # Only run on successful PR builds (not forks)
-        if: >
-            github.event.workflow_run.conclusion == 'success' &&
-            github.event.workflow_run.event == 'pull_request' &&
-            !github.event.workflow_run.head_repository.fork
         permissions:
             contents: read
             pull-requests: write
         steps:
-            - name: Get PR information
+            - name: Set PR info from inputs
               id: pr-info
-              uses: actions/github-script@v7
-              with:
-                  script: |
-                      // Get the PR associated with this workflow run
-                      const runId = context.payload.workflow_run.id;
-                      const headSha = context.payload.workflow_run.head_sha;
-                      const headBranch = context.payload.workflow_run.head_branch;
-
-                      // Find the PR for this branch
-                      const { data: pullRequests } = await github.rest.pulls.list({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        state: 'open',
-                        head: `${context.repo.owner}:${headBranch}`
-                      });
-
-                      if (pullRequests.length === 0) {
-                        core.setFailed('No open PR found for branch ' + headBranch);
-                        return;
-                      }
-
-                      const pr = pullRequests[0];
-                      core.setOutput('pr_number', pr.number);
-                      core.setOutput('head_sha', headSha);
-                      core.setOutput('head_branch', headBranch);
-                      core.setOutput('pr_title', pr.title);
-
-                      console.log(`Found PR #${pr.number} with SHA ${headSha}`);
+              run: |
+                  echo "pr_number=${{ inputs.pr_number }}" >> $GITHUB_OUTPUT
+                  echo "head_sha=${{ inputs.head_sha }}" >> $GITHUB_OUTPUT
+                  echo "pr_title=${{ inputs.pr_title }}" >> $GITHUB_OUTPUT
 
             - name: Checkout deploy repo
               uses: actions/checkout@v4

--- a/.github/workflows/trigger-deploy-preview.yml
+++ b/.github/workflows/trigger-deploy-preview.yml
@@ -66,8 +66,9 @@ jobs:
                   git checkout -B "$BRANCH_NAME" "origin/$BASE_BRANCH"
 
                   # Update AUTOMATION_SHA in deploy.yaml
-                  echo "Updating AUTOMATION_SHA to ${{ inputs.head_sha }}"
-                  yq e -i '.env.AUTOMATION_SHA = "${{ inputs.head_sha }}"' .github/workflows/deploy.yaml
+                  HEAD_SHA="${{ inputs.head_sha }}"
+                  echo "Updating AUTOMATION_SHA to $HEAD_SHA"
+                  yq e -i ".env.AUTOMATION_SHA = \"${HEAD_SHA}\"" .github/workflows/deploy.yaml
 
                   # Check if there are changes to commit
                   if git diff --quiet; then
@@ -76,14 +77,15 @@ jobs:
                   else
                     echo "Changes detected, committing"
                     git add .github/workflows/deploy.yaml
-                    git commit -m "Update AUTOMATION_SHA to ${{ inputs.head_sha }}
+                    git commit -m "Update AUTOMATION_SHA to $HEAD_SHA
 
                   Automation PR: https://github.com/${{ github.repository }}/pull/${{ inputs.pr_number }}
-                  Commit: ${{ inputs.head_sha }}"
-
-                    git push --force-with-lease origin "$BRANCH_NAME"
+                  Commit: $HEAD_SHA"
                     echo "has_changes=true" >> $GITHUB_OUTPUT
                   fi
+
+                  # Always push the branch so it exists remotely for PR creation
+                  git push --force origin "$BRANCH_NAME"
 
                   echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/trigger-deploy-preview.yml
+++ b/.github/workflows/trigger-deploy-preview.yml
@@ -49,7 +49,11 @@ jobs:
 
             - name: Install yq
               run: |
-                  sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+                  YQ_VERSION="v4.52.4"
+                  YQ_CHECKSUM="0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c"
+                  wget -qO /tmp/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+                  echo "${YQ_CHECKSUM}  /tmp/yq" | sha256sum -c -
+                  sudo mv /tmp/yq /usr/local/bin/yq
                   sudo chmod +x /usr/local/bin/yq
 
             - name: Update AUTOMATION_SHA and push

--- a/.github/workflows/trigger-deploy-preview.yml
+++ b/.github/workflows/trigger-deploy-preview.yml
@@ -22,6 +22,10 @@ on:
             ALLHANDS_BOT_GITHUB_PAT:
                 required: true
 
+concurrency:
+    group: deploy-preview-${{ inputs.pr_number }}
+    cancel-in-progress: false
+
 env:
     DEPLOY_REPO: OpenHands/deploy
     BASE_BRANCH: automations-project
@@ -65,10 +69,19 @@ jobs:
                   git fetch origin "$BASE_BRANCH"
                   git checkout -B "$BRANCH_NAME" "origin/$BASE_BRANCH"
 
+                  # Verify deploy.yaml exists
+                  if [ ! -f .github/workflows/deploy.yaml ]; then
+                    echo "Error: .github/workflows/deploy.yaml not found" >&2
+                    exit 1
+                  fi
+
                   # Update AUTOMATION_SHA in deploy.yaml
                   HEAD_SHA="${{ inputs.head_sha }}"
                   echo "Updating AUTOMATION_SHA to $HEAD_SHA"
-                  yq e -i ".env.AUTOMATION_SHA = \"${HEAD_SHA}\"" .github/workflows/deploy.yaml
+                  if ! yq e -i ".env.AUTOMATION_SHA = \"${HEAD_SHA}\"" .github/workflows/deploy.yaml; then
+                    echo "Error: Failed to update deploy.yaml with yq" >&2
+                    exit 1
+                  fi
 
                   # Check if there are changes to commit
                   if git diff --quiet; then
@@ -94,21 +107,24 @@ jobs:
               env:
                   GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
                   BRANCH_NAME: ${{ steps.deploy-pr.outputs.branch_name }}
+                  PR_TITLE: ${{ inputs.pr_title }}
               run: |
                   cd deploy-repo
 
                   # Check if PR already exists for this branch
-                  EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --base "${{ env.BASE_BRANCH }}" --json number,url --jq '.[0]')
+                  if ! EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --base "${{ env.BASE_BRANCH }}" --json number,url --jq '.[0]'); then
+                    echo "Error: Failed to query existing PRs" >&2
+                    exit 1
+                  fi
 
                   if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
                     PR_URL=$(echo "$EXISTING_PR" | jq -r '.url')
                     echo "PR already exists: $PR_URL"
                     echo "deploy_pr_url=$PR_URL" >> $GITHUB_OUTPUT
                   else
-                    # Create new PR against automations-project branch
-                    PR_URL=$(gh pr create \
-                      --title "Preview: Automation PR #${{ inputs.pr_number }}" \
-                      --body "**Preview branch for Automation PR #${{ inputs.pr_number }}**
+                    # Create PR body using heredoc to avoid shell injection from PR title
+                    PR_BODY=$(cat <<EOF
+                  **Preview branch for Automation PR #${{ inputs.pr_number }}**
 
                   This PR was automatically created to test automation changes.
 
@@ -116,9 +132,19 @@ jobs:
                   - \`AUTOMATION_SHA\` → \`${{ inputs.head_sha }}\`
 
                   **Source PR:** https://github.com/${{ github.repository }}/pull/${{ inputs.pr_number }}
-                  **Source PR Title:** ${{ inputs.pr_title }}" \
+                  **Source PR Title:** ${PR_TITLE}
+                  EOF
+                  )
+
+                    # Create new PR against automations-project branch
+                    if ! PR_URL=$(gh pr create \
+                      --title "Preview: Automation PR #${{ inputs.pr_number }}" \
+                      --body "$PR_BODY" \
                       --base "${{ env.BASE_BRANCH }}" \
-                      --head "$BRANCH_NAME")
+                      --head "$BRANCH_NAME"); then
+                      echo "Error: Failed to create PR" >&2
+                      exit 1
+                    fi
 
                     echo "Created new PR: $PR_URL"
                     echo "deploy_pr_url=$PR_URL" >> $GITHUB_OUTPUT

--- a/.github/workflows/trigger-deploy-preview.yml
+++ b/.github/workflows/trigger-deploy-preview.yml
@@ -9,7 +9,7 @@ on:
             pr_number:
                 description: The automation PR number
                 required: true
-                type: string
+                type: number
             head_sha:
                 description: The commit SHA to deploy
                 required: true
@@ -34,13 +34,6 @@ jobs:
             contents: read
             pull-requests: write
         steps:
-            - name: Set PR info from inputs
-              id: pr-info
-              run: |
-                  echo "pr_number=${{ inputs.pr_number }}" >> $GITHUB_OUTPUT
-                  echo "head_sha=${{ inputs.head_sha }}" >> $GITHUB_OUTPUT
-                  echo "pr_title=${{ inputs.pr_title }}" >> $GITHUB_OUTPUT
-
             - name: Checkout deploy repo
               uses: actions/checkout@v4
               with:
@@ -50,75 +43,54 @@ jobs:
                   fetch-depth: 0
                   path: deploy-repo
 
-            - name: Check for existing branch and create/update PR
+            - name: Install yq
+              run: |
+                  sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+                  sudo chmod +x /usr/local/bin/yq
+
+            - name: Update AUTOMATION_SHA and push
               id: deploy-pr
               env:
                   GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
-                  PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
-                  HEAD_SHA: ${{ steps.pr-info.outputs.head_sha }}
-                  PR_TITLE: ${{ steps.pr-info.outputs.pr_title }}
               run: |
                   cd deploy-repo
-                  BRANCH_NAME="au-pr-${PR_NUMBER}"
+                  BRANCH_NAME="au-pr-${{ inputs.pr_number }}"
                   BASE_BRANCH="${{ env.BASE_BRANCH }}"
 
                   # Configure git
                   git config user.name "all-hands-bot"
                   git config user.email "all-hands-bot@all-hands.dev"
 
-                  # Check if branch exists on remote
-                  if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
-                    echo "Branch $BRANCH_NAME exists, checking it out"
-                    git fetch origin "$BRANCH_NAME"
-                    git checkout "$BRANCH_NAME"
-                    # Rebase on top of base branch to get latest changes
-                    git fetch origin "$BASE_BRANCH"
-                    git rebase "origin/$BASE_BRANCH" || git rebase --abort
-                  else
-                    echo "Creating new branch $BRANCH_NAME from $BASE_BRANCH"
-                    git checkout -b "$BRANCH_NAME"
-                  fi
+                  # Always create/reset branch from base - simple, one code path
+                  git fetch origin "$BASE_BRANCH"
+                  git checkout -B "$BRANCH_NAME" "origin/$BASE_BRANCH"
 
-                  # Update AUTOMATION_SHA in deploy.yaml using yq
-                  echo "Updating AUTOMATION_SHA to $HEAD_SHA"
-                  if command -v yq &> /dev/null; then
-                    yq e -i ".env.AUTOMATION_SHA = \"$HEAD_SHA\"" .github/workflows/deploy.yaml
-                  else
-                    # Fallback to sed if yq is not available
-                    if grep -q "AUTOMATION_SHA:" .github/workflows/deploy.yaml; then
-                      sed -i "s/AUTOMATION_SHA: \"[a-f0-9]*\"/AUTOMATION_SHA: \"$HEAD_SHA\"/" .github/workflows/deploy.yaml
-                    else
-                      echo "Warning: AUTOMATION_SHA not found in deploy.yaml"
-                      exit 1
-                    fi
-                  fi
+                  # Update AUTOMATION_SHA in deploy.yaml
+                  echo "Updating AUTOMATION_SHA to ${{ inputs.head_sha }}"
+                  yq e -i '.env.AUTOMATION_SHA = "${{ inputs.head_sha }}"' .github/workflows/deploy.yaml
 
-                  # Check if there are changes
+                  # Check if there are changes to commit
                   if git diff --quiet; then
-                    echo "No changes to commit"
+                    echo "No changes to commit - SHA already up to date"
                     echo "has_changes=false" >> $GITHUB_OUTPUT
                   else
                     echo "Changes detected, committing"
                     git add .github/workflows/deploy.yaml
-                    git commit -m "Update AUTOMATION_SHA to ${HEAD_SHA}
+                    git commit -m "Update AUTOMATION_SHA to ${{ inputs.head_sha }}
 
-                  Automation PR: https://github.com/${{ github.repository }}/pull/${PR_NUMBER}
-                  Commit: ${HEAD_SHA}"
+                  Automation PR: https://github.com/${{ github.repository }}/pull/${{ inputs.pr_number }}
+                  Commit: ${{ inputs.head_sha }}"
 
-                    git push origin "$BRANCH_NAME"
+                    git push --force-with-lease origin "$BRANCH_NAME"
                     echo "has_changes=true" >> $GITHUB_OUTPUT
                   fi
 
                   echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
-            - name: Create or update deploy PR
-              if: steps.deploy-pr.outputs.has_changes == 'true'
-              id: create-pr
+            - name: Create or get deploy PR
+              id: manage-pr
               env:
                   GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
-                  PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
-                  HEAD_SHA: ${{ steps.pr-info.outputs.head_sha }}
-                  PR_TITLE: ${{ steps.pr-info.outputs.pr_title }}
                   BRANCH_NAME: ${{ steps.deploy-pr.outputs.branch_name }}
               run: |
                   cd deploy-repo
@@ -133,16 +105,16 @@ jobs:
                   else
                     # Create new PR against automations-project branch
                     PR_URL=$(gh pr create \
-                      --title "Preview: Automation PR #${PR_NUMBER}" \
-                      --body "**Preview branch for Automation PR #${PR_NUMBER}**
+                      --title "Preview: Automation PR #${{ inputs.pr_number }}" \
+                      --body "**Preview branch for Automation PR #${{ inputs.pr_number }}**
 
                   This PR was automatically created to test automation changes.
 
                   **Changes:**
-                  - \`AUTOMATION_SHA\` → \`${HEAD_SHA}\`
+                  - \`AUTOMATION_SHA\` → \`${{ inputs.head_sha }}\`
 
-                  **Source PR:** https://github.com/${{ github.repository }}/pull/${PR_NUMBER}
-                  **Source PR Title:** ${PR_TITLE}" \
+                  **Source PR:** https://github.com/${{ github.repository }}/pull/${{ inputs.pr_number }}
+                  **Source PR Title:** ${{ inputs.pr_title }}" \
                       --base "${{ env.BASE_BRANCH }}" \
                       --head "$BRANCH_NAME")
 
@@ -150,30 +122,17 @@ jobs:
                     echo "deploy_pr_url=$PR_URL" >> $GITHUB_OUTPUT
                   fi
 
-            - name: Get deploy PR URL for existing PR
-              if: steps.deploy-pr.outputs.has_changes != 'true'
-              id: get-existing-pr
-              env:
-                  GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
-                  BRANCH_NAME: ${{ steps.deploy-pr.outputs.branch_name }}
-              run: |
-                  cd deploy-repo
-                  EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --base "${{ env.BASE_BRANCH }}" --json url --jq '.[0].url')
-                  if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
-                    echo "deploy_pr_url=$EXISTING_PR" >> $GITHUB_OUTPUT
-                  fi
-
             - name: Comment on automation PR
               uses: actions/github-script@v7
               env:
-                  DEPLOY_PR_URL: ${{ steps.create-pr.outputs.deploy_pr_url || steps.get-existing-pr.outputs.deploy_pr_url }}
-                  PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
-                  HEAD_SHA: ${{ steps.pr-info.outputs.head_sha }}
+                  DEPLOY_PR_URL: ${{ steps.manage-pr.outputs.deploy_pr_url }}
+                  HAS_CHANGES: ${{ steps.deploy-pr.outputs.has_changes }}
               with:
                   script: |
-                      const prNumber = parseInt(process.env.PR_NUMBER);
+                      const prNumber = ${{ inputs.pr_number }};
                       const deployPrUrl = process.env.DEPLOY_PR_URL;
-                      const headSha = process.env.HEAD_SHA;
+                      const headSha = '${{ inputs.head_sha }}';
+                      const hasChanges = process.env.HAS_CHANGES === 'true';
 
                       if (!deployPrUrl) {
                         console.log('No deploy PR URL available, skipping comment');
@@ -191,9 +150,13 @@ jobs:
                         hour12: true
                       }).format(new Date());
 
+                      const statusMessage = hasChanges 
+                        ? 'A deploy preview has been created/updated for this PR.'
+                        : 'No changes needed - deploy preview is already up to date.';
+
                       const commentBody = `🚀 **Deploy Preview PR Created/Updated**
 
-                      A deploy preview has been created/updated for this PR.
+                      ${statusMessage}
 
                       **Deploy PR:** ${deployPrUrl}
                       **Automation SHA:** \`${headSha}\`


### PR DESCRIPTION
## Summary

This PR adds a new CI workflow that automatically creates deploy preview PRs in the deploy repo when changes are pushed to automation PRs.

## How It Works

1. Developer opens a PR in the automation repo
2. Docker build runs and pushes image to GHCR
3. After Docker build succeeds, `trigger-deploy-preview.yml` runs:
   - Creates/checks out branch `au-pr-XX` in deploy repo (where XX is the automation PR number)
   - Updates `AUTOMATION_SHA` in the deploy repo's `deploy.yaml` (this variable already exists in the `automations-project` branch)
   - Creates/updates PR in deploy repo against the `automations-project` base branch
   - Comments on automation PR with deploy repo PR link
4. Deploy repo CI runs on the `au-pr-XX` branch and deploys the automation service

## Requirements

- The `ALLHANDS_BOT_GITHUB_PAT` secret must be configured with permissions to:
  - Create branches and PRs in the deploy repo
  - Comment on PRs in this repo

## Deploy Repo Configuration

The deploy repo's `automations-project` branch already has:
- `AUTOMATION_SHA` environment variable in `.github/workflows/deploy.yaml`
- `deploy-automation` job for automation service deployment
- Integration tests configured to run after automation deployment