### PR TITLE
feat: serve app under /api/automation base path

### DIFF
--- a/automation/app.py
+++ b/automation/app.py
@@ -134,10 +134,7 @@ def _build_cors_origins() -> list[str]:
 
 def _create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
-    settings = get_settings()
-    base_path = settings.base_path
-
-    application = FastAPI(
+    return FastAPI(
         title="OpenHands Automations Service",
         description=(
             "Scheduled and event-driven automation execution for OpenHands Cloud"
@@ -146,43 +143,45 @@ def _create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
-    application.add_middleware(
-        CORSMiddleware,
-        allow_origins=_build_cors_origins(),
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
-
-    # Include uploads_router and preset_router BEFORE router to avoid route conflict.
-    # The main router has /v1/{automation_id} which would match /v1/uploads
-    # or /v1/preset/prompt and fail UUID validation if included first.
-    application.include_router(uploads_router, prefix=base_path)
-    application.include_router(preset_router, prefix=base_path)
-    application.include_router(router, prefix=base_path)
-
-    @application.get(f"{base_path}/health")
-    async def health():
-        return {"status": "ok"}
-
-    @application.get(f"{base_path}/ready")
-    async def readiness():
-        """Readiness probe — checks DB connectivity.
-
-        Returns 503 when the DB is unreachable so Kubernetes stops routing traffic.
-        """
-        try:
-            async with application.state.engine.connect() as conn:
-                await conn.execute(text("SELECT 1"))
-            return {"status": "ready"}
-        except Exception as e:
-            logger.error("Readiness check failed: %s", e, exc_info=True)
-            return JSONResponse(
-                status_code=503,
-                content={"status": "not_ready", "error": "database unavailable"},
-            )
-
-    return application
-
 
 app = _create_app()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_build_cors_origins(),
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+_base_path = get_settings().base_path
+
+# Include uploads_router and preset_router BEFORE router to avoid route conflict.
+# The main router has /v1/{automation_id} which would match /v1/uploads
+# or /v1/preset/prompt and fail UUID validation if included first.
+app.include_router(uploads_router, prefix=_base_path)
+app.include_router(preset_router, prefix=_base_path)
+app.include_router(router, prefix=_base_path)
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@app.get("/ready")
+async def readiness():
+    """Readiness probe — checks DB connectivity.
+
+    Returns 503 when the DB is unreachable so Kubernetes stops routing traffic.
+    """
+    try:
+        async with app.state.engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+        return {"status": "ready"}
+    except Exception as e:
+        logger.error("Readiness check failed: %s", e, exc_info=True)
+        return JSONResponse(
+            status_code=503,
+            content={"status": "not_ready", "error": "database unavailable"},
+        )

--- a/automation/app.py
+++ b/automation/app.py
@@ -164,12 +164,17 @@ app.include_router(preset_router, prefix=_base_path)
 app.include_router(router, prefix=_base_path)
 
 
+# Static /health and /ready paths are a convenience for k8s probes — the fixed
+# path requires less templating.  Base-path endpoints are still available for
+# publicly-routed traffic like integration tests.
 @app.get("/health")
+@app.get(f"{_base_path}/health")
 async def health():
     return {"status": "ok"}
 
 
 @app.get("/ready")
+@app.get(f"{_base_path}/ready")
 async def readiness():
     """Readiness probe — checks DB connectivity.
 

--- a/automation/app.py
+++ b/automation/app.py
@@ -132,12 +132,12 @@ def _build_cors_origins() -> list[str]:
     return origins
 
 
-BASE_PATH = "/api/automation"
-
-
 def _create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
-    return FastAPI(
+    settings = get_settings()
+    base_path = settings.base_path
+
+    application = FastAPI(
         title="OpenHands Automations Service",
         description=(
             "Scheduled and event-driven automation execution for OpenHands Cloud"
@@ -146,43 +146,43 @@ def _create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
+    application.add_middleware(
+        CORSMiddleware,
+        allow_origins=_build_cors_origins(),
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    # Include uploads_router and preset_router BEFORE router to avoid route conflict.
+    # The main router has /v1/{automation_id} which would match /v1/uploads
+    # or /v1/preset/prompt and fail UUID validation if included first.
+    application.include_router(uploads_router, prefix=base_path)
+    application.include_router(preset_router, prefix=base_path)
+    application.include_router(router, prefix=base_path)
+
+    @application.get(f"{base_path}/health")
+    async def health():
+        return {"status": "ok"}
+
+    @application.get(f"{base_path}/ready")
+    async def readiness():
+        """Readiness probe — checks DB connectivity.
+
+        Returns 503 when the DB is unreachable so Kubernetes stops routing traffic.
+        """
+        try:
+            async with application.state.engine.connect() as conn:
+                await conn.execute(text("SELECT 1"))
+            return {"status": "ready"}
+        except Exception as e:
+            logger.error("Readiness check failed: %s", e, exc_info=True)
+            return JSONResponse(
+                status_code=503,
+                content={"status": "not_ready", "error": "database unavailable"},
+            )
+
+    return application
+
 
 app = _create_app()
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=_build_cors_origins(),
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
-# Include uploads_router and preset_router BEFORE router to avoid route conflict.
-# The main router has /v1/{automation_id} which would match /v1/uploads
-# or /v1/preset/prompt and fail UUID validation if included first.
-app.include_router(uploads_router, prefix=BASE_PATH)
-app.include_router(preset_router, prefix=BASE_PATH)
-app.include_router(router, prefix=BASE_PATH)
-
-
-@app.get(f"{BASE_PATH}/health")
-async def health():
-    return {"status": "ok"}
-
-
-@app.get(f"{BASE_PATH}/ready")
-async def readiness():
-    """Readiness probe — checks DB connectivity.
-
-    Returns 503 when the DB is unreachable so Kubernetes stops routing traffic.
-    """
-    try:
-        async with app.state.engine.connect() as conn:
-            await conn.execute(text("SELECT 1"))
-        return {"status": "ready"}
-    except Exception as e:
-        logger.error("Readiness check failed: %s", e, exc_info=True)
-        return JSONResponse(
-            status_code=503,
-            content={"status": "not_ready", "error": "database unavailable"},
-        )

--- a/automation/app.py
+++ b/automation/app.py
@@ -132,11 +132,11 @@ def _build_cors_origins() -> list[str]:
     return origins
 
 
+BASE_PATH = "/api/automation"
+
+
 def _create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
-    settings = get_settings()
-    # root_path is derived from AUTOMATION_BASE_URL path component.
-    # e.g., https://app.all-hands.dev/api/automation -> /api/automation
     return FastAPI(
         title="OpenHands Automations Service",
         description=(
@@ -144,7 +144,6 @@ def _create_app() -> FastAPI:
         ),
         version="0.1.0",
         lifespan=lifespan,
-        root_path=settings.root_path,
     )
 
 
@@ -161,17 +160,17 @@ app.add_middleware(
 # Include uploads_router and preset_router BEFORE router to avoid route conflict.
 # The main router has /v1/{automation_id} which would match /v1/uploads
 # or /v1/preset/prompt and fail UUID validation if included first.
-app.include_router(uploads_router)
-app.include_router(preset_router)
-app.include_router(router)
+app.include_router(uploads_router, prefix=BASE_PATH)
+app.include_router(preset_router, prefix=BASE_PATH)
+app.include_router(router, prefix=BASE_PATH)
 
 
-@app.get("/health")
+@app.get(f"{BASE_PATH}/health")
 async def health():
     return {"status": "ok"}
 
 
-@app.get("/ready")
+@app.get(f"{BASE_PATH}/ready")
 async def readiness():
     """Readiness probe — checks DB connectivity.
 

--- a/automation/config.py
+++ b/automation/config.py
@@ -1,7 +1,6 @@
 """Application configuration loaded from environment variables."""
 
 from functools import lru_cache
-from urllib.parse import urlparse
 
 from pydantic_settings import BaseSettings
 
@@ -59,19 +58,7 @@ class Settings(BaseSettings):
     @property
     def resolved_base_url(self) -> str:
         """Public base URL with localhost fallback for dev."""
-        return self.base_url or f"http://localhost:{self.server_port}"
-
-    @property
-    def root_path(self) -> str:
-        """Root path for Swagger UI, derived from base_url.
-
-        When base_url is set (e.g., https://app.all-hands.dev/api/automation),
-        extracts the path component (/api/automation) for FastAPI's root_path.
-        This allows Swagger UI to correctly resolve the OpenAPI spec URL.
-        """
-        if self.base_url:
-            return urlparse(self.base_url).path.rstrip("/")
-        return ""
+        return self.base_url or f"http://localhost:{self.server_port}/api/automation"
 
 
 # Hardcoded internal URL scheme for uploaded tarballs.

--- a/automation/config.py
+++ b/automation/config.py
@@ -1,6 +1,7 @@
 """Application configuration loaded from environment variables."""
 
 from functools import lru_cache
+from urllib.parse import urlparse
 
 from pydantic_settings import BaseSettings
 
@@ -38,8 +39,9 @@ class Settings(BaseSettings):
     # API keys (called by the dispatcher before each automation run).
     service_key: str = ""
 
-    # Public URL for the automation service (used for sandbox callbacks).
-    # In production, this is the ingress URL (e.g., https://automation.all-hands.dev).
+    # Public base URL where this service is reachable (without /api/automation).
+    # Example: https://app.all-hands.dev or https://domain/acmecorp
+    # The /api/automation path is appended automatically by resolved_base_url.
     # If empty, falls back to http://localhost:{server_port} (dev only).
     base_url: str = ""
 
@@ -56,9 +58,25 @@ class Settings(BaseSettings):
     model_config = {"env_prefix": "AUTOMATION_"}
 
     @property
+    def base_path(self) -> str:
+        """Route prefix derived from base_url path component + /api/automation.
+
+        Examples:
+            base_url=""                          -> /api/automation
+            base_url="https://domain"            -> /api/automation
+            base_url="https://domain/acmecorp"   -> /acmecorp/api/automation
+        """
+        if self.base_url:
+            prefix = urlparse(self.base_url).path.rstrip("/")
+        else:
+            prefix = ""
+        return f"{prefix}/api/automation"
+
+    @property
     def resolved_base_url(self) -> str:
-        """Public base URL with localhost fallback for dev."""
-        return self.base_url or f"http://localhost:{self.server_port}/api/automation"
+        """Public base URL with /api/automation appended."""
+        base = self.base_url or f"http://localhost:{self.server_port}"
+        return f"{base.rstrip('/')}/api/automation"
 
 
 # Hardcoded internal URL scheme for uploaded tarballs.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -181,7 +181,7 @@ class TestAuthIntegration:
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
                 response = await client.get(
-                    "/v1",
+                    "/api/automation/v1",
                     headers={"Authorization": "Bearer real-key-123"},
                 )
 
@@ -213,7 +213,7 @@ class TestAuthIntegration:
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
-                response = await client.get("/v1")
+                response = await client.get("/api/automation/v1")
 
             assert response.status_code == 401
         finally:
@@ -243,7 +243,7 @@ class TestAuthIntegration:
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
                 response = await client.get(
-                    "/v1",
+                    "/api/automation/v1",
                     headers={"Authorization": "Bearer bad-key"},
                 )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,35 +3,20 @@
 from automation.config import Settings
 
 
-class TestRootPathExtraction:
-    """Verify root_path is correctly extracted from base_url."""
+class TestResolvedBaseUrl:
+    """Verify resolved_base_url includes the /api/automation path."""
 
-    def test_root_path_with_path_component(self):
-        """Extract path from full URL."""
+    def test_resolved_base_url_with_base_url_set(self):
+        """When base_url is set, it is returned as-is."""
         settings = Settings(base_url="https://app.all-hands.dev/api/automation")
-        assert settings.root_path == "/api/automation"
+        assert settings.resolved_base_url == "https://app.all-hands.dev/api/automation"
 
-    def test_root_path_with_trailing_slash(self):
-        """Trailing slash should be stripped."""
-        settings = Settings(base_url="https://app.all-hands.dev/api/automation/")
-        assert settings.root_path == "/api/automation"
+    def test_resolved_base_url_fallback_includes_base_path(self):
+        """When base_url is empty, localhost fallback includes /api/automation."""
+        settings = Settings(base_url="", server_port=8000)
+        assert settings.resolved_base_url == "http://localhost:8000/api/automation"
 
-    def test_root_path_without_path(self):
-        """URL at root should return empty string."""
-        settings = Settings(base_url="https://app.all-hands.dev")
-        assert settings.root_path == ""
-
-    def test_root_path_with_only_slash(self):
-        """URL with only root path should return empty string."""
-        settings = Settings(base_url="https://app.all-hands.dev/")
-        assert settings.root_path == ""
-
-    def test_root_path_empty_base_url(self):
-        """Empty base_url should return empty string."""
-        settings = Settings(base_url="")
-        assert settings.root_path == ""
-
-    def test_root_path_default_base_url(self):
-        """Default settings (no base_url) should return empty root_path."""
-        settings = Settings()
-        assert settings.root_path == ""
+    def test_resolved_base_url_fallback_custom_port(self):
+        """Localhost fallback uses the configured server_port."""
+        settings = Settings(base_url="", server_port=9000)
+        assert settings.resolved_base_url == "http://localhost:9000/api/automation"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,20 +3,49 @@
 from automation.config import Settings
 
 
-class TestResolvedBaseUrl:
-    """Verify resolved_base_url includes the /api/automation path."""
+class TestBasePath:
+    """Verify base_path is derived from base_url path + /api/automation."""
 
-    def test_resolved_base_url_with_base_url_set(self):
-        """When base_url is set, it is returned as-is."""
-        settings = Settings(base_url="https://app.all-hands.dev/api/automation")
+    def test_base_path_no_base_url(self):
+        settings = Settings(base_url="")
+        assert settings.base_path == "/api/automation"
+
+    def test_base_path_domain_only(self):
+        settings = Settings(base_url="https://app.all-hands.dev")
+        assert settings.base_path == "/api/automation"
+
+    def test_base_path_with_subpath(self):
+        settings = Settings(base_url="https://domain/acmecorp")
+        assert settings.base_path == "/acmecorp/api/automation"
+
+    def test_base_path_strips_trailing_slash(self):
+        settings = Settings(base_url="https://domain/acmecorp/")
+        assert settings.base_path == "/acmecorp/api/automation"
+
+    def test_base_path_root_slash_only(self):
+        settings = Settings(base_url="https://domain/")
+        assert settings.base_path == "/api/automation"
+
+
+class TestResolvedBaseUrl:
+    """Verify resolved_base_url appends /api/automation to base_url."""
+
+    def test_resolved_base_url_appends_base_path(self):
+        settings = Settings(base_url="https://app.all-hands.dev")
         assert settings.resolved_base_url == "https://app.all-hands.dev/api/automation"
 
-    def test_resolved_base_url_fallback_includes_base_path(self):
-        """When base_url is empty, localhost fallback includes /api/automation."""
+    def test_resolved_base_url_with_subpath(self):
+        settings = Settings(base_url="https://domain/acmecorp")
+        assert settings.resolved_base_url == "https://domain/acmecorp/api/automation"
+
+    def test_resolved_base_url_strips_trailing_slash(self):
+        settings = Settings(base_url="https://app.all-hands.dev/")
+        assert settings.resolved_base_url == "https://app.all-hands.dev/api/automation"
+
+    def test_resolved_base_url_fallback(self):
         settings = Settings(base_url="", server_port=8000)
         assert settings.resolved_base_url == "http://localhost:8000/api/automation"
 
     def test_resolved_base_url_fallback_custom_port(self):
-        """Localhost fallback uses the configured server_port."""
         settings = Settings(base_url="", server_port=9000)
         assert settings.resolved_base_url == "http://localhost:9000/api/automation"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -10,7 +10,7 @@ class TestHealthEndpoints:
 
     def test_health_endpoint(self, sync_client):
         """GET /health returns ok status."""
-        response = sync_client.get("/health")
+        response = sync_client.get("/api/automation/health")
 
         assert response.status_code == 200
         assert response.json() == {"status": "ok"}
@@ -18,7 +18,7 @@ class TestHealthEndpoints:
     async def test_ready_endpoint_success(self, async_client):
         """GET /ready returns ready status when DB is available."""
         # async_client fixture sets up app.state.engine
-        response = await async_client.get("/ready")
+        response = await async_client.get("/api/automation/ready")
 
         assert response.status_code == 200
         assert response.json() == {"status": "ready"}
@@ -32,7 +32,7 @@ class TestHealthEndpoints:
         app.state.engine = mock_engine
 
         try:
-            response = await async_client.get("/ready")
+            response = await async_client.get("/api/automation/ready")
 
             assert response.status_code == 503
             data = response.json()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -10,7 +10,7 @@ class TestHealthEndpoints:
 
     def test_health_endpoint(self, sync_client):
         """GET /health returns ok status."""
-        response = sync_client.get("/api/automation/health")
+        response = sync_client.get("/health")
 
         assert response.status_code == 200
         assert response.json() == {"status": "ok"}
@@ -18,7 +18,7 @@ class TestHealthEndpoints:
     async def test_ready_endpoint_success(self, async_client):
         """GET /ready returns ready status when DB is available."""
         # async_client fixture sets up app.state.engine
-        response = await async_client.get("/api/automation/ready")
+        response = await async_client.get("/ready")
 
         assert response.status_code == 200
         assert response.json() == {"status": "ready"}
@@ -32,7 +32,7 @@ class TestHealthEndpoints:
         app.state.engine = mock_engine
 
         try:
-            response = await async_client.get("/api/automation/ready")
+            response = await async_client.get("/ready")
 
             assert response.status_code == 503
             data = response.json()

--- a/tests/test_preset_router.py
+++ b/tests/test_preset_router.py
@@ -197,7 +197,9 @@ class TestCreateAutomationFromPrompt:
             "trigger": {"type": "cron", "schedule": "0 9 * * 1", "timezone": "UTC"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/prompt", json=payload
+        )
 
         assert response.status_code == 201
         data = response.json()
@@ -239,7 +241,9 @@ class TestCreateAutomationFromPrompt:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/prompt", json=payload
+        )
 
         assert response.status_code == 201
         data = response.json()
@@ -272,7 +276,9 @@ class TestCreateAutomationFromPrompt:
             "timeout": 300,
         }
 
-        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/prompt", json=payload
+        )
 
         assert response.status_code == 201
         data = response.json()
@@ -300,7 +306,9 @@ class TestCreateAutomationFromPrompt:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/prompt", json=payload
+        )
 
         assert response.status_code == 422
 
