### PR TITLE
fix: use engine.begin() for SQLAlchemy 2.0 migration commit

### DIFF
--- a/.github/workflows/trigger-deploy-preview.yml
+++ b/.github/workflows/trigger-deploy-preview.yml
@@ -28,7 +28,7 @@ concurrency:
 
 env:
     DEPLOY_REPO: OpenHands/deploy
-    BASE_BRANCH: automations-project
+    BASE_BRANCH: main
 
 jobs:
     trigger-deploy:

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -82,7 +82,8 @@ def run_migrations_online():
     concurrently. Other processes will wait for the lock to be released.
     """
     engine = get_engine()
-    with engine.connect() as connection:
+    # Use engine.begin() for auto-commit behavior (required in SQLAlchemy 2.0)
+    with engine.begin() as connection:
         # Acquire advisory lock - blocks until lock is available
         # This ensures only one migration runs at a time across all pods
         connection.execute(text(f"SELECT pg_advisory_lock({MIGRATION_LOCK_ID})"))


### PR DESCRIPTION
## Problem

Database migrations were running but **silently rolling back** in feature environments with fresh databases. The `automations`, `automation_runs`, and `tarball_uploads` tables were never created, causing 500 errors on all API calls.

## Root Cause

In **SQLAlchemy 2.0**, `engine.connect()` no longer auto-commits transactions. The migration code was:

```python
with engine.connect() as connection:
    connection.execute(text("SELECT pg_advisory_lock(...)"))
    try:
        context.configure(connection=connection, ...)
        with context.begin_transaction():
            context.run_migrations()  # DDL runs here
    finally:
        connection.execute(text("SELECT pg_advisory_unlock(...)"))
# Connection closes → ROLLBACK (no commit was called!)
```

The advisory lock command starts an implicit transaction. When the `with engine.connect()` block exits without an explicit `commit()`, SQLAlchemy 2.0 rolls back the entire transaction, including all the DDL from migrations.

## Solution

Use `engine.begin()` instead of `engine.connect()`. This context manager auto-commits on successful exit and rolls back on error - the correct behavior for DDL operations.

## Why Staging Worked

Staging's database already had tables from earlier deployments (before this bug was introduced or when using SQLAlchemy 1.x). Alembic saw `alembic_version` at head and did nothing, so no commit was needed.

## Testing

Verified manually in the feature environment:
- Before fix: `alembic upgrade head` runs, logs show migrations executing, but tables don't exist
- After fix: Tables are created and persist correctly

## Diagnosis Steps Taken

1. Confirmed database connection works ✓
2. Confirmed environment variables are set correctly ✓
3. Found migrations run but tables are empty after
4. Tested explicit `commit()` - tables persist ✓
5. Identified `engine.connect()` vs `engine.begin()` as the issue