### PR TITLE
feat: Disable automations when configured in erroneous state

### DIFF
--- a/automation/dispatcher.py
+++ b/automation/dispatcher.py
@@ -22,10 +22,16 @@ from sqlalchemy.orm import selectinload
 
 from automation.config import Settings
 from automation.constants import MAX_RUN_DURATION, MAX_RUN_DURATION_SECONDS
+from automation.exceptions import PermanentDispatchError, TarballNotFoundError
 from automation.execution import dispatch_automation
 from automation.models import AutomationRun, AutomationRunStatus, TarballUpload
 from automation.utils.api_key import APIKeyError, get_api_key_for_automation_run
-from automation.utils.run import mark_run_status, mark_run_terminal, update_sandbox_id
+from automation.utils.run import (
+    disable_automation,
+    mark_run_status,
+    mark_run_terminal,
+    update_sandbox_id,
+)
 from automation.utils.tarball_validation import is_http_url, parse_internal_upload_id
 
 
@@ -56,7 +62,13 @@ async def _download_internal_tarball(
     upload_id: uuid.UUID,
     session: AsyncSession | None,
 ) -> bytes:
-    """Download a tarball from storage using the TarballUpload record."""
+    """Download a tarball from storage using the TarballUpload record.
+
+    Raises:
+        TarballNotFoundError: If the tarball upload record doesn't exist.
+            This is a permanent error that should disable the automation.
+        ValueError: If no database session is provided.
+    """
     if session is None:
         raise ValueError("Database session required to resolve oh-internal:// URLs")
 
@@ -65,7 +77,10 @@ async def _download_internal_tarball(
     )
     upload = result.scalars().first()
     if upload is None:
-        raise FileNotFoundError(f"TarballUpload {upload_id} not found")
+        raise TarballNotFoundError(
+            f"Internal tarball upload not found: {upload_id}. "
+            "The tarball may have been deleted."
+        )
 
     from automation.storage import get_file_store
 