@@ -311,7 +319,9 @@ class TestCreateAutomationFromPrompt:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/prompt", json=payload
+        )
 
         assert response.status_code == 422
 
@@ -323,7 +333,9 @@ class TestCreateAutomationFromPrompt:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/prompt", json=payload
+        )
 
         assert response.status_code == 422
 
@@ -335,7 +347,9 @@ class TestCreateAutomationFromPrompt:
             "trigger": {"type": "cron", "schedule": "invalid-cron"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/prompt", json=payload
+        )
 
         assert response.status_code == 422
 
@@ -346,7 +360,9 @@ class TestCreateAutomationFromPrompt:
             "prompt": "Do something",
         }
 
-        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/prompt", json=payload
+        )
 
         assert response.status_code == 422
 
@@ -361,7 +377,9 @@ class TestCreateAutomationFromPrompt:
             "timeout": 120,
         }
 
-        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/prompt", json=payload
+        )
 
         assert response.status_code == 201
         data = response.json()
@@ -375,7 +393,9 @@ class TestCreateAutomationFromPrompt:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/prompt", json=payload
+        )
 
         assert response.status_code == 422
 
@@ -391,7 +411,9 @@ class TestCreateAutomationFromPrompt:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/prompt", json=payload
+        )
 
         assert response.status_code == 201
 
