### PR TITLE
Simplify API route prefix from /api/v1/automations to /v1 + other fixes

### DIFF
--- a/automation/app.py
+++ b/automation/app.py
@@ -145,8 +145,11 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.include_router(router)
+# Include uploads_router BEFORE router to avoid route conflict.
+# The main router has /v1/{automation_id} which would match /v1/uploads
+# and fail UUID validation if included first.
 app.include_router(uploads_router)
+app.include_router(router)
 
 
 @app.get("/health")

--- a/automation/app.py
+++ b/automation/app.py
@@ -33,7 +33,12 @@ async def lifespan(app: FastAPI):
     setup_all_loggers()
 
     # Silence noisy third-party loggers
-    for noisy_logger in ("ddtrace", "httpx", "httpcore"):
+    for noisy_logger in (
+        "ddtrace",
+        "httpx",
+        "httpcore",
+        "sqlalchemy.engine",  # Suppress SQL statement logging
+    ):
         logging.getLogger(noisy_logger).setLevel(logging.WARNING)
 
     logger.info("Starting OpenHands Automations Service")

--- a/automation/config.py
+++ b/automation/config.py
@@ -31,6 +31,9 @@ class Settings(BaseSettings):
     # Dispatcher (polls automation_runs table for pending jobs)
     dispatcher_interval_seconds: int = 10
 
+    # Watchdog (scans for stale RUNNING runs past their timeout)
+    watchdog_interval_seconds: int = 60
+
     # Service key for authenticating with the SaaS API to fetch per-user
     # API keys (called by the dispatcher before each automation run).
     service_key: str = ""

--- a/automation/dispatcher.py
+++ b/automation/dispatcher.py
@@ -5,7 +5,7 @@ to sandboxes via the SaaS API.  Uses FOR UPDATE SKIP LOCKED for
 multi-worker safety.
 
 Completion is handled asynchronously: the SDK running inside the sandbox
-POSTs to ``/api/v1/automations/runs/{id}/complete`` when the entry-point
+POSTs to ``/v1/runs/{id}/complete`` when the entry-point
 exits, so the dispatcher does **not** block waiting for results.
 """
 
@@ -124,7 +124,7 @@ async def _execute_run(
 
     callback_url = (
         f"{settings.resolved_base_url.rstrip('/')}"
-        f"/api/v1/automations/runs/{run_id}/complete"
+        f"/v1/runs/{run_id}/complete"
     )
 
     try:

--- a/automation/dispatcher.py
+++ b/automation/dispatcher.py
@@ -13,6 +13,7 @@ import asyncio
 import json
 import logging
 import uuid
+from datetime import timedelta
 from typing import Any
 
 from sqlalchemy import select
@@ -20,7 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
 from automation.config import Settings
-from automation.constants import MAX_RUN_DURATION_SECONDS
+from automation.constants import MAX_RUN_DURATION, MAX_RUN_DURATION_SECONDS
 from automation.execution import dispatch_automation
 from automation.models import AutomationRun, AutomationRunStatus, TarballUpload
 from automation.utils.api_key import APIKeyError, get_api_key_for_automation_run
@@ -233,7 +234,15 @@ async def dispatch_pending_runs(
             extra = _run_extra(run_id=run_id, automation_id=automation_id)
             try:
                 logger.info("Dispatching automation run", extra=extra)
-                await mark_run_status(session, run, AutomationRunStatus.RUNNING)
+                # Use automation's custom timeout if set, otherwise use default
+                max_duration = (
+                    timedelta(seconds=run.automation.timeout)
+                    if run.automation and run.automation.timeout
+                    else MAX_RUN_DURATION
+                )
+                await mark_run_status(
+                    session, run, AutomationRunStatus.RUNNING, max_duration=max_duration
+                )
                 dispatched_runs.append(run)
             except Exception:
                 logger.exception("Failed to dispatch run", extra=extra)

--- a/automation/dispatcher.py
+++ b/automation/dispatcher.py
@@ -122,10 +122,7 @@ async def _execute_run(
             run_id=run_id, automation_id=automation_id, sandbox_id=sandbox_id
         )
 
-    callback_url = (
-        f"{settings.resolved_base_url.rstrip('/')}"
-        f"/v1/runs/{run_id}/complete"
-    )
+    callback_url = f"{settings.resolved_base_url.rstrip('/')}/v1/runs/{run_id}/complete"
 
     try:
         # 1. Fetch a per-user API key from the SaaS service

--- a/automation/router.py
+++ b/automation/router.py
@@ -30,7 +30,7 @@ from automation.utils.tarball_validation import validate_tarball_path
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/v1/automations", tags=["Automations"])
+router = APIRouter(prefix="/v1", tags=["Automations"])
 
 
 # --- CRUD ---
@@ -45,7 +45,7 @@ async def create_automation(
     """Create a new automation.
 
     The tarball_path can be either:
