### PR TITLE
feat: add sandbox automation metadata utility

### DIFF
--- a/automation/dispatcher.py
+++ b/automation/dispatcher.py
@@ -32,6 +32,7 @@ from automation.utils.run import (
     mark_run_terminal,
     update_sandbox_id,
 )
+from automation.utils.sandbox_metadata import set_sandbox_automation_metadata
 from automation.utils.tarball_validation import is_http_url, parse_internal_upload_id
 
 
@@ -202,6 +203,20 @@ async def _execute_run(
             # Store sandbox_id for later verification by the watchdog
             if result.sandbox_id:
                 await update_sandbox_id(session_factory, run.id, result.sandbox_id)
+
+                # Set automation metadata on the sandbox so conversations inherit it
+                await set_sandbox_automation_metadata(
+                    api_url=settings.openhands_api_base_url,
+                    service_key=settings.service_key,
+                    sandbox_id=result.sandbox_id,
+                    automation_id=str(automation.id),
+                    automation_name=automation.name,
+                    trigger_type=json.dumps(automation.trigger)
+                    if automation.trigger
+                    else None,
+                    run_id=run_id,
+                )
+
             logger.info(
                 "Automation dispatched successfully, waiting for callback",
                 extra=sandbox_extra,

--- a/automation/utils/__init__.py
+++ b/automation/utils/__init__.py
@@ -6,6 +6,7 @@ from automation.utils.cron import (
     get_prev_fire_time,
     is_automation_due,
 )
+from automation.utils.sandbox_metadata import set_sandbox_automation_metadata
 from automation.utils.time import utcnow
 
 
@@ -15,5 +16,6 @@ __all__ = [
     "get_next_fire_time",
     "get_prev_fire_time",
     "is_automation_due",
+    "set_sandbox_automation_metadata",
     "utcnow",
 ]

--- a/automation/utils/sandbox_metadata.py
+++ b/automation/utils/sandbox_metadata.py
@@ -1,0 +1,93 @@
+"""Utility for setting sandbox automation metadata via the service API.
+
+This module provides functions to associate automation metadata with sandboxes
+in OH Cloud, allowing conversations created within those sandboxes to inherit
+the automation context (trigger type, automation ID, etc.).
+"""
+
+import logging
+from typing import Any
+
+import httpx
+
+
+logger = logging.getLogger("automation.utils.sandbox_metadata")
+
+
+async def set_sandbox_automation_metadata(
+    api_url: str,
+    service_key: str,
+    sandbox_id: str,
+    automation_id: str | None = None,
+    automation_name: str | None = None,
+    trigger_type: str | None = None,
+    run_id: str | None = None,
+    extra_metadata: dict[str, Any] | None = None,
+) -> bool:
+    """Set automation metadata on a sandbox via the service API.
+
+    This allows OH Cloud to associate conversations created in the sandbox
+    with the automation that triggered them. The metadata is stored in the
+    sandbox_automation_metadata table and copied to conversations via webhooks.
+
+    This is a best-effort operation - failures are logged but do not fail the dispatch.
+
+    Args:
+        api_url: The OpenHands API base URL
+        service_key: The service API key for authentication (AUTOMATIONS_SERVICE_KEY)
+        sandbox_id: The sandbox ID to set metadata on
+        automation_id: The automation definition ID
+        automation_name: Human-readable name of the automation
+        trigger_type: The trigger configuration (JSON string or type name)
+        run_id: The specific automation run ID
+        extra_metadata: Additional metadata as key-value pairs
+
+    Returns:
+        True if metadata was set successfully, False otherwise
+    """
+    if not service_key:
+        logger.debug("No service key configured, skipping sandbox metadata")
+        return False
+
+    url = f"{api_url.rstrip('/')}/api/service/sandboxes/{sandbox_id}/automation-metadata"
+    headers = {
+        "X-Service-API-Key": service_key,
+        "Content-Type": "application/json",
+    }
+    payload: dict[str, Any] = {
+        "automation_id": automation_id,
+        "automation_name": automation_name,
+        "trigger_type": trigger_type,
+        "run_id": run_id,
+    }
+    if extra_metadata:
+        payload["extra_metadata"] = extra_metadata
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.put(url, headers=headers, json=payload)
+            response.raise_for_status()
+            logger.info(
+                "Set sandbox automation metadata",
+                extra={
+                    "sandbox_id": sandbox_id,
+                    "automation_id": automation_id,
+                    "run_id": run_id,
+                },
+            )
+            return True
+    except httpx.HTTPStatusError as e:
+        logger.warning(
+            "Failed to set sandbox automation metadata: HTTP %s - %s",
+            e.response.status_code,
+            e.response.text,
+            extra={"sandbox_id": sandbox_id, "automation_id": automation_id},
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to set sandbox automation metadata: %s",
+            str(e),
+            extra={"sandbox_id": sandbox_id, "automation_id": automation_id},
+        )
+
+    return False

--- a/tests/test_sandbox_metadata.py
+++ b/tests/test_sandbox_metadata.py
@@ -1,0 +1,198 @@
+"""Tests for the sandbox_metadata utility module."""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+import httpx
+
+from automation.utils.sandbox_metadata import set_sandbox_automation_metadata
+
+
+class TestSetSandboxAutomationMetadata:
+    """Tests for set_sandbox_automation_metadata function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_service_key(self):
+        """Should return False and skip API call when service_key is empty."""
+        result = await set_sandbox_automation_metadata(
+            api_url="https://test.example.com",
+            service_key="",
+            sandbox_id="sandbox-123",
+            automation_id="auto-456",
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_service_key_is_none(self):
+        """Should return False and skip API call when service_key is None."""
+        result = await set_sandbox_automation_metadata(
+            api_url="https://test.example.com",
+            service_key=None,  # type: ignore
+            sandbox_id="sandbox-123",
+            automation_id="auto-456",
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_successful_api_call_returns_true(self):
+        """Should return True when API call succeeds."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.put = AsyncMock(return_value=mock_response)
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            result = await set_sandbox_automation_metadata(
+                api_url="https://test.example.com",
+                service_key="test-service-key",
+                sandbox_id="sandbox-123",
+                automation_id="auto-456",
+                automation_name="Test Automation",
+                trigger_type="cron",
+                run_id="run-789",
+            )
+
+            assert result is True
+            mock_client.put.assert_called_once()
+            call_args = mock_client.put.call_args
+            assert call_args[0][0] == "https://test.example.com/api/service/sandboxes/sandbox-123/automation-metadata"
+            assert call_args[1]["headers"]["X-Service-API-Key"] == "test-service-key"
+            assert call_args[1]["json"]["automation_id"] == "auto-456"
+            assert call_args[1]["json"]["automation_name"] == "Test Automation"
+            assert call_args[1]["json"]["trigger_type"] == "cron"
+            assert call_args[1]["json"]["run_id"] == "run-789"
+
+    @pytest.mark.asyncio
+    async def test_api_url_trailing_slash_is_stripped(self):
+        """Should strip trailing slash from api_url."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.put = AsyncMock(return_value=mock_response)
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            await set_sandbox_automation_metadata(
+                api_url="https://test.example.com/",  # Note trailing slash
+                service_key="test-key",
+                sandbox_id="sandbox-123",
+            )
+
+            call_args = mock_client.put.call_args
+            # Should not have double slash
+            assert "//" not in call_args[0][0].replace("https://", "")
+
+    @pytest.mark.asyncio
+    async def test_http_error_returns_false(self):
+        """Should return False and log warning on HTTP error."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        mock_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "Server Error",
+                request=MagicMock(),
+                response=mock_response,
+            )
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.put = AsyncMock(return_value=mock_response)
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            result = await set_sandbox_automation_metadata(
+                api_url="https://test.example.com",
+                service_key="test-key",
+                sandbox_id="sandbox-123",
+            )
+
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_connection_error_returns_false(self):
+        """Should return False and log warning on connection error."""
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.put = AsyncMock(
+                side_effect=httpx.ConnectError("Connection refused")
+            )
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            result = await set_sandbox_automation_metadata(
+                api_url="https://test.example.com",
+                service_key="test-key",
+                sandbox_id="sandbox-123",
+            )
+
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_timeout_error_returns_false(self):
+        """Should return False and log warning on timeout."""
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.put = AsyncMock(
+                side_effect=httpx.TimeoutException("Request timed out")
+            )
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            result = await set_sandbox_automation_metadata(
+                api_url="https://test.example.com",
+                service_key="test-key",
+                sandbox_id="sandbox-123",
+            )
+
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_extra_metadata_is_included_in_payload(self):
+        """Should include extra_metadata in the request payload."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.put = AsyncMock(return_value=mock_response)
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            extra = {"custom_key": "custom_value", "number": 42}
+            await set_sandbox_automation_metadata(
+                api_url="https://test.example.com",
+                service_key="test-key",
+                sandbox_id="sandbox-123",
+                extra_metadata=extra,
+            )
+
+            call_args = mock_client.put.call_args
+            assert call_args[1]["json"]["extra_metadata"] == extra
+
+    @pytest.mark.asyncio
+    async def test_none_values_are_passed_to_api(self):
+        """Should pass None values to API (they are valid)."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.put = AsyncMock(return_value=mock_response)
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            await set_sandbox_automation_metadata(
+                api_url="https://test.example.com",
+                service_key="test-key",
+                sandbox_id="sandbox-123",
+                # All optional params are None by default
+            )
+
+            call_args = mock_client.put.call_args
+            json_payload = call_args[1]["json"]
+            assert json_payload["automation_id"] is None
+            assert json_payload["automation_name"] is None
+            assert json_payload["trigger_type"] is None
+            assert json_payload["run_id"] is None
+            # extra_metadata should not be in payload when None
+            assert "extra_metadata" not in json_payload


### PR DESCRIPTION
## Summary

Add utility function to set automation metadata on sandboxes via the OH Cloud service API. This allows OH Cloud to associate conversations created in automation-triggered sandboxes with the automation context (trigger type, automation ID, run ID, etc.).

## Changes

### New Files
- `automation/utils/sandbox_metadata.py` - Contains `set_sandbox_automation_metadata()` async function

### Modified Files
- `automation/utils/__init__.py` - Export the new utility
- `automation/dispatcher.py` - Call `set_sandbox_automation_metadata()` after sandbox creation

## How It Works

1. After the dispatcher creates a sandbox and gets the sandbox_id
2. It calls `set_sandbox_automation_metadata()` with:
   - `automation_id` - The automation definition ID
   - `automation_name` - Human-readable name
   - `trigger_type` - JSON-serialized trigger config
   - `run_id` - The specific run ID
3. This POSTs to `PUT /api/service/sandboxes/{id}/automation-metadata` on OH Cloud
4. Authentication uses `X-Service-API-Key` header with `AUTOMATIONS_SERVICE_KEY`

## Related PR

This PR requires a corresponding change in OpenHands/OpenHands to add the service endpoint and storage.

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a64ee22a-60c6-4216-af2c-3c4319c3ac87)