@@ -412,7 +434,9 @@ class TestCreateAutomationFromPrompt:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/prompt", json=payload
+        )
 
         assert response.status_code == 500
 
@@ -633,7 +657,9 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "0 9 * * 1", "timezone": "UTC"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/plugin", json=payload
+        )
 
         assert response.status_code == 201
         data = response.json()
@@ -681,7 +707,9 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/plugin", json=payload
+        )
 
         assert response.status_code == 201
         data = response.json()
@@ -716,7 +744,9 @@ class TestCreateAutomationFromPlugin:
             "timeout": 300,
         }
 
-        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/plugin", json=payload
+        )
 
         assert response.status_code == 201
         data = response.json()
@@ -745,7 +775,9 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/plugin", json=payload
+        )
 
         assert response.status_code == 422
 
@@ -758,7 +790,9 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/plugin", json=payload
+        )
 
         assert response.status_code == 422
 
@@ -770,7 +804,9 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/plugin", json=payload
+        )
 
         assert response.status_code == 422
 
@@ -783,7 +819,9 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "invalid-cron"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/plugin", json=payload
+        )
 
         assert response.status_code == 422
 
@@ -804,7 +842,9 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/plugin", json=payload
+        )
 
         assert response.status_code == 201
 
@@ -836,7 +876,9 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/plugin", json=payload
+        )
 
         assert response.status_code == 500
 
