### PR TITLE
fix: remove nested transaction in alembic migrations

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -83,14 +83,16 @@ def run_migrations_online():
     """
     engine = get_engine()
     # Use engine.begin() for auto-commit behavior (required in SQLAlchemy 2.0)
+    # Note: Do NOT use context.begin_transaction() here - engine.begin() already
+    # provides transaction management. Nesting transactions causes issues where
+    # only the first migration gets committed.
     with engine.begin() as connection:
         # Acquire advisory lock - blocks until lock is available
         # This ensures only one migration runs at a time across all pods
         connection.execute(text(f"SELECT pg_advisory_lock({MIGRATION_LOCK_ID})"))
         try:
             context.configure(connection=connection, target_metadata=target_metadata)
-            with context.begin_transaction():
-                context.run_migrations()
+            context.run_migrations()
         finally:
             # Release the lock so other waiting processes can proceed
             connection.execute(text(f"SELECT pg_advisory_unlock({MIGRATION_LOCK_ID})"))


### PR DESCRIPTION
## Problem

On fresh deployments, only the first migration (001) was being applied while subsequent migrations (002) were silently skipped. This caused the `tarball_uploads` table to not exist, resulting in 500 errors:

```
asyncpg.exceptions.UndefinedTableError: relation "tarball_uploads" does not exist
```

## Root Cause

The `migrations/env.py` had nested transaction handling:

```python
with engine.begin() as connection:  # Transaction 1: auto-commits on block exit
    ...
    with context.begin_transaction():  # Transaction 2: nested/savepoint
        context.run_migrations()
```

With `engine.begin()`, SQLAlchemy 2.0 already provides transaction management with auto-commit on successful exit. The nested `context.begin_transaction()` created a savepoint that interfered with multi-migration runs, causing only the first migration to be committed.

## Fix

Remove the nested `context.begin_transaction()` call since `engine.begin()` already handles the transaction lifecycle.

## Testing

After this fix, running `alembic upgrade head` on a fresh database should apply all migrations (001 and 002) in a single run.

## Production Remediation

After merging and deploying this fix, the automation pods will need to be restarted to re-run migrations and create the missing `tarball_uploads` table.
