### PR TITLE
Add OpenHands stop hook for pre-commit checks

### DIFF
--- a/.openhands/hooks.json
+++ b/.openhands/hooks.json
@@ -1,0 +1,14 @@
+{
+  "stop": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".openhands/hooks/on_stop.sh",
+          "timeout": 300
+        }
+      ]
+    }
+  ]
+}

--- a/.openhands/hooks/on_stop.sh
+++ b/.openhands/hooks/on_stop.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Stop hook: runs pre-commit before allowing agent to finish
+#
+# This hook runs when the agent attempts to stop/finish.
+# It can BLOCK the stop by:
+#   - Exiting with code 2 (blocked)
+#   - Outputting JSON: {"decision": "deny", "additionalContext": "feedback message"}
+#
+# Environment variables available:
+#   OPENHANDS_PROJECT_DIR - Project directory
+#   OPENHANDS_SESSION_ID - Session ID
+#   GITHUB_TOKEN - GitHub API token (if available)
+
+set -o pipefail
+
+PROJECT_DIR="${OPENHANDS_PROJECT_DIR:-$(pwd)}"
+cd "$PROJECT_DIR" || exit 1
+
+# Collect all issues to report back to the agent
+ISSUES=""
+BLOCK_STOP=false
+
+log_issue() {
+    ISSUES="${ISSUES}${1}\n"
+    BLOCK_STOP=true
+}
+
+>&2 echo "=== Stop Hook ==="
+>&2 echo "Project directory: $PROJECT_DIR"
+>&2 echo ""
+
+# --------------------------
+# Step 1: Run pre-commit on all files
+# --------------------------
+>&2 echo "=== Running pre-commit run --all-files ==="
+if command -v uv &> /dev/null; then
+    PRECOMMIT_OUTPUT=$(uv run pre-commit run --all-files 2>&1)
+    PRECOMMIT_EXIT=$?
+else
+    PRECOMMIT_OUTPUT=$(pre-commit run --all-files 2>&1)
+    PRECOMMIT_EXIT=$?
+fi
+
+>&2 echo "$PRECOMMIT_OUTPUT"
+
+if [ $PRECOMMIT_EXIT -ne 0 ]; then
+    >&2 echo "⚠️  pre-commit found issues (exit code: $PRECOMMIT_EXIT)"
+    log_issue "## Pre-commit Failed\n\nPre-commit checks failed. Please fix the following issues:\n\n\`\`\`\n${PRECOMMIT_OUTPUT}\n\`\`\`"
+else
+    >&2 echo "✓ pre-commit passed"
+fi
+>&2 echo ""
+
+# --------------------------
+# Final decision
+# --------------------------
+if [ "$BLOCK_STOP" = true ]; then
+    >&2 echo "=== BLOCKING STOP: Issues found ==="
+    # Output JSON to provide feedback to the agent
+    # Escape the issues for JSON
+    ESCAPED_ISSUES=$(echo -e "$ISSUES" | jq -Rs .)
+    echo "{\"decision\": \"deny\", \"reason\": \"Pre-commit checks failed\", \"additionalContext\": $ESCAPED_ISSUES}"
+    exit 2
+fi
+
+>&2 echo "=== All checks passed, allowing stop ==="
+echo '{"decision": "allow"}'
+exit 0


### PR DESCRIPTION
## Summary

Adds an OpenHands stop hook that runs pre-commit checks before allowing the agent to finish. This ensures code quality by blocking agent completion when pre-commit checks fail.

## Changes

- **`.openhands/hooks.json`** - Hook configuration that registers the `on_stop.sh` hook to run when the agent attempts to stop/finish
- **`.openhands/hooks/on_stop.sh`** - Shell script that:
  - Runs `uv run pre-commit run --all-files`
  - Blocks stop (exit code 2) if pre-commit fails
  - Returns detailed error output as JSON for the agent to act on
  - Allows stop if all checks pass

## How it works

When an agent tries to finish its task, the hook intercepts the stop action and:

1. Runs `pre-commit run --all-files` using `uv` (falls back to direct `pre-commit` if uv unavailable)
2. If pre-commit passes → returns `{"decision": "allow"}` and allows the agent to complete
3. If pre-commit fails → returns `{"decision": "deny", "additionalContext": "<error details>"}` with exit code 2, blocking the agent and providing feedback

## Future enhancements

This is the first of potentially more hooks. Additional capabilities we may add later (inspired by the SDK repo):
- Smart test execution based on changed files
- CI status monitoring before completion