@@ -851,7 +893,9 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/plugin", json=payload
+        )
 
         assert response.status_code == 201
         data = response.json()
@@ -880,7 +924,9 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
+        response = await async_client.post(
+            "/api/automation/v1/preset/plugin", json=payload
+        )
 
         assert response.status_code == 201
 

--- a/tests/test_preset_router.py
+++ b/tests/test_preset_router.py
@@ -197,7 +197,7 @@ class TestCreateAutomationFromPrompt:
             "trigger": {"type": "cron", "schedule": "0 9 * * 1", "timezone": "UTC"},
         }
 
-        response = await async_client.post("/v1/preset/prompt", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
 
         assert response.status_code == 201
         data = response.json()
@@ -239,7 +239,7 @@ class TestCreateAutomationFromPrompt:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/v1/preset/prompt", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
 
         assert response.status_code == 201
         data = response.json()
@@ -272,7 +272,7 @@ class TestCreateAutomationFromPrompt:
             "timeout": 300,
         }
 
-        response = await async_client.post("/v1/preset/prompt", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
 
         assert response.status_code == 201
         data = response.json()
@@ -300,7 +300,7 @@ class TestCreateAutomationFromPrompt:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/v1/preset/prompt", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
 
         assert response.status_code == 422
 
@@ -311,7 +311,7 @@ class TestCreateAutomationFromPrompt:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/v1/preset/prompt", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
 
         assert response.status_code == 422
 
@@ -323,7 +323,7 @@ class TestCreateAutomationFromPrompt:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/v1/preset/prompt", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
 
         assert response.status_code == 422
 
@@ -335,7 +335,7 @@ class TestCreateAutomationFromPrompt:
             "trigger": {"type": "cron", "schedule": "invalid-cron"},
         }
 
