### PR TITLE
Fix callback URL to include /api/automation prefix

### DIFF
--- a/automation/constants.py
+++ b/automation/constants.py
@@ -3,6 +3,12 @@
 from datetime import timedelta
 
 
+# API path prefix (added by middleware in production)
+# When the automation service runs as a sidecar, nginx routes requests through
+# /api/automation/* and strips the prefix. However, for callback URLs, the
+# sandbox SDK needs the full path including this prefix.
+API_PATH_PREFIX = "/api/automation"
+
 # Maximum allowed timeout for automation runs (10 minutes)
 # Used for:
 # - Validation in API requests (timeout field)

--- a/automation/dispatcher.py
+++ b/automation/dispatcher.py
@@ -5,7 +5,7 @@ to sandboxes via the SaaS API.  Uses FOR UPDATE SKIP LOCKED for
 multi-worker safety.
 
 Completion is handled asynchronously: the SDK running inside the sandbox
-POSTs to ``/v1/runs/{id}/complete`` when the entry-point
+POSTs to ``/api/automation/v1/runs/{id}/complete`` when the entry-point
 exits, so the dispatcher does **not** block waiting for results.
 """
 
@@ -21,7 +21,11 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
 from automation.config import Settings
-from automation.constants import MAX_RUN_DURATION, MAX_RUN_DURATION_SECONDS
+from automation.constants import (
+    API_PATH_PREFIX,
+    MAX_RUN_DURATION,
+    MAX_RUN_DURATION_SECONDS,
+)
 from automation.exceptions import PermanentDispatchError, TarballNotFoundError
 from automation.execution import dispatch_automation
 from automation.models import AutomationRun, AutomationRunStatus, TarballUpload
@@ -138,7 +142,10 @@ async def _execute_run(
             run_id=run_id, automation_id=automation_id, sandbox_id=sandbox_id
         )
 
-    callback_url = f"{settings.resolved_base_url.rstrip('/')}/v1/runs/{run_id}/complete"
+    callback_url = (
+        f"{settings.resolved_base_url.rstrip('/')}"
+        f"{API_PATH_PREFIX}/v1/runs/{run_id}/complete"
+    )
 
     try:
         # 1. Fetch a per-user API key from the SaaS service

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -537,3 +537,166 @@ class TestEffectiveTimeout:
         call_args = mock_execute.call_args
         run_arg = call_args[0][0]
         assert run_arg.automation.timeout is None
+
+
+class TestCallbackUrl:
+    """Tests for callback URL construction in dispatcher.
+
+    These tests don't require Docker since they mock all I/O and use
+    mock objects for the automation and run models.
+    """
+
+    @patch("automation.dispatcher.dispatch_automation")
+    @patch("automation.dispatcher.get_api_key_for_automation_run")
+    async def test_callback_url_includes_api_automation_prefix(
+        self, mock_get_api_key, mock_dispatch
+    ):
+        """Callback URL includes /api/automation prefix for middleware routing."""
+        from unittest.mock import MagicMock
+
+        from automation.config import Settings
+        from automation.dispatcher import _execute_run
+
+        mock_get_api_key.return_value = "test-api-key"
+        mock_dispatch.return_value = AsyncMock(success=True, sandbox_id="sb-123")
+
+        # Create mock automation and run without database
+        run_id = uuid.uuid4()
+        automation = MagicMock()
+        automation.id = uuid.uuid4()
+        automation.user_id = TEST_USER_ID
+        automation.org_id = TEST_ORG_ID
+        automation.name = "Callback URL Test"
+        automation.trigger = {"type": "cron", "schedule": "* * * * *", "timezone": "UTC"}
+        automation.tarball_path = "https://example.com/code.tar.gz"
+        automation.entrypoint = "uv run main.py"
+        automation.timeout = None
+
+        run = MagicMock()
+        run.id = run_id
+        run.automation = automation
+        run.automation_id = automation.id
+
+        settings = Settings(
+            openhands_api_base_url="https://test.example.com",
+            service_key="test-service-key",
+            base_url="http://localhost:8000",
+        )
+
+        # Mock session factory (not actually used with HTTP tarball)
+        mock_session_factory = MagicMock()
+
+        await _execute_run(run, settings, mock_session_factory)
+
+        # Verify dispatch_automation was called with correct callback_url
+        mock_dispatch.assert_called_once()
+        call_kwargs = mock_dispatch.call_args.kwargs
+        callback_url = call_kwargs["callback_url"]
+
+        # The callback URL should include /api/automation prefix
+        expected_url = (
+            f"http://localhost:8000/api/automation/v1/runs/{run_id}/complete"
+        )
+        assert callback_url == expected_url
+
+    @patch("automation.dispatcher.dispatch_automation")
+    @patch("automation.dispatcher.get_api_key_for_automation_run")
+    async def test_callback_url_with_custom_base_url(
+        self, mock_get_api_key, mock_dispatch
+    ):
+        """Callback URL uses custom base_url when configured."""
+        from unittest.mock import MagicMock
+
+        from automation.config import Settings
+        from automation.dispatcher import _execute_run
+
+        mock_get_api_key.return_value = "test-api-key"
+        mock_dispatch.return_value = AsyncMock(success=True, sandbox_id="sb-456")
+
+        run_id = uuid.uuid4()
+        automation = MagicMock()
+        automation.id = uuid.uuid4()
+        automation.user_id = TEST_USER_ID
+        automation.org_id = TEST_ORG_ID
+        automation.name = "Custom Base URL Test"
+        automation.trigger = {"type": "cron", "schedule": "* * * * *", "timezone": "UTC"}
+        automation.tarball_path = "https://example.com/code.tar.gz"
+        automation.entrypoint = "uv run main.py"
+        automation.timeout = None
+
+        run = MagicMock()
+        run.id = run_id
+        run.automation = automation
+        run.automation_id = automation.id
+
+        custom_settings = Settings(
+            openhands_api_base_url="https://test.example.com",
+            service_key="test-service-key",
+            base_url="https://automation.all-hands.dev",
+        )
+
+        mock_session_factory = MagicMock()
+
+        await _execute_run(run, custom_settings, mock_session_factory)
+
+        # Verify callback URL uses the custom base_url
+        mock_dispatch.assert_called_once()
+        call_kwargs = mock_dispatch.call_args.kwargs
+        callback_url = call_kwargs["callback_url"]
+
+        expected_url = (
+            f"https://automation.all-hands.dev/api/automation/v1/runs/{run_id}/complete"
+        )
+        assert callback_url == expected_url
+
+    @patch("automation.dispatcher.dispatch_automation")
+    @patch("automation.dispatcher.get_api_key_for_automation_run")
+    async def test_callback_url_strips_trailing_slash(
+        self, mock_get_api_key, mock_dispatch
+    ):
+        """Callback URL strips trailing slash from base_url."""
+        from unittest.mock import MagicMock
+
+        from automation.config import Settings
+        from automation.dispatcher import _execute_run
+
+        mock_get_api_key.return_value = "test-api-key"
+        mock_dispatch.return_value = AsyncMock(success=True, sandbox_id="sb-789")
+
+        run_id = uuid.uuid4()
+        automation = MagicMock()
+        automation.id = uuid.uuid4()
+        automation.user_id = TEST_USER_ID
+        automation.org_id = TEST_ORG_ID
+        automation.name = "Trailing Slash Test"
+        automation.trigger = {"type": "cron", "schedule": "* * * * *", "timezone": "UTC"}
+        automation.tarball_path = "https://example.com/code.tar.gz"
+        automation.entrypoint = "uv run main.py"
+        automation.timeout = None
+
+        run = MagicMock()
+        run.id = run_id
+        run.automation = automation
+        run.automation_id = automation.id
+
+        # Settings with trailing slash in base_url
+        settings_with_slash = Settings(
+            openhands_api_base_url="https://test.example.com",
+            service_key="test-service-key",
+            base_url="https://automation.all-hands.dev/",  # trailing slash
+        )
+
+        mock_session_factory = MagicMock()
+
+        await _execute_run(run, settings_with_slash, mock_session_factory)
+
+        mock_dispatch.assert_called_once()
+        call_kwargs = mock_dispatch.call_args.kwargs
+        callback_url = call_kwargs["callback_url"]
+
+        # Should NOT have double slashes
+        assert "//" not in callback_url.replace("https://", "")
+        expected_url = (
+            f"https://automation.all-hands.dev/api/automation/v1/runs/{run_id}/complete"
+        )
+        assert callback_url == expected_url

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -567,7 +567,11 @@ class TestCallbackUrl:
         automation.user_id = TEST_USER_ID
         automation.org_id = TEST_ORG_ID
         automation.name = "Callback URL Test"
-        automation.trigger = {"type": "cron", "schedule": "* * * * *", "timezone": "UTC"}
+        automation.trigger = {
+            "type": "cron",
+            "schedule": "* * * * *",
+            "timezone": "UTC",
+        }
         automation.tarball_path = "https://example.com/code.tar.gz"
         automation.entrypoint = "uv run main.py"
         automation.timeout = None
@@ -594,9 +598,7 @@ class TestCallbackUrl:
         callback_url = call_kwargs["callback_url"]
 
         # The callback URL should include /api/automation prefix
-        expected_url = (
-            f"http://localhost:8000/api/automation/v1/runs/{run_id}/complete"
-        )
+        expected_url = f"http://localhost:8000/api/automation/v1/runs/{run_id}/complete"
         assert callback_url == expected_url
 
     @patch("automation.dispatcher.dispatch_automation")
@@ -619,7 +621,11 @@ class TestCallbackUrl:
         automation.user_id = TEST_USER_ID
         automation.org_id = TEST_ORG_ID
         automation.name = "Custom Base URL Test"
-        automation.trigger = {"type": "cron", "schedule": "* * * * *", "timezone": "UTC"}
+        automation.trigger = {
+            "type": "cron",
+            "schedule": "* * * * *",
+            "timezone": "UTC",
+        }
         automation.tarball_path = "https://example.com/code.tar.gz"
         automation.entrypoint = "uv run main.py"
         automation.timeout = None
@@ -669,7 +675,11 @@ class TestCallbackUrl:
         automation.user_id = TEST_USER_ID
         automation.org_id = TEST_ORG_ID
         automation.name = "Trailing Slash Test"
-        automation.trigger = {"type": "cron", "schedule": "* * * * *", "timezone": "UTC"}
+        automation.trigger = {
+            "type": "cron",
+            "schedule": "* * * * *",
+            "timezone": "UTC",
+        }
         automation.tarball_path = "https://example.com/code.tar.gz"
         automation.entrypoint = "uv run main.py"
         automation.timeout = None


### PR DESCRIPTION
## Problem

Completion callbacks from SDK running inside sandboxes were not being registered properly. The callback URL passed when dispatching automation runs was missing the `/api/automation` prefix that's added by nginx middleware in production.

**Before:**
```
{base_url}/v1/runs/{run_id}/complete
```

**After:**
```
{base_url}/api/automation/v1/runs/{run_id}/complete
```

Without this prefix, the SDK's POST to the completion endpoint would fail to reach the automation service's router, causing:
- Completion callbacks to fail
- Runs to remain in RUNNING status until the watchdog eventually marks them as failed

## Changes

### `automation/constants.py`
- Added `API_PATH_PREFIX = "/api/automation"` constant with documentation explaining its purpose

### `automation/dispatcher.py`
- Updated callback URL construction to include the `/api/automation` prefix
- Updated module docstring to reflect the correct endpoint path
- Imported the new `API_PATH_PREFIX` constant

### `tests/test_dispatcher.py`
Added `TestCallbackUrl` class with 3 unit tests:
- `test_callback_url_includes_api_automation_prefix` - Verifies the prefix is included
- `test_callback_url_with_custom_base_url` - Verifies custom base URL is used correctly  
- `test_callback_url_strips_trailing_slash` - Verifies no double slashes when base_url has trailing slash

## Testing

All new tests pass:
```bash
uv run pytest tests/test_dispatcher.py::TestCallbackUrl -v
# 3 passed
```

Tests are designed to run without Docker by mocking external dependencies.