-    - Internal upload: oh-internal://uploads/{uuid} (from /api/v1/uploads)
+    - Internal upload: oh-internal://uploads/{uuid} (from /v1/uploads)
     - External public URL: https://, s3://, or gs:// URLs
     """
     # Validate tarball_path (checks ownership for internal uploads)

--- a/automation/uploads.py
+++ b/automation/uploads.py
@@ -16,7 +16,7 @@ from automation.storage import FileSizeLimitExceeded, GoogleCloudFileStore
 from automation.utils import utcnow
 
 
-router = APIRouter(prefix="/api/v1/uploads", tags=["Uploads"])
+router = APIRouter(prefix="/v1/uploads", tags=["Uploads"])
 
 # Maximum upload size: 1MB
 MAX_UPLOAD_SIZE = 1 * 1024 * 1024

--- a/automation/watchdog.py
+++ b/automation/watchdog.py
@@ -26,9 +26,6 @@ from automation.utils.time import utcnow
 
 logger = logging.getLogger("automation.watchdog")
 
-# Default scan interval
-WATCHDOG_INTERVAL_SECONDS = 120
-
 
 def _run_extra(
     run_id: str | None = None,
@@ -173,6 +170,18 @@ async def _verify_and_mark_run(
         )
 
     error_msg = verification.error or "no completion callback received"
+
+    # Log that we're killing the run due to timeout
+    logger.warning(
+        "Killing run due to timeout: run_id=%s, sandbox_id=%s, "
+        "timeout_at=%s, reason=%s",
+        run_id,
+        sandbox_id,
+        run.timeout_at,
+        error_msg,
+        extra=extra,
+    )
+
     stmt = (
         update(AutomationRun)
         .where(
@@ -245,10 +254,21 @@ async def mark_stale_runs(
 async def watchdog_loop(
     session_factory: async_sessionmaker[AsyncSession],
     settings: Settings,
-    interval_seconds: int = WATCHDOG_INTERVAL_SECONDS,
+    interval_seconds: int | None = None,
     shutdown_event: asyncio.Event | None = None,
 ) -> None:
-    """Main watchdog loop — scans for stale runs periodically."""
+    """Main watchdog loop — scans for stale runs periodically.
+
+    Args:
+        session_factory: Async session maker for database access.
+        settings: Application settings.
+        interval_seconds: Override for scan interval. If None, uses
+            settings.watchdog_interval_seconds (default: 60s).
+        shutdown_event: Event to signal graceful shutdown.
+    """
+    if interval_seconds is None:
+        interval_seconds = settings.watchdog_interval_seconds
+
     logger.info(
         "Watchdog started, scanning every %ds",
         interval_seconds,

--- a/automation/watchdog.py
+++ b/automation/watchdog.py
@@ -106,11 +106,14 @@ async def _verify_and_mark_run(
     )
 
     if verification.verified:
-        # We got an actual result from the sandbox
-        if verification.success:
+        exit_code = verification.exit_code
+
+        # exit_code == 0: Command completed successfully, we just missed the callback
+        if exit_code == 0:
             logger.info(
-                "Verified run completed successfully (exit_code=%s)",
-                verification.exit_code,
+                "Verified run completed successfully (exit_code=%s), "
+                "callback was missed",
+                exit_code,
                 extra=extra,
             )
             stmt = (
@@ -124,8 +127,34 @@ async def _verify_and_mark_run(
                     completed_at=now,
                 )
             )
+
+        # exit_code == -1 or None: Command was killed/timed out by bash service
+        elif exit_code is None or exit_code == -1:
+            error_msg = "command timed out or was killed"
+            if verification.stderr:
+                error_msg += f"\nstderr: {verification.stderr[-1000:]}"
+
+            logger.warning(
+                "Run timed out (exit_code=%s)",
+                exit_code,
+                extra=extra,
+            )
+            stmt = (
+                update(AutomationRun)
+                .where(
+                    AutomationRun.id == run.id,
+                    AutomationRun.status == AutomationRunStatus.RUNNING,
+                )
+                .values(
+                    status=AutomationRunStatus.FAILED,
+                    completed_at=now,
+                    error_detail=f"Timed out: {error_msg}",
+                )
+            )
+
+        # Any other exit code: Command failed with an actual error
         else:
-            error_parts = [f"exit_code={verification.exit_code}"]
+            error_parts = [f"exit_code={exit_code}"]
             if verification.stderr:
                 error_parts.append(f"stderr: {verification.stderr[-1000:]}")
             if verification.stdout:
@@ -134,7 +163,7 @@ async def _verify_and_mark_run(
 
             logger.warning(
                 "Verified run failed (exit_code=%s)",
-                verification.exit_code,
+                exit_code,
                 extra=extra,
             )
             stmt = (
@@ -149,13 +178,14 @@ async def _verify_and_mark_run(
                     error_detail=error_detail,
                 )
             )
+
         result = await session.execute(stmt)  # type: ignore[assignment]
         return result.rowcount > 0
 
     # Verification failed - sandbox not available or command still running
     # This likely means the sandbox crashed or was cleaned up
     logger.warning(
-        "Could not verify run status: %s, marking FAILED",
+        "Could not verify run status: %s, marking as timed out",
         verification.error,
         extra=extra,
     )
@@ -171,10 +201,8 @@ async def _verify_and_mark_run(
 
     error_msg = verification.error or "no completion callback received"
 
-    # Log that we're killing the run due to timeout
     logger.warning(
-        "Killing run due to timeout: run_id=%s, sandbox_id=%s, "
-        "timeout_at=%s, reason=%s",
+        "Marking run as timed out: run_id=%s, sandbox_id=%s, timeout_at=%s, reason=%s",
         run_id,
         sandbox_id,
         run.timeout_at,

--- a/automation/watchdog.py
+++ b/automation/watchdog.py
@@ -282,7 +282,6 @@ async def mark_stale_runs(
 async def watchdog_loop(
     session_factory: async_sessionmaker[AsyncSession],
     settings: Settings,
-    interval_seconds: int | None = None,
     shutdown_event: asyncio.Event | None = None,
 ) -> None:
     """Main watchdog loop — scans for stale runs periodically.