-        response = await async_client.post("/v1/preset/prompt", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
 
         assert response.status_code == 422
 
@@ -346,7 +346,7 @@ class TestCreateAutomationFromPrompt:
             "prompt": "Do something",
         }
 
-        response = await async_client.post("/v1/preset/prompt", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
 
         assert response.status_code == 422
 
@@ -361,7 +361,7 @@ class TestCreateAutomationFromPrompt:
             "timeout": 120,
         }
 
-        response = await async_client.post("/v1/preset/prompt", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
 
         assert response.status_code == 201
         data = response.json()
@@ -375,7 +375,7 @@ class TestCreateAutomationFromPrompt:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/v1/preset/prompt", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
 
         assert response.status_code == 422
 
@@ -391,7 +391,7 @@ class TestCreateAutomationFromPrompt:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/v1/preset/prompt", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
 
         assert response.status_code == 201
 
@@ -412,7 +412,7 @@ class TestCreateAutomationFromPrompt:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/v1/preset/prompt", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/prompt", json=payload)
 
         assert response.status_code == 500
 
@@ -633,7 +633,7 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "0 9 * * 1", "timezone": "UTC"},
         }
 
-        response = await async_client.post("/v1/preset/plugin", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
 
         assert response.status_code == 201
         data = response.json()
@@ -681,7 +681,7 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/v1/preset/plugin", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
 
         assert response.status_code == 201
         data = response.json()
@@ -716,7 +716,7 @@ class TestCreateAutomationFromPlugin:
             "timeout": 300,
         }
 
-        response = await async_client.post("/v1/preset/plugin", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
 
         assert response.status_code == 201
         data = response.json()
@@ -745,7 +745,7 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/v1/preset/plugin", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
 
         assert response.status_code == 422
 
@@ -758,7 +758,7 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/v1/preset/plugin", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
 
         assert response.status_code == 422
 
@@ -770,7 +770,7 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/v1/preset/plugin", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
 
         assert response.status_code == 422
 
@@ -783,7 +783,7 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "invalid-cron"},
         }
 
-        response = await async_client.post("/v1/preset/plugin", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
 
         assert response.status_code == 422
 
@@ -804,7 +804,7 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/v1/preset/plugin", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
 
         assert response.status_code == 201
 
@@ -836,7 +836,7 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/v1/preset/plugin", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
 
         assert response.status_code == 500
 
@@ -851,7 +851,7 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/v1/preset/plugin", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
 
         assert response.status_code == 201
         data = response.json()
@@ -880,7 +880,7 @@ class TestCreateAutomationFromPlugin:
             "trigger": {"type": "cron", "schedule": "0 0 * * *"},
         }
 
-        response = await async_client.post("/v1/preset/plugin", json=payload)
+        response = await async_client.post("/api/automation/v1/preset/plugin", json=payload)
 
         assert response.status_code == 201
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -708,7 +708,9 @@ class TestDispatchAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.post(f"/api/automation/v1/{automation.id}/dispatch")
+        response = await async_client.post(
+            f"/api/automation/v1/{automation.id}/dispatch"
+        )
 
         assert response.status_code == 201
         data = response.json()
@@ -743,7 +745,9 @@ class TestDispatchAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.post(f"/api/automation/v1/{automation.id}/dispatch")
+        response = await async_client.post(
+            f"/api/automation/v1/{automation.id}/dispatch"
+        )
 
         assert response.status_code == 404
 
