### PR TITLE
fix: Configure root_path for Swagger UI when mounted at /api/automation

### DIFF
--- a/automation/app.py
+++ b/automation/app.py
@@ -134,10 +134,8 @@ def _build_cors_origins() -> list[str]:
 def _create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
     settings = get_settings()
-    # When mounted at /api/automation/, Swagger UI needs root_path to find
-    # the OpenAPI spec. Without this, /docs loads /openapi.json (main app's
-    # spec) instead of /api/automation/openapi.json (this service's spec).
-    # Set AUTOMATION_ROOT_PATH="/api/automation" in production.
+    # root_path is derived from AUTOMATION_BASE_URL path component.
+    # e.g., https://app.all-hands.dev/api/automation -> /api/automation
     return FastAPI(
         title="OpenHands Automations Service",
         description=(

--- a/automation/app.py
+++ b/automation/app.py
@@ -131,12 +131,23 @@ def _build_cors_origins() -> list[str]:
     return origins
 
 
-app = FastAPI(
-    title="OpenHands Automations Service",
-    description="Scheduled and event-driven automation execution for OpenHands Cloud",
-    version="0.1.0",
-    lifespan=lifespan,
-)
+def _create_app() -> FastAPI:
+    """Create and configure the FastAPI application."""
+    settings = get_settings()
+    # When mounted at /api/automation/, Swagger UI needs root_path to find
+    # the OpenAPI spec. Without this, /docs loads /openapi.json (main app's
+    # spec) instead of /api/automation/openapi.json (this service's spec).
+    # Set AUTOMATION_ROOT_PATH="/api/automation" in production.
+    return FastAPI(
+        title="OpenHands Automations Service",
+        description="Scheduled automation execution for OpenHands Cloud",
+        version="0.1.0",
+        lifespan=lifespan,
+        root_path=settings.root_path if settings.root_path else "",
+    )
+
+
+app = _create_app()
 
 app.add_middleware(
     CORSMiddleware,

--- a/automation/app.py
+++ b/automation/app.py
@@ -140,10 +140,12 @@ def _create_app() -> FastAPI:
     # Set AUTOMATION_ROOT_PATH="/api/automation" in production.
     return FastAPI(
         title="OpenHands Automations Service",
-        description="Scheduled automation execution for OpenHands Cloud",
+        description=(
+            "Scheduled and event-driven automation execution for OpenHands Cloud"
+        ),
         version="0.1.0",
         lifespan=lifespan,
-        root_path=settings.root_path if settings.root_path else "",
+        root_path=settings.root_path,
     )
 
 

--- a/automation/config.py
+++ b/automation/config.py
@@ -1,6 +1,7 @@
 """Application configuration loaded from environment variables."""
 
 from functools import lru_cache
+from urllib.parse import urlparse
 
 from pydantic_settings import BaseSettings
 
@@ -53,17 +54,24 @@ class Settings(BaseSettings):
     # CORS origins (comma-separated list, defaults to openhands_api_base_url)
     cors_origins: str = ""
 
-    # Root path for the API (used by Swagger UI to find the OpenAPI spec).
-    # In production, this is set to "/api/automation" when mounted behind a proxy.
-    # Leave empty for standalone development (defaults to "/").
-    root_path: str = ""
-
     model_config = {"env_prefix": "AUTOMATION_"}
 
     @property
     def resolved_base_url(self) -> str:
         """Public base URL with localhost fallback for dev."""
         return self.base_url or f"http://localhost:{self.server_port}"
+
+    @property
+    def root_path(self) -> str:
+        """Root path for Swagger UI, derived from base_url.
+
+        When base_url is set (e.g., https://app.all-hands.dev/api/automation),
+        extracts the path component (/api/automation) for FastAPI's root_path.
+        This allows Swagger UI to correctly resolve the OpenAPI spec URL.
+        """
+        if self.base_url:
+            return urlparse(self.base_url).path.rstrip("/")
+        return ""
 
 
 # Hardcoded internal URL scheme for uploaded tarballs.

--- a/automation/config.py
+++ b/automation/config.py
@@ -53,6 +53,11 @@ class Settings(BaseSettings):
     # CORS origins (comma-separated list, defaults to openhands_api_base_url)
     cors_origins: str = ""
 
+    # Root path for the API (used by Swagger UI to find the OpenAPI spec).
+    # In production, this is set to "/api/automation" when mounted behind a proxy.
+    # Leave empty for standalone development (defaults to "/").
+    root_path: str = ""
+
     model_config = {"env_prefix": "AUTOMATION_"}
 
     @property

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,37 @@
+"""Tests for configuration module."""
+
+from automation.config import Settings
+
+
+class TestRootPathExtraction:
+    """Verify root_path is correctly extracted from base_url."""
+
+    def test_root_path_with_path_component(self):
+        """Extract path from full URL."""
+        settings = Settings(base_url="https://app.all-hands.dev/api/automation")
+        assert settings.root_path == "/api/automation"
+
+    def test_root_path_with_trailing_slash(self):
+        """Trailing slash should be stripped."""
+        settings = Settings(base_url="https://app.all-hands.dev/api/automation/")
+        assert settings.root_path == "/api/automation"
+
+    def test_root_path_without_path(self):
+        """URL at root should return empty string."""
+        settings = Settings(base_url="https://app.all-hands.dev")
+        assert settings.root_path == ""
+
+    def test_root_path_with_only_slash(self):
+        """URL with only root path should return empty string."""
+        settings = Settings(base_url="https://app.all-hands.dev/")
+        assert settings.root_path == ""
+
+    def test_root_path_empty_base_url(self):
+        """Empty base_url should return empty string."""
+        settings = Settings(base_url="")
+        assert settings.root_path == ""
+
+    def test_root_path_default_base_url(self):
+        """Default settings (no base_url) should return empty root_path."""
+        settings = Settings()
+        assert settings.root_path == ""


### PR DESCRIPTION
## Summary

Fixes #29

When the automation service is mounted at `/api/automation/` path, Swagger UI incorrectly loads the main OpenHands API spec (`/openapi.json`) instead of the automation service's spec (`/api/automation/openapi.json`).

## Solution

Instead of adding a new environment variable, this PR derives `root_path` from the **existing** `AUTOMATION_BASE_URL` setting:

- When `base_url` is `https://app.all-hands.dev/api/automation`
- The service extracts `/api/automation` as the `root_path`
- FastAPI uses this to correctly resolve Swagger UI's OpenAPI spec URL

## Changes

1. **`config.py`**: Added `root_path` computed property that extracts the path from `base_url`
2. **`app.py`**: Wrapped app creation in `_create_app()` to access settings, passes `root_path` to FastAPI

## No Deployment Changes Required

The existing `automationBaseUrl` Helm value (which sets `AUTOMATION_BASE_URL`) already contains the path information needed. No changes to the OpenHands-Cloud chart or deploy repo values are required.

## Testing

```python
# Local dev (no base_url) - root_path is empty
>>> Settings().root_path
''

# Production (base_url set) - root_path extracted from path
>>> os.environ['AUTOMATION_BASE_URL'] = 'https://app.all-hands.dev/api/automation'
>>> Settings().root_path
'/api/automation'
```

- ✅ Unit tests pass
- ✅ Pre-commit checks pass (ruff format, ruff lint, pycodestyle, pyright)

---
*This PR was created by an AI assistant (OpenHands) on behalf of jpshackelford.*