@@ -290,16 +289,13 @@ async def watchdog_loop(
     Args:
         session_factory: Async session maker for database access.
         settings: Application settings.
-        interval_seconds: Override for scan interval. If None, uses
-            settings.watchdog_interval_seconds (default: 60s).
         shutdown_event: Event to signal graceful shutdown.
     """
-    if interval_seconds is None:
-        interval_seconds = settings.watchdog_interval_seconds
+    interval = settings.watchdog_interval_seconds
 
     logger.info(
         "Watchdog started, scanning every %ds",
-        interval_seconds,
+        interval,
     )
 
     while True:
@@ -316,10 +312,10 @@ async def watchdog_loop(
 
         if shutdown_event is not None:
             try:
-                await asyncio.wait_for(shutdown_event.wait(), timeout=interval_seconds)
+                await asyncio.wait_for(shutdown_event.wait(), timeout=interval)
                 logger.info("Watchdog received shutdown signal, exiting")
                 break
             except TimeoutError:
                 pass
         else:
-            await asyncio.sleep(interval_seconds)
+            await asyncio.sleep(interval)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -181,7 +181,7 @@ class TestAuthIntegration:
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
                 response = await client.get(
-                    "/api/v1/automations",
+                    "/v1",
                     headers={"Authorization": "Bearer real-key-123"},
                 )
 
@@ -213,7 +213,7 @@ class TestAuthIntegration:
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
-                response = await client.get("/api/v1/automations")
+                response = await client.get("/v1")
 
             assert response.status_code == 401
         finally:
@@ -243,7 +243,7 @@ class TestAuthIntegration:
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
                 response = await client.get(
-                    "/api/v1/automations",
+                    "/v1",
                     headers={"Authorization": "Bearer bad-key"},
                 )
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -14,7 +14,7 @@ OTHER_ORG_ID = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
 
 
 class TestCreateAutomation:
-    """Tests for POST /api endpoint."""
+    """Tests for POST /v1 endpoint."""
 
     async def test_create_automation_success(self, async_client, async_session):
         """Valid request creates automation and returns 201."""
@@ -306,7 +306,7 @@ class TestCreateAutomation:
 
 
 class TestListAutomations:
-    """Tests for GET /api endpoint."""
+    """Tests for GET /v1 endpoint."""
 
     async def test_list_automations_empty(self, async_client):
         """No automations returns empty list."""
@@ -406,7 +406,7 @@ class TestListAutomations:
 
 
 class TestGetAutomation:
-    """Tests for GET /api/{id} endpoint."""
+    """Tests for GET /v1/{id} endpoint."""
 
     async def test_get_automation_success(self, async_client, async_session):
         """Valid ID returns automation."""
@@ -474,7 +474,7 @@ class TestGetAutomation:
 
 
 class TestDeleteAutomation:
-    """Tests for DELETE /api/{id} endpoint."""
+    """Tests for DELETE /v1/{id} endpoint."""
 
     async def test_delete_automation_soft_deletes(self, async_client, async_session):
         """DELETE sets enabled=False and deleted_at."""
@@ -528,7 +528,7 @@ class TestDeleteAutomation:
 
 
 class TestUpdateAutomation:
-    """Tests for PATCH /api/{id} endpoint."""
+    """Tests for PATCH /v1/{id} endpoint."""
 
     async def test_update_automation_name(self, async_client, async_session):
         """PATCH updates the automation name."""
@@ -693,7 +693,7 @@ class TestUpdateAutomation:
 
 
 class TestDispatchAutomation:
-    """Tests for POST /api/{id}/dispatch endpoint."""
+    """Tests for POST /v1/{id}/dispatch endpoint."""
 
     async def test_dispatch_automation_success(self, async_client, async_session):
         """Dispatching an automation creates a PENDING run."""
@@ -818,7 +818,7 @@ class TestDispatchAutomation:
 
 
 class TestListAutomationRuns:
-    """Tests for GET /api/{id}/runs endpoint."""
+    """Tests for GET /v1/{id}/runs endpoint."""
 
     async def test_list_runs_empty(self, async_client, async_session):
         """Listing runs for automation with no runs returns empty list."""

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -14,7 +14,7 @@ OTHER_ORG_ID = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
 
 
 class TestCreateAutomation:
-    """Tests for POST /api/v1/automations endpoint."""
+    """Tests for POST /api endpoint."""
 
     async def test_create_automation_success(self, async_client, async_session):
         """Valid request creates automation and returns 201."""
@@ -26,7 +26,7 @@ class TestCreateAutomation:
             "entrypoint": "uv run script.py",
         }
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         assert response.status_code == 201
         data = response.json()
@@ -52,7 +52,7 @@ class TestCreateAutomation:
             "entrypoint": "python main.py",
         }
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         assert response.status_code == 201
         data = response.json()
@@ -68,7 +68,7 @@ class TestCreateAutomation:
             "entrypoint": "uv run script.py",
         }
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         assert response.status_code == 422
         detail = response.json()["detail"]
@@ -82,7 +82,7 @@ class TestCreateAutomation:
         """Missing required fields returns 422."""
         payload = {"name": "Incomplete"}
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -94,7 +94,7 @@ class TestCreateAutomation:
             "tarball_path": "s3://bucket/path/to/code.tar.gz",
         }
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -107,7 +107,7 @@ class TestCreateAutomation:
             "entrypoint": "uv run main.py",
         }
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         assert response.status_code == 422
         assert any(
@@ -125,7 +125,7 @@ class TestCreateAutomation:
             "entrypoint": "uv run main.py",
         }
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         # Should pass schema validation (422 would mean schema rejected it)
         # Will get 404 because the upload doesn't exist, but that's fine -
@@ -141,7 +141,7 @@ class TestCreateAutomation:
             "entrypoint": "uv run main.py; rm -rf /",
         }
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -154,7 +154,7 @@ class TestCreateAutomation:
             "entrypoint": "/usr/bin/python main.py",
         }
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -168,7 +168,7 @@ class TestCreateAutomation:
             "entrypoint": "uv run main.py",
         }
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -182,7 +182,7 @@ class TestCreateAutomation:
             "entrypoint": "uv run main.py",
         }
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -196,7 +196,7 @@ class TestCreateAutomation:
             "entrypoint": "uv run main.py",
         }
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -210,7 +210,7 @@ class TestCreateAutomation:
             "entrypoint": "uv run main.py",
         }
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         assert response.status_code == 201
         assert response.json()["setup_script_path"] == "scripts/setup.sh"
@@ -225,7 +225,7 @@ class TestCreateAutomation:
             "timeout": 300,
         }
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         assert response.status_code == 201
         data = response.json()
@@ -240,7 +240,7 @@ class TestCreateAutomation:
             "entrypoint": "python main.py",
         }
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         assert response.status_code == 201
         data = response.json()
@@ -256,7 +256,7 @@ class TestCreateAutomation:
             "timeout": 0,
         }
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -270,7 +270,7 @@ class TestCreateAutomation:
             "timeout": -100,
         }
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -284,7 +284,7 @@ class TestCreateAutomation:
             "timeout": 601,  # MAX_RUN_DURATION_SECONDS is 600 (10 minutes)
         }
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -298,7 +298,7 @@ class TestCreateAutomation:
             "timeout": 600,  # MAX_RUN_DURATION_SECONDS is 600 (10 minutes)
         }
 
-        response = await async_client.post("/api/v1/automations", json=payload)
+        response = await async_client.post("/v1", json=payload)
 
         assert response.status_code == 201
         data = response.json()
@@ -306,11 +306,11 @@ class TestCreateAutomation:
 
 
 class TestListAutomations:
-    """Tests for GET /api/v1/automations endpoint."""
+    """Tests for GET /api endpoint."""
 
     async def test_list_automations_empty(self, async_client):
         """No automations returns empty list."""
-        response = await async_client.get("/api/v1/automations")
+        response = await async_client.get("/v1")
 
         assert response.status_code == 200
         data = response.json()
@@ -331,7 +331,7 @@ class TestListAutomations:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get("/api/v1/automations")
+        response = await async_client.get("/v1")
 
         assert response.status_code == 200
         data = response.json()
@@ -354,7 +354,7 @@ class TestListAutomations:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get("/api/v1/automations")
+        response = await async_client.get("/v1")
 
         assert response.status_code == 200
         data = response.json()
@@ -375,7 +375,7 @@ class TestListAutomations:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get("/api/v1/automations")
+        response = await async_client.get("/v1")
 
         assert response.status_code == 200
         data = response.json()
@@ -397,7 +397,7 @@ class TestListAutomations:
             async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get("/api/v1/automations?limit=2&offset=0")
+        response = await async_client.get("/v1?limit=2&offset=0")
 
         assert response.status_code == 200
         data = response.json()
@@ -406,7 +406,7 @@ class TestListAutomations:
 
 
 class TestGetAutomation:
-    """Tests for GET /api/v1/automations/{id} endpoint."""
+    """Tests for GET /api/{id} endpoint."""
 
     async def test_get_automation_success(self, async_client, async_session):
         """Valid ID returns automation."""
@@ -421,7 +421,7 @@ class TestGetAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get(f"/api/v1/automations/{automation.id}")
+        response = await async_client.get(f"/v1/{automation.id}")
 
         assert response.status_code == 200
         data = response.json()
@@ -432,7 +432,7 @@ class TestGetAutomation:
         """Invalid ID returns 404."""
         fake_id = uuid.uuid4()
 
-        response = await async_client.get(f"/api/v1/automations/{fake_id}")
+        response = await async_client.get(f"/v1/{fake_id}")
 
         assert response.status_code == 404
         assert "Automation not found" in response.json()["detail"]
@@ -451,7 +451,7 @@ class TestGetAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get(f"/api/v1/automations/{automation.id}")
+        response = await async_client.get(f"/v1/{automation.id}")
 
         assert response.status_code == 404
 
@@ -468,13 +468,13 @@ class TestGetAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get(f"/api/v1/automations/{automation.id}")
+        response = await async_client.get(f"/v1/{automation.id}")
 
         assert response.status_code == 404
 
 
 class TestDeleteAutomation:
-    """Tests for DELETE /api/v1/automations/{id} endpoint."""
+    """Tests for DELETE /api/{id} endpoint."""
 
     async def test_delete_automation_soft_deletes(self, async_client, async_session):
         """DELETE sets enabled=False and deleted_at."""
@@ -491,7 +491,7 @@ class TestDeleteAutomation:
         await async_session.commit()
         automation_id = automation.id
 
-        response = await async_client.delete(f"/api/v1/automations/{automation_id}")
+        response = await async_client.delete(f"/v1/{automation_id}")
 
         assert response.status_code == 204
 
@@ -504,7 +504,7 @@ class TestDeleteAutomation:
         """DELETE on non-existent ID returns 404."""
         fake_id = uuid.uuid4()
 
-        response = await async_client.delete(f"/api/v1/automations/{fake_id}")
+        response = await async_client.delete(f"/v1/{fake_id}")
 
         assert response.status_code == 404
 
@@ -522,13 +522,13 @@ class TestDeleteAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.delete(f"/api/v1/automations/{automation.id}")
+        response = await async_client.delete(f"/v1/{automation.id}")
 
         assert response.status_code == 404
 
 
 class TestUpdateAutomation:
-    """Tests for PATCH /api/v1/automations/{id} endpoint."""
+    """Tests for PATCH /api/{id} endpoint."""
 
     async def test_update_automation_name(self, async_client, async_session):
         """PATCH updates the automation name."""
@@ -544,7 +544,7 @@ class TestUpdateAutomation:
         await async_session.commit()
 
         response = await async_client.patch(
-            f"/api/v1/automations/{automation.id}",
+            f"/v1/{automation.id}",
             json={"name": "Updated Name"},
         )
 
@@ -567,7 +567,7 @@ class TestUpdateAutomation:
         await async_session.commit()
 
         response = await async_client.patch(
-            f"/api/v1/automations/{automation.id}",
+            f"/v1/{automation.id}",
             json={"trigger": {"type": "cron", "schedule": "*/5 * * * *"}},
         )
 
@@ -589,7 +589,7 @@ class TestUpdateAutomation:
         await async_session.commit()
 
         response = await async_client.patch(
-            f"/api/v1/automations/{automation.id}",
+            f"/v1/{automation.id}",
             json={"enabled": False},
         )
 
@@ -601,7 +601,7 @@ class TestUpdateAutomation:
         fake_id = uuid.uuid4()
 
         response = await async_client.patch(
-            f"/api/v1/automations/{fake_id}",
+            f"/v1/{fake_id}",
             json={"name": "Updated"},
         )
 
@@ -621,7 +621,7 @@ class TestUpdateAutomation:
         await async_session.commit()
 
         response = await async_client.patch(
-            f"/api/v1/automations/{automation.id}",
+            f"/v1/{automation.id}",
             json={"name": "Hacked"},
         )
 
@@ -642,7 +642,7 @@ class TestUpdateAutomation:
         await async_session.commit()
 
         response = await async_client.patch(
-            f"/api/v1/automations/{automation.id}",
+            f"/v1/{automation.id}",
             json={"timeout": 120},
         )
 
@@ -663,7 +663,7 @@ class TestUpdateAutomation:
         await async_session.commit()
 
         response = await async_client.patch(
-            f"/api/v1/automations/{automation.id}",
+            f"/v1/{automation.id}",
             json={"timeout": -10},
         )
 
@@ -685,7 +685,7 @@ class TestUpdateAutomation:
         await async_session.commit()
 
         response = await async_client.patch(
-            f"/api/v1/automations/{automation.id}",
+            f"/v1/{automation.id}",
             json={"timeout": 700},  # MAX_RUN_DURATION_SECONDS is 600 (10 minutes)
         )
 
@@ -693,7 +693,7 @@ class TestUpdateAutomation:
 
 
 class TestDispatchAutomation:
-    """Tests for POST /api/v1/automations/{id}/dispatch endpoint."""
+    """Tests for POST /api/{id}/dispatch endpoint."""
 
     async def test_dispatch_automation_success(self, async_client, async_session):
         """Dispatching an automation creates a PENDING run."""
@@ -709,7 +709,7 @@ class TestDispatchAutomation:
         await async_session.commit()
 
         response = await async_client.post(
-            f"/api/v1/automations/{automation.id}/dispatch"
+            f"/v1/{automation.id}/dispatch"
         )
 
         assert response.status_code == 201
@@ -726,7 +726,7 @@ class TestDispatchAutomation:
         """Dispatching a nonexistent automation returns 404."""
         fake_id = uuid.uuid4()
 
-        response = await async_client.post(f"/api/v1/automations/{fake_id}/dispatch")
+        response = await async_client.post(f"/v1/{fake_id}/dispatch")
 
         assert response.status_code == 404
         assert "Automation not found" in response.json()["detail"]
@@ -746,7 +746,7 @@ class TestDispatchAutomation:
         await async_session.commit()
 
         response = await async_client.post(
-            f"/api/v1/automations/{automation.id}/dispatch"
+            f"/v1/{automation.id}/dispatch"
         )
 
         assert response.status_code == 404
@@ -765,7 +765,7 @@ class TestDispatchAutomation:
         await async_session.commit()
 
         response = await async_client.post(
-            f"/api/v1/automations/{automation.id}/dispatch"
+            f"/v1/{automation.id}/dispatch"
         )
 
         assert response.status_code == 404
@@ -783,8 +783,8 @@ class TestDispatchAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        resp1 = await async_client.post(f"/api/v1/automations/{automation.id}/dispatch")
-        resp2 = await async_client.post(f"/api/v1/automations/{automation.id}/dispatch")
+        resp1 = await async_client.post(f"/v1/{automation.id}/dispatch")
+        resp2 = await async_client.post(f"/v1/{automation.id}/dispatch")
 
         assert resp1.status_code == 201
         assert resp2.status_code == 201
@@ -815,7 +815,7 @@ class TestDispatchAutomation:
         assert automation.last_triggered_at is None
 
         response = await async_client.post(
-            f"/api/v1/automations/{automation.id}/dispatch"
+            f"/v1/{automation.id}/dispatch"
         )
 
         assert response.status_code == 201
@@ -826,7 +826,7 @@ class TestDispatchAutomation:
 
 
 class TestListAutomationRuns:
-    """Tests for GET /api/v1/automations/{id}/runs endpoint."""
+    """Tests for GET /api/{id}/runs endpoint."""
 
     async def test_list_runs_empty(self, async_client, async_session):
         """Listing runs for automation with no runs returns empty list."""
@@ -841,7 +841,7 @@ class TestListAutomationRuns:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get(f"/api/v1/automations/{automation.id}/runs")
+        response = await async_client.get(f"/v1/{automation.id}/runs")
 
         assert response.status_code == 200
         data = response.json()
@@ -863,13 +863,13 @@ class TestListAutomationRuns:
 
         # Dispatch a run
         dispatch_resp = await async_client.post(
-            f"/api/v1/automations/{automation.id}/dispatch"
+            f"/v1/{automation.id}/dispatch"
         )
         assert dispatch_resp.status_code == 201
         run_id = dispatch_resp.json()["id"]
 
         # List runs
-        response = await async_client.get(f"/api/v1/automations/{automation.id}/runs")
+        response = await async_client.get(f"/v1/{automation.id}/runs")
 
         assert response.status_code == 200
         data = response.json()
@@ -910,7 +910,7 @@ class TestListAutomationRuns:
         await async_session.commit()
 
         # List runs
-        response = await async_client.get(f"/api/v1/automations/{automation.id}/runs")
+        response = await async_client.get(f"/v1/{automation.id}/runs")
 
         assert response.status_code == 200
         data = response.json()
@@ -936,13 +936,13 @@ class TestListAutomationRuns:
         # Dispatch 5 runs
         for _ in range(5):
             resp = await async_client.post(
-                f"/api/v1/automations/{automation.id}/dispatch"
+                f"/v1/{automation.id}/dispatch"
             )
             assert resp.status_code == 201
 
         # Get first page
         response = await async_client.get(
-            f"/api/v1/automations/{automation.id}/runs",
+            f"/v1/{automation.id}/runs",
             params={"limit": 2, "offset": 0},
         )
 
@@ -953,7 +953,7 @@ class TestListAutomationRuns:
 
         # Get second page
         response = await async_client.get(
-            f"/api/v1/automations/{automation.id}/runs",
+            f"/v1/{automation.id}/runs",
             params={"limit": 2, "offset": 2},
         )
 
@@ -966,7 +966,7 @@ class TestListAutomationRuns:
         """Listing runs for nonexistent automation returns 404."""
         fake_id = uuid.uuid4()
 
-        response = await async_client.get(f"/api/v1/automations/{fake_id}/runs")
+        response = await async_client.get(f"/v1/{fake_id}/runs")
 
         assert response.status_code == 404
         assert "Automation not found" in response.json()["detail"]
@@ -984,7 +984,7 @@ class TestListAutomationRuns:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get(f"/api/v1/automations/{automation.id}/runs")
+        response = await async_client.get(f"/v1/{automation.id}/runs")
 
         assert response.status_code == 404
 
@@ -1002,7 +1002,7 @@ class TestListAutomationRuns:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get(f"/api/v1/automations/{automation.id}/runs")
+        response = await async_client.get(f"/v1/{automation.id}/runs")
 
         assert response.status_code == 404
 
@@ -1020,7 +1020,7 @@ class TestListAutomationRuns:
         await async_session.commit()
 
         response = await async_client.get(
-            f"/api/v1/automations/{automation.id}/runs",
+            f"/v1/{automation.id}/runs",
             params={"limit": 101},
         )
 
@@ -1051,7 +1051,7 @@ class TestListAutomationRuns:
         await async_session.commit()
 
         # List runs without specifying limit
-        response = await async_client.get(f"/api/v1/automations/{automation.id}/runs")
+        response = await async_client.get(f"/v1/{automation.id}/runs")
 
         assert response.status_code == 200
         data = response.json()

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -708,9 +708,7 @@ class TestDispatchAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.post(
-            f"/v1/{automation.id}/dispatch"
-        )
+        response = await async_client.post(f"/v1/{automation.id}/dispatch")
 
         assert response.status_code == 201
         data = response.json()
@@ -745,9 +743,7 @@ class TestDispatchAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.post(
-            f"/v1/{automation.id}/dispatch"
-        )
+        response = await async_client.post(f"/v1/{automation.id}/dispatch")
 
         assert response.status_code == 404
 
@@ -764,9 +760,7 @@ class TestDispatchAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.post(
-            f"/v1/{automation.id}/dispatch"
-        )
+        response = await async_client.post(f"/v1/{automation.id}/dispatch")
 
         assert response.status_code == 404
 
@@ -814,9 +808,7 @@ class TestDispatchAutomation:
 
         assert automation.last_triggered_at is None
 
-        response = await async_client.post(
-            f"/v1/{automation.id}/dispatch"
-        )
+        response = await async_client.post(f"/v1/{automation.id}/dispatch")
 
         assert response.status_code == 201
 
@@ -862,9 +854,7 @@ class TestListAutomationRuns:
         await async_session.commit()
 
         # Dispatch a run
-        dispatch_resp = await async_client.post(
-            f"/v1/{automation.id}/dispatch"
-        )
+        dispatch_resp = await async_client.post(f"/v1/{automation.id}/dispatch")
         assert dispatch_resp.status_code == 201
         run_id = dispatch_resp.json()["id"]
 
@@ -935,9 +925,7 @@ class TestListAutomationRuns:
 
         # Dispatch 5 runs
         for _ in range(5):
-            resp = await async_client.post(
-                f"/v1/{automation.id}/dispatch"
-            )
+            resp = await async_client.post(f"/v1/{automation.id}/dispatch")
             assert resp.status_code == 201
 
         # Get first page

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -9,7 +9,6 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from sqlalchemy import select
 
 from automation.models import Automation, AutomationRun, AutomationRunStatus
 from automation.utils import utcnow
@@ -71,20 +70,21 @@ class TestVerifyAndMarkRunExitCodes:
             stderr="",
         )
 
-        with patch(
-            "automation.watchdog.verify_run_status",
-            new_callable=AsyncMock,
-            return_value=verification,
-        ), patch(
-            "automation.watchdog.get_api_key_for_run",
-            new_callable=AsyncMock,
-            return_value="test-api-key",
+        with (
+            patch(
+                "automation.watchdog.verify_run_status",
+                new_callable=AsyncMock,
+                return_value=verification,
+            ),
+            patch(
+                "automation.watchdog.get_api_key_for_run",
+                new_callable=AsyncMock,
+                return_value="test-api-key",
+            ),
         ):
             async with async_session_factory() as session:
                 run = await session.get(AutomationRun, run_id)
-                result = await _verify_and_mark_run(
-                    session, run, mock_settings, utcnow()
-                )
+                result = await _verify_and_mark_run(session, run, mock_settings)
                 await session.commit()
 
         assert result is True
@@ -100,7 +100,7 @@ class TestVerifyAndMarkRunExitCodes:
     async def test_exit_code_minus_1_marks_timed_out(
         self, async_session_factory, automation_with_run, mock_settings
     ):
-        """Exit code -1 means command was killed/timed out - mark as FAILED with timeout."""
+        """Exit code -1 means command was killed/timed out."""
         run_id = automation_with_run["run_id"]
 
         verification = VerificationResult(
@@ -111,20 +111,21 @@ class TestVerifyAndMarkRunExitCodes:
             stderr="Command timed out after 60 seconds",
         )
 
-        with patch(
-            "automation.watchdog.verify_run_status",
-            new_callable=AsyncMock,
-            return_value=verification,
-        ), patch(
-            "automation.watchdog.get_api_key_for_run",
-            new_callable=AsyncMock,
-            return_value="test-api-key",
+        with (
+            patch(
+                "automation.watchdog.verify_run_status",
+                new_callable=AsyncMock,
+                return_value=verification,
+            ),
+            patch(
+                "automation.watchdog.get_api_key_for_run",
+                new_callable=AsyncMock,
+                return_value="test-api-key",
+            ),
         ):
             async with async_session_factory() as session:
                 run = await session.get(AutomationRun, run_id)
-                result = await _verify_and_mark_run(
-                    session, run, mock_settings, utcnow()
-                )
+                result = await _verify_and_mark_run(session, run, mock_settings)
                 await session.commit()
 
         assert result is True
@@ -152,20 +153,21 @@ class TestVerifyAndMarkRunExitCodes:
             stderr="",
         )
 
-        with patch(
-            "automation.watchdog.verify_run_status",
-            new_callable=AsyncMock,
-            return_value=verification,
-        ), patch(
-            "automation.watchdog.get_api_key_for_run",
-            new_callable=AsyncMock,
-            return_value="test-api-key",
+        with (
+            patch(
+                "automation.watchdog.verify_run_status",
+                new_callable=AsyncMock,
+                return_value=verification,
+            ),
+            patch(
+                "automation.watchdog.get_api_key_for_run",
+                new_callable=AsyncMock,
+                return_value="test-api-key",
+            ),
         ):
             async with async_session_factory() as session:
                 run = await session.get(AutomationRun, run_id)
-                result = await _verify_and_mark_run(
-                    session, run, mock_settings, utcnow()
-                )
+                result = await _verify_and_mark_run(session, run, mock_settings)
                 await session.commit()
 
         assert result is True
@@ -181,7 +183,7 @@ class TestVerifyAndMarkRunExitCodes:
     async def test_nonzero_exit_code_marks_failed_without_timeout(
         self, async_session_factory, automation_with_run, mock_settings
     ):
-        """Non-zero exit code (not -1) means command failed - mark as FAILED without timeout."""
+        """Non-zero exit code (not -1) means command failed."""
         run_id = automation_with_run["run_id"]
 
         verification = VerificationResult(
@@ -192,20 +194,21 @@ class TestVerifyAndMarkRunExitCodes:
             stderr="Error: something went wrong",
         )
 
-        with patch(
-            "automation.watchdog.verify_run_status",
-            new_callable=AsyncMock,
-            return_value=verification,
-        ), patch(
-            "automation.watchdog.get_api_key_for_run",
-            new_callable=AsyncMock,
-            return_value="test-api-key",
+        with (
+            patch(
+                "automation.watchdog.verify_run_status",
+                new_callable=AsyncMock,
+                return_value=verification,
+            ),
+            patch(
+                "automation.watchdog.get_api_key_for_run",
+                new_callable=AsyncMock,
+                return_value="test-api-key",
+            ),
         ):
             async with async_session_factory() as session:
                 run = await session.get(AutomationRun, run_id)
-                result = await _verify_and_mark_run(
-                    session, run, mock_settings, utcnow()
-                )
+                result = await _verify_and_mark_run(session, run, mock_settings)
                 await session.commit()
 
         assert result is True
@@ -234,20 +237,21 @@ class TestVerifyAndMarkRunExitCodes:
             stderr="bash: command not found",
         )
 
-        with patch(
-            "automation.watchdog.verify_run_status",
-            new_callable=AsyncMock,
-            return_value=verification,
-        ), patch(
-            "automation.watchdog.get_api_key_for_run",
-            new_callable=AsyncMock,
-            return_value="test-api-key",
+        with (
+            patch(
+                "automation.watchdog.verify_run_status",
+                new_callable=AsyncMock,
+                return_value=verification,
+            ),
+            patch(
+                "automation.watchdog.get_api_key_for_run",
+                new_callable=AsyncMock,
+                return_value="test-api-key",
+            ),
         ):
             async with async_session_factory() as session:
                 run = await session.get(AutomationRun, run_id)
-                result = await _verify_and_mark_run(
-                    session, run, mock_settings, utcnow()
-                )
+                result = await _verify_and_mark_run(session, run, mock_settings)
                 await session.commit()
 
         assert result is True
@@ -275,23 +279,25 @@ class TestVerifyAndMarkRunVerificationFailed:
             error="Sandbox not available",
         )
 
-        with patch(
-            "automation.watchdog.verify_run_status",
-            new_callable=AsyncMock,
-            return_value=verification,
-        ), patch(
-            "automation.watchdog.get_api_key_for_run",
-            new_callable=AsyncMock,
-            return_value="test-api-key",
-        ), patch(
-            "automation.watchdog.cleanup_sandbox",
-            new_callable=AsyncMock,
-        ) as mock_cleanup:
+        with (
+            patch(
+                "automation.watchdog.verify_run_status",
+                new_callable=AsyncMock,
+                return_value=verification,
+            ),
+            patch(
+                "automation.watchdog.get_api_key_for_run",
+                new_callable=AsyncMock,
+                return_value="test-api-key",
+            ),
+            patch(
+                "automation.watchdog.cleanup_sandbox",
+                new_callable=AsyncMock,
+            ) as mock_cleanup,
+        ):
             async with async_session_factory() as session:
                 run = await session.get(AutomationRun, run_id)
-                result = await _verify_and_mark_run(
-                    session, run, mock_settings, utcnow()
-                )
+                result = await _verify_and_mark_run(session, run, mock_settings)
                 await session.commit()
 
         assert result is True
@@ -341,23 +347,25 @@ class TestVerifyAndMarkRunVerificationFailed:
             error="Sandbox not available",
         )
 
-        with patch(
-            "automation.watchdog.verify_run_status",
-            new_callable=AsyncMock,
-            return_value=verification,
-        ), patch(
-            "automation.watchdog.get_api_key_for_run",
-            new_callable=AsyncMock,
-            return_value="test-api-key",
-        ), patch(
-            "automation.watchdog.cleanup_sandbox",
-            new_callable=AsyncMock,
-        ) as mock_cleanup:
+        with (
+            patch(
+                "automation.watchdog.verify_run_status",
+                new_callable=AsyncMock,
+                return_value=verification,
+            ),
+            patch(
+                "automation.watchdog.get_api_key_for_run",
+                new_callable=AsyncMock,
+                return_value="test-api-key",
+            ),
+            patch(
+                "automation.watchdog.cleanup_sandbox",
+                new_callable=AsyncMock,
+            ) as mock_cleanup,
+        ):
             async with async_session_factory() as session:
                 run = await session.get(AutomationRun, run_id)
-                result = await _verify_and_mark_run(
-                    session, run, mock_settings, utcnow()
-                )
+                result = await _verify_and_mark_run(session, run, mock_settings)
                 await session.commit()
 
         assert result is True

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -77,7 +77,7 @@ class TestVerifyAndMarkRunExitCodes:
                 return_value=verification,
             ),
             patch(
-                "automation.watchdog.get_api_key_for_run",
+                "automation.watchdog.get_api_key_for_automation_run",
                 new_callable=AsyncMock,
                 return_value="test-api-key",
             ),
@@ -118,7 +118,7 @@ class TestVerifyAndMarkRunExitCodes:
                 return_value=verification,
             ),
             patch(
-                "automation.watchdog.get_api_key_for_run",
+                "automation.watchdog.get_api_key_for_automation_run",
                 new_callable=AsyncMock,
                 return_value="test-api-key",
             ),
@@ -160,7 +160,7 @@ class TestVerifyAndMarkRunExitCodes:
                 return_value=verification,
             ),
             patch(
-                "automation.watchdog.get_api_key_for_run",
+                "automation.watchdog.get_api_key_for_automation_run",
                 new_callable=AsyncMock,
                 return_value="test-api-key",
             ),
@@ -201,7 +201,7 @@ class TestVerifyAndMarkRunExitCodes:
                 return_value=verification,
             ),
             patch(
-                "automation.watchdog.get_api_key_for_run",
+                "automation.watchdog.get_api_key_for_automation_run",
                 new_callable=AsyncMock,
                 return_value="test-api-key",
             ),
@@ -244,7 +244,7 @@ class TestVerifyAndMarkRunExitCodes:
                 return_value=verification,
             ),
             patch(
-                "automation.watchdog.get_api_key_for_run",
+                "automation.watchdog.get_api_key_for_automation_run",
                 new_callable=AsyncMock,
                 return_value="test-api-key",
             ),
@@ -286,7 +286,7 @@ class TestVerifyAndMarkRunVerificationFailed:
                 return_value=verification,
             ),
             patch(
-                "automation.watchdog.get_api_key_for_run",
+                "automation.watchdog.get_api_key_for_automation_run",
                 new_callable=AsyncMock,
                 return_value="test-api-key",
             ),
@@ -354,7 +354,7 @@ class TestVerifyAndMarkRunVerificationFailed:
                 return_value=verification,
             ),
             patch(
-                "automation.watchdog.get_api_key_for_run",
+                "automation.watchdog.get_api_key_for_automation_run",
                 new_callable=AsyncMock,
                 return_value="test-api-key",
             ),

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,365 @@
+"""Tests for the watchdog module.
+
+The watchdog processes stale runs (RUNNING but past timeout_at) and marks them
+with appropriate status based on sandbox verification results.
+"""
+
+import uuid
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from automation.models import Automation, AutomationRun, AutomationRunStatus
+from automation.utils import utcnow
+from automation.utils.sandbox import VerificationResult
+from automation.watchdog import _verify_and_mark_run
+
+
+# Test UUIDs
+TEST_USER_ID = uuid.UUID("12345678-1234-5678-1234-567812345678")
+TEST_ORG_ID = uuid.UUID("87654321-4321-8765-4321-876543218765")
+
+
+@pytest.fixture
+async def automation_with_run(async_session_factory):
+    """Create an automation with a RUNNING run that is past timeout."""
+    async with async_session_factory() as session:
+        automation = Automation(
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            name="Test Automation",
+            trigger={"type": "cron", "schedule": "* * * * *", "timezone": "UTC"},
+            tarball_path="s3://bucket/code.tar.gz",
+            entrypoint="uv run main.py",
+            enabled=True,
+            timeout=60,
+        )
+        session.add(automation)
+        await session.commit()
+
+        now = utcnow()
+        run = AutomationRun(
+            automation_id=automation.id,
+            status=AutomationRunStatus.RUNNING,
+            sandbox_id="test-sandbox-123",
+            started_at=now - timedelta(minutes=5),
+            timeout_at=now - timedelta(minutes=1),  # Already past timeout
+        )
+        session.add(run)
+        await session.commit()
+
+        yield {"automation": automation, "run": run, "run_id": run.id}
+
+
+class TestVerifyAndMarkRunExitCodes:
+    """Tests for _verify_and_mark_run handling different exit codes."""
+
+    @pytest.mark.asyncio
+    async def test_exit_code_0_marks_completed(
+        self, async_session_factory, automation_with_run, mock_settings
+    ):
+        """Exit code 0 means command succeeded - mark as COMPLETED."""
+        run_id = automation_with_run["run_id"]
+
+        verification = VerificationResult(
+            verified=True,
+            success=True,
+            exit_code=0,
+            stdout="Success output",
+            stderr="",
+        )
+
+        with patch(
+            "automation.watchdog.verify_run_status",
+            new_callable=AsyncMock,
+            return_value=verification,
+        ), patch(
+            "automation.watchdog.get_api_key_for_run",
+            new_callable=AsyncMock,
+            return_value="test-api-key",
+        ):
+            async with async_session_factory() as session:
+                run = await session.get(AutomationRun, run_id)
+                result = await _verify_and_mark_run(
+                    session, run, mock_settings, utcnow()
+                )
+                await session.commit()
+
+        assert result is True
+
+        # Verify the run was marked as COMPLETED
+        async with async_session_factory() as session:
+            run = await session.get(AutomationRun, run_id)
+            assert run.status == AutomationRunStatus.COMPLETED
+            assert run.completed_at is not None
+            assert run.error_detail is None
+
+    @pytest.mark.asyncio
+    async def test_exit_code_minus_1_marks_timed_out(
+        self, async_session_factory, automation_with_run, mock_settings
+    ):
+        """Exit code -1 means command was killed/timed out - mark as FAILED with timeout."""
+        run_id = automation_with_run["run_id"]
+
+        verification = VerificationResult(
+            verified=True,
+            success=False,
+            exit_code=-1,
+            stdout="",
+            stderr="Command timed out after 60 seconds",
+        )
+
+        with patch(
+            "automation.watchdog.verify_run_status",
+            new_callable=AsyncMock,
+            return_value=verification,
+        ), patch(
+            "automation.watchdog.get_api_key_for_run",
+            new_callable=AsyncMock,
+            return_value="test-api-key",
+        ):
+            async with async_session_factory() as session:
+                run = await session.get(AutomationRun, run_id)
+                result = await _verify_and_mark_run(
+                    session, run, mock_settings, utcnow()
+                )
+                await session.commit()
+
+        assert result is True
+
+        # Verify the run was marked as FAILED with timeout message
+        async with async_session_factory() as session:
+            run = await session.get(AutomationRun, run_id)
+            assert run.status == AutomationRunStatus.FAILED
+            assert run.completed_at is not None
+            assert "Timed out" in run.error_detail
+            assert "timed out" in run.error_detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_exit_code_none_marks_timed_out(
+        self, async_session_factory, automation_with_run, mock_settings
+    ):
+        """Exit code None means command was killed - mark as FAILED with timeout."""
+        run_id = automation_with_run["run_id"]
+
+        verification = VerificationResult(
+            verified=True,
+            success=False,
+            exit_code=None,
+            stdout="",
+            stderr="",
+        )
+
+        with patch(
+            "automation.watchdog.verify_run_status",
+            new_callable=AsyncMock,
+            return_value=verification,
+        ), patch(
+            "automation.watchdog.get_api_key_for_run",
+            new_callable=AsyncMock,
+            return_value="test-api-key",
+        ):
+            async with async_session_factory() as session:
+                run = await session.get(AutomationRun, run_id)
+                result = await _verify_and_mark_run(
+                    session, run, mock_settings, utcnow()
+                )
+                await session.commit()
+
+        assert result is True
+
+        # Verify the run was marked as FAILED with timeout message
+        async with async_session_factory() as session:
+            run = await session.get(AutomationRun, run_id)
+            assert run.status == AutomationRunStatus.FAILED
+            assert run.completed_at is not None
+            assert "Timed out" in run.error_detail
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_code_marks_failed_without_timeout(
+        self, async_session_factory, automation_with_run, mock_settings
+    ):
+        """Non-zero exit code (not -1) means command failed - mark as FAILED without timeout."""
+        run_id = automation_with_run["run_id"]
+
+        verification = VerificationResult(
+            verified=True,
+            success=False,
+            exit_code=1,
+            stdout="Some output",
+            stderr="Error: something went wrong",
+        )
+
+        with patch(
+            "automation.watchdog.verify_run_status",
+            new_callable=AsyncMock,
+            return_value=verification,
+        ), patch(
+            "automation.watchdog.get_api_key_for_run",
+            new_callable=AsyncMock,
+            return_value="test-api-key",
+        ):
+            async with async_session_factory() as session:
+                run = await session.get(AutomationRun, run_id)
+                result = await _verify_and_mark_run(
+                    session, run, mock_settings, utcnow()
+                )
+                await session.commit()
+
+        assert result is True
+
+        # Verify the run was marked as FAILED with exit code (not timeout)
+        async with async_session_factory() as session:
+            run = await session.get(AutomationRun, run_id)
+            assert run.status == AutomationRunStatus.FAILED
+            assert run.completed_at is not None
+            assert "exit_code=1" in run.error_detail
+            assert "Timed out" not in run.error_detail
+            assert "stderr: Error: something went wrong" in run.error_detail
+
+    @pytest.mark.asyncio
+    async def test_exit_code_127_marks_failed_without_timeout(
+        self, async_session_factory, automation_with_run, mock_settings
+    ):
+        """Exit code 127 (command not found) - mark as FAILED without timeout."""
+        run_id = automation_with_run["run_id"]
+
+        verification = VerificationResult(
+            verified=True,
+            success=False,
+            exit_code=127,
+            stdout="",
+            stderr="bash: command not found",
+        )
+
+        with patch(
+            "automation.watchdog.verify_run_status",
+            new_callable=AsyncMock,
+            return_value=verification,
+        ), patch(
+            "automation.watchdog.get_api_key_for_run",
+            new_callable=AsyncMock,
+            return_value="test-api-key",
+        ):
+            async with async_session_factory() as session:
+                run = await session.get(AutomationRun, run_id)
+                result = await _verify_and_mark_run(
+                    session, run, mock_settings, utcnow()
+                )
+                await session.commit()
+
+        assert result is True
+
+        # Verify the run was marked as FAILED with exit code (not timeout)
+        async with async_session_factory() as session:
+            run = await session.get(AutomationRun, run_id)
+            assert run.status == AutomationRunStatus.FAILED
+            assert "exit_code=127" in run.error_detail
+            assert "Timed out" not in run.error_detail
+
+
+class TestVerifyAndMarkRunVerificationFailed:
+    """Tests for _verify_and_mark_run when verification fails."""
+
+    @pytest.mark.asyncio
+    async def test_verification_failed_marks_timed_out(
+        self, async_session_factory, automation_with_run, mock_settings
+    ):
+        """When verification fails (sandbox unavailable), mark as timed out."""
+        run_id = automation_with_run["run_id"]
+
+        verification = VerificationResult(
+            verified=False,
+            error="Sandbox not available",
+        )
+
+        with patch(
+            "automation.watchdog.verify_run_status",
+            new_callable=AsyncMock,
+            return_value=verification,
+        ), patch(
+            "automation.watchdog.get_api_key_for_run",
+            new_callable=AsyncMock,
+            return_value="test-api-key",
+        ), patch(
+            "automation.watchdog.cleanup_sandbox",
+            new_callable=AsyncMock,
+        ) as mock_cleanup:
+            async with async_session_factory() as session:
+                run = await session.get(AutomationRun, run_id)
+                result = await _verify_and_mark_run(
+                    session, run, mock_settings, utcnow()
+                )
+                await session.commit()
+
+        assert result is True
+        mock_cleanup.assert_called_once()
+
+        # Verify the run was marked as FAILED with timeout message
+        async with async_session_factory() as session:
+            run = await session.get(AutomationRun, run_id)
+            assert run.status == AutomationRunStatus.FAILED
+            assert run.completed_at is not None
+            assert "Timed out" in run.error_detail
+            assert "Sandbox not available" in run.error_detail
+
+    @pytest.mark.asyncio
+    async def test_verification_failed_no_cleanup_if_keep_alive(
+        self, async_session_factory, mock_settings
+    ):
+        """When keep_alive is True, don't cleanup sandbox on verification failure."""
+        async with async_session_factory() as session:
+            automation = Automation(
+                user_id=TEST_USER_ID,
+                org_id=TEST_ORG_ID,
+                name="Keep Alive Automation",
+                trigger={"type": "cron", "schedule": "* * * * *", "timezone": "UTC"},
+                tarball_path="s3://bucket/code.tar.gz",
+                entrypoint="uv run main.py",
+                enabled=True,
+            )
+            session.add(automation)
+            await session.commit()
+
+            now = utcnow()
+            run = AutomationRun(
+                automation_id=automation.id,
+                status=AutomationRunStatus.RUNNING,
+                sandbox_id="test-sandbox-456",
+                started_at=now - timedelta(minutes=5),
+                timeout_at=now - timedelta(minutes=1),
+                keep_alive=True,
+            )
+            session.add(run)
+            await session.commit()
+            run_id = run.id
+
+        verification = VerificationResult(
+            verified=False,
+            error="Sandbox not available",
+        )
+
+        with patch(
+            "automation.watchdog.verify_run_status",
+            new_callable=AsyncMock,
+            return_value=verification,
+        ), patch(
+            "automation.watchdog.get_api_key_for_run",
+            new_callable=AsyncMock,
+            return_value="test-api-key",
+        ), patch(
+            "automation.watchdog.cleanup_sandbox",
+            new_callable=AsyncMock,
+        ) as mock_cleanup:
+            async with async_session_factory() as session:
+                run = await session.get(AutomationRun, run_id)
+                result = await _verify_and_mark_run(
+                    session, run, mock_settings, utcnow()
+                )
+                await session.commit()
+
+        assert result is True
+        # Cleanup should NOT be called when keep_alive is True
+        mock_cleanup.assert_not_called()


### PR DESCRIPTION
## Summary

Simplifies the API route prefix for a cleaner URL structure. The API for the automation service will be served via `/api/automation/` subpath with `v1` route prefixes.

For example, the endpoint to create an automation will look like:
```
https://staging.all-hands.dev/api/automation/v1/{aid}
```

## Fixes

- **Router order**: Include `uploads_router` before main router to prevent UUID validation errors on `/v1/uploads`
- **Dispatcher timeout**: Use `automation.timeout_seconds` (not `settings.default_timeout`) when computing `timeout_at`
- **Watchdog exit codes**: Handle exit codes correctly:
  - `0` → COMPLETED (missed callback)
  - `-1` or `None` → FAILED with "Timed out" message
  - Other → FAILED with exit code details
- **Watchdog config**: Remove `interval_seconds` param, use `settings.watchdog_interval_seconds` directly
- **Logger noise**: Silence `sqlalchemy.engine` logger to suppress noisy SQL statement logs