@@ -760,7 +764,9 @@ class TestDispatchAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.post(f"/api/automation/v1/{automation.id}/dispatch")
+        response = await async_client.post(
+            f"/api/automation/v1/{automation.id}/dispatch"
+        )
 
         assert response.status_code == 404
 
@@ -808,7 +814,9 @@ class TestDispatchAutomation:
 
         assert automation.last_triggered_at is None
 
-        response = await async_client.post(f"/api/automation/v1/{automation.id}/dispatch")
+        response = await async_client.post(
+            f"/api/automation/v1/{automation.id}/dispatch"
+        )
 
         assert response.status_code == 201
 
@@ -854,7 +862,9 @@ class TestListAutomationRuns:
         await async_session.commit()
 
         # Dispatch a run
-        dispatch_resp = await async_client.post(f"/api/automation/v1/{automation.id}/dispatch")
+        dispatch_resp = await async_client.post(
+            f"/api/automation/v1/{automation.id}/dispatch"
+        )
         assert dispatch_resp.status_code == 201
         run_id = dispatch_resp.json()["id"]
 
@@ -925,7 +935,9 @@ class TestListAutomationRuns:
 
         # Dispatch 5 runs
         for _ in range(5):
-            resp = await async_client.post(f"/api/automation/v1/{automation.id}/dispatch")
+            resp = await async_client.post(
+                f"/api/automation/v1/{automation.id}/dispatch"
+            )
             assert resp.status_code == 201
 
         # Get first page

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -26,7 +26,7 @@ class TestCreateAutomation:
             "entrypoint": "uv run script.py",
         }
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 201
         data = response.json()
@@ -52,7 +52,7 @@ class TestCreateAutomation:
             "entrypoint": "python main.py",
         }
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 201
         data = response.json()
@@ -68,7 +68,7 @@ class TestCreateAutomation:
             "entrypoint": "uv run script.py",
         }
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 422
         detail = response.json()["detail"]
@@ -82,7 +82,7 @@ class TestCreateAutomation:
         """Missing required fields returns 422."""
         payload = {"name": "Incomplete"}
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -94,7 +94,7 @@ class TestCreateAutomation:
             "tarball_path": "s3://bucket/path/to/code.tar.gz",
         }
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -107,7 +107,7 @@ class TestCreateAutomation:
             "entrypoint": "uv run main.py",
         }
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 422
         assert any(
@@ -125,7 +125,7 @@ class TestCreateAutomation:
             "entrypoint": "uv run main.py",
         }
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         # Should pass schema validation (422 would mean schema rejected it)
         # Will get 404 because the upload doesn't exist, but that's fine -
@@ -141,7 +141,7 @@ class TestCreateAutomation:
             "entrypoint": "uv run main.py; rm -rf /",
         }
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -154,7 +154,7 @@ class TestCreateAutomation:
             "entrypoint": "/usr/bin/python main.py",
         }
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -168,7 +168,7 @@ class TestCreateAutomation:
             "entrypoint": "uv run main.py",
         }
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -182,7 +182,7 @@ class TestCreateAutomation:
             "entrypoint": "uv run main.py",
         }
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -196,7 +196,7 @@ class TestCreateAutomation:
             "entrypoint": "uv run main.py",
         }
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -210,7 +210,7 @@ class TestCreateAutomation:
             "entrypoint": "uv run main.py",
         }
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 201
         assert response.json()["setup_script_path"] == "scripts/setup.sh"
@@ -225,7 +225,7 @@ class TestCreateAutomation:
             "timeout": 300,
         }
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 201
         data = response.json()
@@ -240,7 +240,7 @@ class TestCreateAutomation:
             "entrypoint": "python main.py",
         }
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 201
         data = response.json()
@@ -256,7 +256,7 @@ class TestCreateAutomation:
             "timeout": 0,
         }
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -270,7 +270,7 @@ class TestCreateAutomation:
             "timeout": -100,
         }
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -284,7 +284,7 @@ class TestCreateAutomation:
             "timeout": 601,  # MAX_RUN_DURATION_SECONDS is 600 (10 minutes)
         }
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 422
 
@@ -298,7 +298,7 @@ class TestCreateAutomation:
             "timeout": 600,  # MAX_RUN_DURATION_SECONDS is 600 (10 minutes)
         }
 
-        response = await async_client.post("/v1", json=payload)
+        response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 201
         data = response.json()
@@ -310,7 +310,7 @@ class TestListAutomations:
 
     async def test_list_automations_empty(self, async_client):
         """No automations returns empty list."""
-        response = await async_client.get("/v1")
+        response = await async_client.get("/api/automation/v1")
 
         assert response.status_code == 200
         data = response.json()
@@ -331,7 +331,7 @@ class TestListAutomations:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get("/v1")
+        response = await async_client.get("/api/automation/v1")
 
         assert response.status_code == 200
         data = response.json()
@@ -354,7 +354,7 @@ class TestListAutomations:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get("/v1")
+        response = await async_client.get("/api/automation/v1")
 
         assert response.status_code == 200
         data = response.json()
@@ -375,7 +375,7 @@ class TestListAutomations:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get("/v1")
+        response = await async_client.get("/api/automation/v1")
 
         assert response.status_code == 200
         data = response.json()
@@ -397,7 +397,7 @@ class TestListAutomations:
             async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get("/v1?limit=2&offset=0")
+        response = await async_client.get("/api/automation/v1?limit=2&offset=0")
 
         assert response.status_code == 200
         data = response.json()