@@ -201,6 +216,19 @@ async def _execute_run(
             await mark_run_terminal(
                 session_factory, run, AutomationRunStatus.FAILED, result.error
             )
+
+    except PermanentDispatchError as exc:
+        # Permanent configuration error - disable the automation
+        logger.error(
+            "Permanent dispatch error, disabling automation: %s",
+            exc,
+            exc_info=True,
+            extra=log_extra(),
+        )
+        await mark_run_terminal(
+            session_factory, run, AutomationRunStatus.FAILED, str(exc)
+        )
+        await disable_automation(session_factory, automation.id, str(exc))
 
     except (APIKeyError, ValueError) as exc:
         logger.error("Dispatch error: %s", exc, exc_info=True, extra=log_extra())

--- a/automation/exceptions.py
+++ b/automation/exceptions.py
@@ -1,0 +1,29 @@
+"""Custom exceptions for the automation service.
+
+These exceptions help distinguish between transient failures (which may
+succeed on retry) and permanent failures (which should disable the automation).
+"""
+
+
+class PermanentDispatchError(Exception):
+    """Base class for errors that indicate the automation is misconfigured.
+
+    When raised, the automation should be disabled since retrying will not help.
+    Examples: tarball URL doesn't exist, malformed configuration.
+
+    These are distinct from transient errors like network timeouts or service
+    unavailability, which may succeed on retry.
+    """
+
+    pass
+
+
+class TarballNotFoundError(PermanentDispatchError):
+    """The tarball could not be found - either the internal upload is missing
+    or the external URL returns 404.
+
+    This is a permanent error that warrants disabling the automation,
+    since the configured tarball_path does not point to a valid resource.
+    """
+
+    pass

--- a/automation/execution.py
+++ b/automation/execution.py
@@ -7,6 +7,7 @@ extract it, run setup, run the entrypoint, tear down.
 import asyncio
 import io
 import logging
+import re
 import tarfile
 from typing import Any
 
@@ -32,6 +33,7 @@ from automation.constants import (
     TARBALL_PATH,
     WORK_DIR,
 )
+from automation.exceptions import TarballNotFoundError
 from automation.utils.sandbox import delete_sandbox
 
 
@@ -219,6 +221,24 @@ async def _start_bash(
     return body.get("id")
 
 
+def _is_permanent_http_error(stderr: str) -> bool:
+    """Check if curl stderr indicates a permanent HTTP error (4xx client errors).
+
+    We only treat 4xx errors as permanent because they indicate the URL is wrong
+    or inaccessible (404 Not Found, 403 Forbidden, 401 Unauthorized, etc.).
+    5xx errors are transient server issues that may resolve on retry.
+
+    Returns True if the error is permanent and the automation should be disabled.
+    """
+    # curl error format: "The requested URL returned error: 404"
+    # We look for 4xx status codes
+    match = re.search(r"returned error:\s*(\d{3})", stderr)
+    if match:
+        status_code = int(match.group(1))
+        return 400 <= status_code < 500
+    return False
+
+
 async def _download_in_sandbox(
     client: httpx.AsyncClient,
     agent_url: str,
@@ -233,7 +253,10 @@ async def _download_in_sandbox(
     This is used for external URLs (https://) to avoid downloading
     untrusted, potentially large files on the automation service.
 
-    Raises RuntimeError if the download fails.
+    Raises:
+        TarballNotFoundError: If the URL returns a 4xx HTTP error (permanent).
+            This indicates the URL is wrong or inaccessible.
+        RuntimeError: For other download failures (transient).
     """
     # Use curl with safety limits:
     # -f: fail silently on HTTP errors (returns exit code 22)
@@ -260,6 +283,14 @@ async def _download_in_sandbox(
             raise RuntimeError(
                 f"Tarball exceeds size limit ({max_filesize // 1024 // 1024} MB)"
             )
+
+        # Check if this is a permanent HTTP error (4xx)
+        if exit_code == 22 and _is_permanent_http_error(stderr):
+            raise TarballNotFoundError(
+                f"External tarball URL is not accessible: {tarball_url}. "
+                f"HTTP error: {stderr.strip()}"
+            )
+
         raise RuntimeError(f"Failed to download tarball (exit={exit_code}): {stderr}")
 
 

--- a/automation/execution.py
+++ b/automation/execution.py
@@ -33,7 +33,7 @@ from automation.constants import (
     TARBALL_PATH,
     WORK_DIR,
 )
-from automation.exceptions import TarballNotFoundError
+from automation.exceptions import PermanentDispatchError, TarballNotFoundError
 from automation.utils.sandbox import delete_sandbox
 
 
@@ -412,6 +412,11 @@ async def dispatch_automation(
 
             return DispatchResult(success=True, sandbox_id=sandbox_id)
 
+        except PermanentDispatchError:
+            # Clean up sandbox before re-raising so dispatcher can disable automation
+            if sandbox_id:
+                await delete_sandbox(client, api_url, api_key, sandbox_id)
+            raise
         except Exception as e:
             logger.exception("Automation dispatch failed", extra=log_extra())
             # Delete sandbox on dispatch failure to avoid orphaned sandboxes

--- a/automation/execution.py
+++ b/automation/execution.py
@@ -415,7 +415,10 @@ async def dispatch_automation(
         except PermanentDispatchError:
             # Clean up sandbox before re-raising so dispatcher can disable automation
             if sandbox_id:
-                await delete_sandbox(client, api_url, api_key, sandbox_id)
+                try:
+                    await delete_sandbox(client, api_url, api_key, sandbox_id)
+                except Exception:
+                    logger.exception("Failed to delete sandbox during error cleanup")
             raise
         except Exception as e:
             logger.exception("Automation dispatch failed", extra=log_extra())

--- a/automation/utils/run.py
+++ b/automation/utils/run.py
@@ -4,7 +4,7 @@ import logging
 import uuid
 from datetime import timedelta
 
-from sqlalchemy import update
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from automation.constants import MAX_RUN_DURATION
@@ -13,6 +13,61 @@ from automation.utils.time import utcnow
 
 
 logger = logging.getLogger(__name__)
+
+
+async def disable_automation(
+    session_factory: async_sessionmaker[AsyncSession],
+    automation_id: uuid.UUID,
+    reason: str,
+) -> bool:
+    """Disable an automation due to a permanent configuration error.
+
+    This function sets enabled=False on the automation when we detect
+    an unrecoverable error condition (e.g., tarball URL doesn't exist).
+    The automation can be re-enabled manually after fixing the configuration.
+
+    Args:
+        session_factory: Async session factory
+        automation_id: The automation ID to disable
+        reason: Human-readable reason for disabling (logged)
+
+    Returns:
+        True if the automation was disabled, False if not found or already disabled
+    """
+    extra = {"automation_id": str(automation_id)}
+
+    try:
+        async with session_factory() as session:
+            result = await session.execute(
+                select(Automation).where(Automation.id == automation_id)
+            )
+            automation = result.scalars().first()
+
+            if automation is None:
+                logger.warning("Cannot disable automation: not found", extra=extra)
+                return False
+
+            if not automation.enabled:
+                logger.info("Automation already disabled", extra=extra)
+                return False
+
+            await session.execute(
+                update(Automation)
+                .where(Automation.id == automation_id)
+                .values(enabled=False)
+            )
+            await session.commit()
+
+            logger.warning(
+                "Automation disabled due to permanent error: %s",
+                reason,
+                extra=extra,
+            )
+            return True
+
+    except Exception:
+        logger.exception("Failed to disable automation", extra=extra)
+        return False
 
 
 async def create_pending_run(

--- a/automation/utils/run.py
+++ b/automation/utils/run.py
@@ -4,7 +4,7 @@ import logging
 import uuid
 from datetime import timedelta
 
-from sqlalchemy import select, update
+from sqlalchemy import CursorResult, select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from automation.constants import MAX_RUN_DURATION
@@ -26,6 +26,9 @@ async def disable_automation(
     an unrecoverable error condition (e.g., tarball URL doesn't exist).
     The automation can be re-enabled manually after fixing the configuration.
 
+    Uses optimistic locking (UPDATE WHERE enabled=True) to handle race
+    conditions when multiple runs fail simultaneously.
+
     Args:
         session_factory: Async session factory
         automation_id: The automation ID to disable
@@ -38,24 +41,27 @@ async def disable_automation(
 
     try:
         async with session_factory() as session:
-            result = await session.execute(
-                select(Automation).where(Automation.id == automation_id)
-            )
-            automation = result.scalars().first()
-
-            if automation is None:
-                logger.warning("Cannot disable automation: not found", extra=extra)
-                return False
-
-            if not automation.enabled:
-                logger.info("Automation already disabled", extra=extra)
-                return False
-
-            await session.execute(
+            # Use optimistic locking: only update if currently enabled
+            result: CursorResult = await session.execute(  # type: ignore[assignment]
                 update(Automation)
-                .where(Automation.id == automation_id)
+                .where(
+                    Automation.id == automation_id,
+                    Automation.enabled == True,  # noqa: E712
+                )
                 .values(enabled=False)
             )
+
+            if result.rowcount == 0:
+                # Either not found or already disabled - check which
+                check = await session.execute(
+                    select(Automation).where(Automation.id == automation_id)
+                )
+                if check.scalars().first() is None:
+                    logger.warning("Cannot disable automation: not found", extra=extra)
+                else:
+                    logger.info("Automation already disabled", extra=extra)
+                return False
+
             await session.commit()
 
             logger.warning(

--- a/tests/test_disable_automation.py
+++ b/tests/test_disable_automation.py
@@ -1,0 +1,349 @@
+"""Tests for automatic disabling of automations with erroneous configurations.
+
+When an automation has a permanent error (e.g., tarball URL doesn't exist),
+the system should automatically disable it to prevent repeated failed runs.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from automation.exceptions import PermanentDispatchError, TarballNotFoundError
+from automation.execution import _is_permanent_http_error
+
+
+# Test UUIDs
+TEST_USER_ID = uuid.UUID("12345678-1234-5678-1234-567812345678")
+TEST_ORG_ID = uuid.UUID("87654321-4321-8765-4321-876543218765")
+
+
+def _docker_available() -> bool:
+    """Check if Docker is available for testcontainers."""
+    try:
+        import socket
+
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect("/var/run/docker.sock")
+        sock.close()
+        return True
+    except (FileNotFoundError, ConnectionRefusedError):
+        return False
+
+
+requires_docker = pytest.mark.skipif(
+    not _docker_available(),
+    reason="Docker not available for testcontainers",
+)
+
+
+class TestExceptions:
+    """Tests for the custom exception hierarchy."""
+
+    def test_tarball_not_found_is_permanent_error(self):
+        """TarballNotFoundError is a PermanentDispatchError."""
+        exc = TarballNotFoundError("test")
+        assert isinstance(exc, PermanentDispatchError)
+
+    def test_permanent_dispatch_error_is_exception(self):
+        """PermanentDispatchError is a standard Exception."""
+        exc = PermanentDispatchError("test")
+        assert isinstance(exc, Exception)
+
+
+class TestIsPermanentHttpError:
+    """Tests for _is_permanent_http_error function."""
+
+    def test_404_is_permanent(self):
+        """HTTP 404 Not Found is a permanent error."""
+        stderr = "curl: (22) The requested URL returned error: 404"
+        assert _is_permanent_http_error(stderr) is True
+
+    def test_403_is_permanent(self):
+        """HTTP 403 Forbidden is a permanent error."""
+        stderr = "curl: (22) The requested URL returned error: 403"
+        assert _is_permanent_http_error(stderr) is True
+
+    def test_401_is_permanent(self):
+        """HTTP 401 Unauthorized is a permanent error."""
+        stderr = "curl: (22) The requested URL returned error: 401"
+        assert _is_permanent_http_error(stderr) is True
+
+    def test_400_is_permanent(self):
+        """HTTP 400 Bad Request is a permanent error."""
+        stderr = "curl: (22) The requested URL returned error: 400"
+        assert _is_permanent_http_error(stderr) is True
+
+    def test_410_is_permanent(self):
+        """HTTP 410 Gone is a permanent error."""
+        stderr = "curl: (22) The requested URL returned error: 410"
+        assert _is_permanent_http_error(stderr) is True
+
+    def test_500_is_not_permanent(self):
+        """HTTP 500 Internal Server Error is a transient error."""
+        stderr = "curl: (22) The requested URL returned error: 500"
+        assert _is_permanent_http_error(stderr) is False
+
+    def test_502_is_not_permanent(self):
+        """HTTP 502 Bad Gateway is a transient error."""
+        stderr = "curl: (22) The requested URL returned error: 502"
+        assert _is_permanent_http_error(stderr) is False
+
+    def test_503_is_not_permanent(self):
+        """HTTP 503 Service Unavailable is a transient error."""
+        stderr = "curl: (22) The requested URL returned error: 503"
+        assert _is_permanent_http_error(stderr) is False
+
+    def test_no_status_code_is_not_permanent(self):
+        """Non-HTTP errors are not permanent."""
+        stderr = "curl: (7) Failed to connect to host.example.com"
+        assert _is_permanent_http_error(stderr) is False
+
+    def test_empty_stderr_is_not_permanent(self):
+        """Empty stderr is not permanent."""
+        assert _is_permanent_http_error("") is False
+
+    def test_timeout_error_is_not_permanent(self):
+        """Timeout errors are not permanent."""
+        stderr = "curl: (28) Operation timed out after 30000 milliseconds"
+        assert _is_permanent_http_error(stderr) is False
+
+
+@requires_docker
+class TestDisableAutomation:
+    """Tests for the disable_automation function."""
+
+    async def test_disables_enabled_automation(self, async_session_factory):
+        """An enabled automation is disabled and returns True."""
+        from automation.models import Automation
+        from automation.utils.run import disable_automation
+
+        async with async_session_factory() as session:
+            automation = Automation(
+                user_id=TEST_USER_ID,
+                org_id=TEST_ORG_ID,
+                name="Test Automation",
+                trigger={"type": "cron", "schedule": "* * * * *", "timezone": "UTC"},
+                tarball_path="https://example.com/missing.tar.gz",
+                entrypoint="uv run main.py",
+                enabled=True,
+            )
+            session.add(automation)
+            await session.commit()
+            automation_id = automation.id
+
+        result = await disable_automation(
+            async_session_factory, automation_id, "Tarball not found"
+        )
+
+        assert result is True
+
+        async with async_session_factory() as session:
+            db_result = await session.execute(
+                select(Automation).where(Automation.id == automation_id)
+            )
+            automation = db_result.scalars().first()
+            assert automation.enabled is False
+
+    async def test_returns_false_for_already_disabled(self, async_session_factory):
+        """Already disabled automation returns False."""
+        from automation.models import Automation
+        from automation.utils.run import disable_automation
+
+        async with async_session_factory() as session:
+            automation = Automation(
+                user_id=TEST_USER_ID,
+                org_id=TEST_ORG_ID,
+                name="Test Automation",
+                trigger={"type": "cron", "schedule": "* * * * *", "timezone": "UTC"},
+                tarball_path="https://example.com/missing.tar.gz",
+                entrypoint="uv run main.py",
+                enabled=False,  # Already disabled
+            )
+            session.add(automation)
+            await session.commit()
+            automation_id = automation.id
+
+        result = await disable_automation(
+            async_session_factory, automation_id, "Tarball not found"
+        )
+
+        assert result is False
+
+    async def test_returns_false_for_nonexistent(self, async_session_factory):
+        """Non-existent automation returns False."""
+        from automation.utils.run import disable_automation
+
+        fake_id = uuid.uuid4()
+        result = await disable_automation(
+            async_session_factory, fake_id, "Tarball not found"
+        )
+
+        assert result is False
+
+
+@requires_docker
+class TestDownloadInternalTarball:
+    """Tests for _download_internal_tarball raising TarballNotFoundError."""
+
+    async def test_raises_tarball_not_found_for_missing_upload(
+        self, async_session_factory
+    ):
+        """TarballNotFoundError is raised when upload record doesn't exist."""
+        from automation.dispatcher import _download_internal_tarball
+
+        fake_upload_id = uuid.uuid4()
+
+        async with async_session_factory() as session:
+            with pytest.raises(TarballNotFoundError) as exc_info:
+                await _download_internal_tarball(fake_upload_id, session)
+
+        assert "not found" in str(exc_info.value).lower()
+        assert str(fake_upload_id) in str(exc_info.value)
+
+
+@requires_docker
+class TestExecuteRunDisablesAutomation:
+    """Tests that _execute_run disables automation on permanent errors."""
+
+    @patch("automation.dispatcher.dispatch_automation")
+    @patch("automation.dispatcher.get_api_key_for_automation_run")
+    async def test_disables_automation_on_internal_tarball_not_found(
+        self,
+        mock_get_api_key,
+        mock_dispatch,
+        async_session_factory,
+        mock_settings,
+    ):
+        """Automation is disabled when internal tarball upload is not found."""
+        from automation.dispatcher import _execute_run
+        from automation.models import Automation, AutomationRun, AutomationRunStatus
+
+        mock_get_api_key.return_value = "test-api-key"
+
+        # Create an automation with a non-existent internal tarball
+        fake_upload_id = uuid.uuid4()
+        async with async_session_factory() as session:
+            automation = Automation(
+                user_id=TEST_USER_ID,
+                org_id=TEST_ORG_ID,
+                name="Test Automation",
+                trigger={"type": "cron", "schedule": "* * * * *", "timezone": "UTC"},
+                tarball_path=f"oh-internal://uploads/{fake_upload_id}",
+                entrypoint="uv run main.py",
+                enabled=True,
+            )
+            session.add(automation)
+            await session.commit()
+
+            run = AutomationRun(
+                automation_id=automation.id,
+                status=AutomationRunStatus.RUNNING,
+            )
+            session.add(run)
+            await session.commit()
+            automation_id = automation.id
+
+        # Re-fetch with automation relationship loaded
+        async with async_session_factory() as session:
+            from sqlalchemy.orm import selectinload
+
+            result = await session.execute(
+                select(AutomationRun)
+                .options(selectinload(AutomationRun.automation))
+                .where(AutomationRun.automation_id == automation_id)
+            )
+            run = result.scalars().first()
+
+            await _execute_run(run, mock_settings, async_session_factory)
+
+        # Verify automation was disabled
+        async with async_session_factory() as session:
+            result = await session.execute(
+                select(Automation).where(Automation.id == automation_id)
+            )
+            automation = result.scalars().first()
+            assert automation.enabled is False
+
+        # Verify run was marked as FAILED
+        async with async_session_factory() as session:
+            result = await session.execute(
+                select(AutomationRun).where(
+                    AutomationRun.automation_id == automation_id
+                )
+            )
+            run = result.scalars().first()
+            assert run.status == AutomationRunStatus.FAILED
+            assert "not found" in run.error_detail.lower()
+
+    @patch("automation.dispatcher.dispatch_automation")
+    @patch("automation.dispatcher.get_api_key_for_automation_run")
+    async def test_does_not_disable_on_transient_error(
+        self,
+        mock_get_api_key,
+        mock_dispatch,
+        async_session_factory,
+        mock_settings,
+    ):
+        """Automation is NOT disabled on transient errors like network failures."""
+        from automation.dispatcher import _execute_run
+        from automation.models import Automation, AutomationRun, AutomationRunStatus
+
+        mock_get_api_key.return_value = "test-api-key"
+        # Simulate a transient dispatch failure (e.g., sandbox creation failed)
+        mock_dispatch.return_value = AsyncMock(
+            success=False, sandbox_id=None, error="Connection timeout"
+        )
+
+        async with async_session_factory() as session:
+            automation = Automation(
+                user_id=TEST_USER_ID,
+                org_id=TEST_ORG_ID,
+                name="Test Automation",
+                trigger={"type": "cron", "schedule": "* * * * *", "timezone": "UTC"},
+                tarball_path="https://example.com/valid.tar.gz",
+                entrypoint="uv run main.py",
+                enabled=True,
+            )
+            session.add(automation)
+            await session.commit()
+
+            run = AutomationRun(
+                automation_id=automation.id,
+                status=AutomationRunStatus.RUNNING,
+            )
+            session.add(run)
+            await session.commit()
+            automation_id = automation.id
+
+        # Re-fetch with automation relationship loaded
+        async with async_session_factory() as session:
+            from sqlalchemy.orm import selectinload
+
+            result = await session.execute(
+                select(AutomationRun)
+                .options(selectinload(AutomationRun.automation))
+                .where(AutomationRun.automation_id == automation_id)
+            )
+            run = result.scalars().first()
+
+            await _execute_run(run, mock_settings, async_session_factory)
+
+        # Verify automation is still enabled (transient error)
+        async with async_session_factory() as session:
+            result = await session.execute(
+                select(Automation).where(Automation.id == automation_id)
+            )
+            automation = result.scalars().first()
+            assert automation.enabled is True
+
+        # Verify run was marked as FAILED
+        async with async_session_factory() as session:
+            result = await session.execute(
+                select(AutomationRun).where(
+                    AutomationRun.automation_id == automation_id
+                )
+            )
+            run = result.scalars().first()
+            assert run.status == AutomationRunStatus.FAILED

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -276,3 +276,45 @@ class TestDispatchAutomationPermanentErrors:
 
         assert "permanently failed" in str(exc_info.value)
         mock_delete_sandbox.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("automation.execution._create_and_wait")
+    @patch("automation.execution.delete_sandbox")
+    @patch("automation.execution._download_in_sandbox")
+    async def test_permanent_error_not_masked_by_cleanup_failure(
+        self,
+        mock_download_in_sandbox,
+        mock_delete_sandbox,
+        mock_create_and_wait,
+    ):
+        """PermanentDispatchError is re-raised even if sandbox cleanup fails.
+
+        This tests the fix for review comment about exception masking:
+        if delete_sandbox() raises, we should still re-raise the original
+        PermanentDispatchError so the dispatcher can disable the automation.
+        """
+        sandbox_id = "test-sandbox-cleanup-fail"
+        mock_create_and_wait.return_value = (
+            sandbox_id,
+            "session-key",
+            "https://agent.example.com",
+        )
+        mock_download_in_sandbox.side_effect = TarballNotFoundError(
+            "External tarball URL is not accessible: 404"
+        )
+        # Simulate cleanup failure
+        mock_delete_sandbox.side_effect = RuntimeError("Failed to delete sandbox")
+
+        # Should still raise TarballNotFoundError, not RuntimeError
+        with pytest.raises(TarballNotFoundError) as exc_info:
+            await dispatch_automation(
+                api_url="https://api.example.com",
+                api_key="test-key",
+                entrypoint="python main.py",
+                tarball_source="https://example.com/missing.tar.gz",
+            )
+
+        # Verify we got the original error, not the cleanup error
+        assert "404" in str(exc_info.value)
+        # Cleanup was still attempted
+        mock_delete_sandbox.assert_called_once()

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -7,9 +7,11 @@ scripts/test_automation.py.
 
 import io
 import tarfile
+from unittest.mock import patch
 
 import pytest
 
+from automation.exceptions import PermanentDispatchError, TarballNotFoundError
 from automation.execution import (
     EXTERNAL_DOWNLOAD_TIMEOUT,
     EXTERNAL_MAX_FILESIZE,
@@ -17,6 +19,7 @@ from automation.execution import (
     DispatchResult,
     _shell_quote,
     build_tarball,
+    dispatch_automation,
 )
 
 
@@ -138,3 +141,138 @@ class TestExternalDownloadConstants:
     def test_max_filesize_is_reasonable(self):
         """Max filesize should be reasonable (10MB - 500MB)."""
         assert 10 * 1024 * 1024 <= EXTERNAL_MAX_FILESIZE <= 500 * 1024 * 1024
+
+
+class TestDispatchAutomationPermanentErrors:
+    """Tests for dispatch_automation handling of PermanentDispatchError."""
+
+    @pytest.mark.asyncio
+    @patch("automation.execution._create_and_wait")
+    @patch("automation.execution.delete_sandbox")
+    @patch("automation.execution._download_in_sandbox")
+    async def test_reraises_permanent_error_after_sandbox_cleanup(
+        self,
+        mock_download_in_sandbox,
+        mock_delete_sandbox,
+        mock_create_and_wait,
+    ):
+        """PermanentDispatchError is re-raised after cleaning up the sandbox."""
+        sandbox_id = "test-sandbox-123"
+        mock_create_and_wait.return_value = (
+            sandbox_id,
+            "session-key",
+            "https://agent.example.com",
+        )
+        mock_download_in_sandbox.side_effect = TarballNotFoundError(
+            "External tarball URL is not accessible"
+        )
+        mock_delete_sandbox.return_value = None
+
+        with pytest.raises(TarballNotFoundError) as exc_info:
+            await dispatch_automation(
+                api_url="https://api.example.com",
+                api_key="test-key",
+                entrypoint="python main.py",
+                tarball_source="https://example.com/missing.tar.gz",
+            )
+
+        assert "not accessible" in str(exc_info.value)
+        # Verify sandbox was deleted before re-raising
+        mock_delete_sandbox.assert_called_once()
+        call_args = mock_delete_sandbox.call_args
+        assert call_args[0][2] == "test-key"  # api_key
+        assert call_args[0][3] == sandbox_id  # sandbox_id
+
+    @pytest.mark.asyncio
+    @patch("automation.execution._create_and_wait")
+    @patch("automation.execution.delete_sandbox")
+    @patch("automation.execution._download_in_sandbox")
+    async def test_transient_error_returns_dispatch_result(
+        self,
+        mock_download_in_sandbox,
+        mock_delete_sandbox,
+        mock_create_and_wait,
+    ):
+        """Non-permanent errors return DispatchResult with success=False."""
+        sandbox_id = "test-sandbox-456"
+        mock_create_and_wait.return_value = (
+            sandbox_id,
+            "session-key",
+            "https://agent.example.com",
+        )
+        mock_download_in_sandbox.side_effect = RuntimeError("Connection timeout")
+        mock_delete_sandbox.return_value = None
+
+        result = await dispatch_automation(
+            api_url="https://api.example.com",
+            api_key="test-key",
+            entrypoint="python main.py",
+            tarball_source="https://example.com/file.tar.gz",
+        )
+
+        # Should return DispatchResult, not raise
+        assert isinstance(result, DispatchResult)
+        assert result.success is False
+        assert result.error is not None
+        assert "Connection timeout" in result.error
+        # Verify sandbox was still cleaned up
+        mock_delete_sandbox.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("automation.execution._create_and_wait")
+    @patch("automation.execution.delete_sandbox")
+    @patch("automation.execution._download_in_sandbox")
+    async def test_permanent_error_without_sandbox_still_raises(
+        self,
+        mock_download_in_sandbox,
+        mock_delete_sandbox,
+        mock_create_and_wait,
+    ):
+        """PermanentDispatchError is re-raised even if sandbox_id is None."""
+        # Simulate sandbox creation started but failed before getting ID
+        mock_create_and_wait.return_value = (
+            "test-sandbox",
+            "session-key",
+            "https://agent.example.com",
+        )
+        mock_download_in_sandbox.side_effect = TarballNotFoundError("404 Not Found")
+
+        with pytest.raises(TarballNotFoundError):
+            await dispatch_automation(
+                api_url="https://api.example.com",
+                api_key="test-key",
+                entrypoint="python main.py",
+                tarball_source="https://example.com/missing.tar.gz",
+            )
+
+    @pytest.mark.asyncio
+    @patch("automation.execution._create_and_wait")
+    @patch("automation.execution.delete_sandbox")
+    @patch("automation.execution._upload")
+    async def test_permanent_error_with_bytes_tarball_reraises(
+        self,
+        mock_upload,
+        mock_delete_sandbox,
+        mock_create_and_wait,
+    ):
+        """PermanentDispatchError during upload is also re-raised."""
+        sandbox_id = "test-sandbox-789"
+        mock_create_and_wait.return_value = (
+            sandbox_id,
+            "session-key",
+            "https://agent.example.com",
+        )
+        # Simulate a permanent error during upload (unlikely but possible)
+        mock_upload.side_effect = PermanentDispatchError("Upload permanently failed")
+        mock_delete_sandbox.return_value = None
+
+        with pytest.raises(PermanentDispatchError) as exc_info:
+            await dispatch_automation(
+                api_url="https://api.example.com",
+                api_key="test-key",
+                entrypoint="python main.py",
+                tarball_source=b"fake tarball bytes",
+            )
+
+        assert "permanently failed" in str(exc_info.value)
+        mock_delete_sandbox.assert_called_once()


### PR DESCRIPTION
## Summary

When an automation has a permanent configuration error (e.g., tarball URL doesn't exist), the system now automatically disables it to prevent repeated failed dispatch attempts.

Fixes #14

## Changes

### New Components

1. **`automation/exceptions.py`**: Custom exception hierarchy for permanent vs transient errors
   - `PermanentDispatchError`: Base class for errors that should disable automation
   - `TarballNotFoundError`: Raised when tarball cannot be found (internal or external)

2. **`automation/utils/run.py`**: Added `disable_automation()` function
   - Sets `enabled=False` on the automation record
   - Handles edge cases (already disabled, not found)
   - Logs the reason for disabling

### Modified Components

3. **`automation/dispatcher.py`**: 
   - `_download_internal_tarball()` now raises `TarballNotFoundError` instead of `FileNotFoundError`
   - `_execute_run()` catches `PermanentDispatchError` and calls `disable_automation()`

4. **`automation/execution.py`**: 
   - Added `_is_permanent_http_error()` helper to detect 4xx HTTP errors from curl output
   - `_download_in_sandbox()` raises `TarballNotFoundError` for 4xx HTTP errors

## Error Classification

### Permanent errors (automation is disabled):
- Internal tarball upload not found in database
- External tarball URL returns HTTP 4xx errors (404 Not Found, 403 Forbidden, 401 Unauthorized, etc.)

### Transient errors (automation remains enabled):
- HTTP 5xx server errors (e.g., 500 Internal Server Error)
- Network timeouts and connection errors
- Sandbox creation failures
- API key minting failures
- Other temporary infrastructure issues

## Testing

Added comprehensive tests in `tests/test_disable_automation.py`:
- Exception hierarchy tests
- HTTP error classification tests (`_is_permanent_http_error`)
- `disable_automation()` function tests
- Integration tests for `_execute_run()` behavior

## Behavior After Disabling

When an automation is disabled due to a permanent error:
1. The current run is marked as `FAILED` with an error detail
2. The automation's `enabled` flag is set to `False`
3. The scheduler will skip this automation until it's re-enabled
4. Users can re-enable manually after fixing the configuration (e.g., updating `tarball_path`)