@@ -421,7 +421,7 @@ class TestGetAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get(f"/v1/{automation.id}")
+        response = await async_client.get(f"/api/automation/v1/{automation.id}")
 
         assert response.status_code == 200
         data = response.json()
@@ -432,7 +432,7 @@ class TestGetAutomation:
         """Invalid ID returns 404."""
         fake_id = uuid.uuid4()
 
-        response = await async_client.get(f"/v1/{fake_id}")
+        response = await async_client.get(f"/api/automation/v1/{fake_id}")
 
         assert response.status_code == 404
         assert "Automation not found" in response.json()["detail"]
@@ -451,7 +451,7 @@ class TestGetAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get(f"/v1/{automation.id}")
+        response = await async_client.get(f"/api/automation/v1/{automation.id}")
 
         assert response.status_code == 404
 
@@ -468,7 +468,7 @@ class TestGetAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get(f"/v1/{automation.id}")
+        response = await async_client.get(f"/api/automation/v1/{automation.id}")
 
         assert response.status_code == 404
 
@@ -491,7 +491,7 @@ class TestDeleteAutomation:
         await async_session.commit()
         automation_id = automation.id
 
-        response = await async_client.delete(f"/v1/{automation_id}")
+        response = await async_client.delete(f"/api/automation/v1/{automation_id}")
 
         assert response.status_code == 204
 
@@ -504,7 +504,7 @@ class TestDeleteAutomation:
         """DELETE on non-existent ID returns 404."""
         fake_id = uuid.uuid4()
 
-        response = await async_client.delete(f"/v1/{fake_id}")
+        response = await async_client.delete(f"/api/automation/v1/{fake_id}")
 
         assert response.status_code == 404
 
@@ -522,7 +522,7 @@ class TestDeleteAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.delete(f"/v1/{automation.id}")
+        response = await async_client.delete(f"/api/automation/v1/{automation.id}")
 
         assert response.status_code == 404
 
@@ -544,7 +544,7 @@ class TestUpdateAutomation:
         await async_session.commit()
 
         response = await async_client.patch(
-            f"/v1/{automation.id}",
+            f"/api/automation/v1/{automation.id}",
             json={"name": "Updated Name"},
         )
 
@@ -567,7 +567,7 @@ class TestUpdateAutomation:
         await async_session.commit()
 
         response = await async_client.patch(
-            f"/v1/{automation.id}",
+            f"/api/automation/v1/{automation.id}",
             json={"trigger": {"type": "cron", "schedule": "*/5 * * * *"}},
         )
 
@@ -589,7 +589,7 @@ class TestUpdateAutomation:
         await async_session.commit()
 
         response = await async_client.patch(
-            f"/v1/{automation.id}",
+            f"/api/automation/v1/{automation.id}",
             json={"enabled": False},
         )
 
@@ -601,7 +601,7 @@ class TestUpdateAutomation:
         fake_id = uuid.uuid4()
 
         response = await async_client.patch(
-            f"/v1/{fake_id}",
+            f"/api/automation/v1/{fake_id}",
             json={"name": "Updated"},
         )
 
@@ -621,7 +621,7 @@ class TestUpdateAutomation:
         await async_session.commit()
 
         response = await async_client.patch(
-            f"/v1/{automation.id}",
+            f"/api/automation/v1/{automation.id}",
             json={"name": "Hacked"},
         )
 
@@ -642,7 +642,7 @@ class TestUpdateAutomation:
         await async_session.commit()
 
         response = await async_client.patch(
-            f"/v1/{automation.id}",
+            f"/api/automation/v1/{automation.id}",
             json={"timeout": 120},
         )
 
@@ -663,7 +663,7 @@ class TestUpdateAutomation:
         await async_session.commit()
 
         response = await async_client.patch(
-            f"/v1/{automation.id}",
+            f"/api/automation/v1/{automation.id}",
             json={"timeout": -10},
         )
 
@@ -685,7 +685,7 @@ class TestUpdateAutomation:
         await async_session.commit()
 
         response = await async_client.patch(
-            f"/v1/{automation.id}",
+            f"/api/automation/v1/{automation.id}",
             json={"timeout": 700},  # MAX_RUN_DURATION_SECONDS is 600 (10 minutes)
         )
 
@@ -708,7 +708,7 @@ class TestDispatchAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.post(f"/v1/{automation.id}/dispatch")
+        response = await async_client.post(f"/api/automation/v1/{automation.id}/dispatch")
 
         assert response.status_code == 201
         data = response.json()
@@ -724,7 +724,7 @@ class TestDispatchAutomation:
         """Dispatching a nonexistent automation returns 404."""
         fake_id = uuid.uuid4()
 
-        response = await async_client.post(f"/v1/{fake_id}/dispatch")
+        response = await async_client.post(f"/api/automation/v1/{fake_id}/dispatch")
 
         assert response.status_code == 404
         assert "Automation not found" in response.json()["detail"]
@@ -743,7 +743,7 @@ class TestDispatchAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.post(f"/v1/{automation.id}/dispatch")
+        response = await async_client.post(f"/api/automation/v1/{automation.id}/dispatch")
 
         assert response.status_code == 404
 
@@ -760,7 +760,7 @@ class TestDispatchAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.post(f"/v1/{automation.id}/dispatch")
+        response = await async_client.post(f"/api/automation/v1/{automation.id}/dispatch")
 
         assert response.status_code == 404
 
@@ -777,8 +777,8 @@ class TestDispatchAutomation:
         async_session.add(automation)
         await async_session.commit()
 
-        resp1 = await async_client.post(f"/v1/{automation.id}/dispatch")
-        resp2 = await async_client.post(f"/v1/{automation.id}/dispatch")
+        resp1 = await async_client.post(f"/api/automation/v1/{automation.id}/dispatch")
+        resp2 = await async_client.post(f"/api/automation/v1/{automation.id}/dispatch")
 
         assert resp1.status_code == 201
         assert resp2.status_code == 201
@@ -808,7 +808,7 @@ class TestDispatchAutomation:
 
         assert automation.last_triggered_at is None
 
-        response = await async_client.post(f"/v1/{automation.id}/dispatch")
+        response = await async_client.post(f"/api/automation/v1/{automation.id}/dispatch")
 
         assert response.status_code == 201
 
@@ -833,7 +833,7 @@ class TestListAutomationRuns:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get(f"/v1/{automation.id}/runs")
+        response = await async_client.get(f"/api/automation/v1/{automation.id}/runs")
 
         assert response.status_code == 200
         data = response.json()
@@ -854,12 +854,12 @@ class TestListAutomationRuns:
         await async_session.commit()
 
         # Dispatch a run
-        dispatch_resp = await async_client.post(f"/v1/{automation.id}/dispatch")
+        dispatch_resp = await async_client.post(f"/api/automation/v1/{automation.id}/dispatch")
         assert dispatch_resp.status_code == 201
         run_id = dispatch_resp.json()["id"]
 
         # List runs
-        response = await async_client.get(f"/v1/{automation.id}/runs")
+        response = await async_client.get(f"/api/automation/v1/{automation.id}/runs")
 
         assert response.status_code == 200
         data = response.json()
@@ -900,7 +900,7 @@ class TestListAutomationRuns:
         await async_session.commit()
 
         # List runs
-        response = await async_client.get(f"/v1/{automation.id}/runs")
+        response = await async_client.get(f"/api/automation/v1/{automation.id}/runs")
 
         assert response.status_code == 200
         data = response.json()
@@ -925,12 +925,12 @@ class TestListAutomationRuns:
 
         # Dispatch 5 runs
         for _ in range(5):
-            resp = await async_client.post(f"/v1/{automation.id}/dispatch")
+            resp = await async_client.post(f"/api/automation/v1/{automation.id}/dispatch")
             assert resp.status_code == 201
 
         # Get first page
         response = await async_client.get(
-            f"/v1/{automation.id}/runs",
+            f"/api/automation/v1/{automation.id}/runs",
             params={"limit": 2, "offset": 0},
         )
 
@@ -941,7 +941,7 @@ class TestListAutomationRuns:
 
         # Get second page
         response = await async_client.get(
-            f"/v1/{automation.id}/runs",
+            f"/api/automation/v1/{automation.id}/runs",
             params={"limit": 2, "offset": 2},
         )
 
@@ -954,7 +954,7 @@ class TestListAutomationRuns:
         """Listing runs for nonexistent automation returns 404."""
         fake_id = uuid.uuid4()
 
-        response = await async_client.get(f"/v1/{fake_id}/runs")
+        response = await async_client.get(f"/api/automation/v1/{fake_id}/runs")
 
         assert response.status_code == 404
         assert "Automation not found" in response.json()["detail"]
@@ -972,7 +972,7 @@ class TestListAutomationRuns:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get(f"/v1/{automation.id}/runs")
+        response = await async_client.get(f"/api/automation/v1/{automation.id}/runs")
 
         assert response.status_code == 404
 
@@ -990,7 +990,7 @@ class TestListAutomationRuns:
         async_session.add(automation)
         await async_session.commit()
 
-        response = await async_client.get(f"/v1/{automation.id}/runs")
+        response = await async_client.get(f"/api/automation/v1/{automation.id}/runs")
 
         assert response.status_code == 404
 
@@ -1008,7 +1008,7 @@ class TestListAutomationRuns:
         await async_session.commit()
 
         response = await async_client.get(
-            f"/v1/{automation.id}/runs",
+            f"/api/automation/v1/{automation.id}/runs",
             params={"limit": 101},
         )
 
@@ -1039,7 +1039,7 @@ class TestListAutomationRuns:
         await async_session.commit()
 
         # List runs without specifying limit
-        response = await async_client.get(f"/v1/{automation.id}/runs")
+        response = await async_client.get(f"/api/automation/v1/{automation.id}/runs")
 
         assert response.status_code == 200
         data = response.json()


### PR DESCRIPTION
## Why

We currently rely on a Traefik `StripPrefix` middleware in our Helm charts to route `/api/automation` traffic to this service. This couples the application to a specific ingress implementation and makes it harder for consumers using other ingress controllers (e.g. nginx, AWS ALB) to deploy. By having the app handle the `/api/automation` prefix directly, we can remove that middleware and simplify ingress configuration.

## Notable details

- The `root_path` config property has been removed — it was only needed when a reverse proxy stripped the prefix before forwarding. Since the app now owns the path, `root_path` would cause double-prefixing in Swagger UI.
- The `resolved_base_url` localhost fallback now includes `/api/automation` so that sandbox callback URLs are correct in local dev without needing `AUTOMATION_BASE_URL` set.