### PR TITLE
feat(backend): add require_permission dependency and enforce on all API endpoints

### DIFF
--- a/automation/auth.py
+++ b/automation/auth.py
@@ -153,11 +153,6 @@ def require_permission(permission: str):
     Checks whether the authenticated user has the given permission string
     in their permissions list.  Raises HTTP 403 if missing, otherwise
     returns the ``AuthenticatedUser``.
-
-    Not wired to any endpoint yet — future use only.  Enabling a
-    permission gate requires changing
-    ``Depends(authenticate_request)`` to
-    ``Depends(require_permission("manage_automations"))``.
     """
 
     async def _check(

--- a/automation/auth.py
+++ b/automation/auth.py
@@ -147,6 +147,37 @@ async def _make_auth_request_with_retry(
     return await client.get(url, headers=headers)
 
 
+def require_permission(permission: str):
+    """Factory that returns a FastAPI dependency enforcing a permission.
+
+    Checks whether the authenticated user has the given permission string
+    in their permissions list.  Raises HTTP 403 if missing, otherwise
+    returns the ``AuthenticatedUser``.
+
+    Not wired to any endpoint yet — future use only.  Enabling a
+    permission gate requires changing
+    ``Depends(authenticate_request)`` to
+    ``Depends(require_permission("manage_automations"))``.
+    """
+
+    async def _check(
+        user: "AuthenticatedUser" = Depends(authenticate_request),
+    ) -> "AuthenticatedUser":
+        if permission not in user.permissions:
+            logger.warning(
+                "Permission denied: user %s missing permission %s",
+                user.user_id,
+                permission,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Requires {permission} permission",
+            )
+        return user
+
+    return _check
+
+
 async def authenticate_request(
     request: Request,
     client: httpx.AsyncClient = Depends(get_http_client),

--- a/automation/router.py
+++ b/automation/router.py
@@ -10,7 +10,7 @@ from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from automation.auth import AuthenticatedUser, authenticate_request
+from automation.auth import AuthenticatedUser, require_permission
 from automation.db import get_session
 from automation.models import Automation, AutomationRun, AutomationRunStatus
 from automation.schemas import (
@@ -33,6 +33,8 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1", tags=["Automations"])
 
+_require_manage_automations = require_permission("manage_automations")
+
 
 # --- CRUD ---
 
@@ -40,7 +42,7 @@ router = APIRouter(prefix="/v1", tags=["Automations"])
 @router.post("", status_code=status.HTTP_201_CREATED)
 async def create_automation(
     body: CreateAutomationRequest,
-    user: AuthenticatedUser = Depends(authenticate_request),
+    user: AuthenticatedUser = Depends(_require_manage_automations),
     session: AsyncSession = Depends(get_session),
 ) -> AutomationResponse:
     """Create a new automation.
@@ -77,7 +79,7 @@ async def create_automation(
 async def list_automations(
     limit: int = Query(default=50, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
-    user: AuthenticatedUser = Depends(authenticate_request),
+    user: AuthenticatedUser = Depends(_require_manage_automations),
     session: AsyncSession = Depends(get_session),
 ) -> AutomationListResponse:
     """List automations for the authenticated user (excludes soft-deleted)."""
@@ -106,7 +108,7 @@ async def list_automations(
 @router.get("/{automation_id}")
 async def get_automation(
     automation_id: uuid.UUID,
-    user: AuthenticatedUser = Depends(authenticate_request),
+    user: AuthenticatedUser = Depends(_require_manage_automations),
     session: AsyncSession = Depends(get_session),
 ) -> AutomationResponse:
     """Get a single automation by ID."""
@@ -118,7 +120,7 @@ async def get_automation(
 async def update_automation(
     automation_id: uuid.UUID,
     body: UpdateAutomationRequest,
-    user: AuthenticatedUser = Depends(authenticate_request),
+    user: AuthenticatedUser = Depends(_require_manage_automations),
     session: AsyncSession = Depends(get_session),
 ) -> AutomationResponse:
     """Partially update an automation."""
@@ -141,7 +143,7 @@ async def update_automation(
 @router.delete("/{automation_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_automation(
     automation_id: uuid.UUID,
-    user: AuthenticatedUser = Depends(authenticate_request),
+    user: AuthenticatedUser = Depends(_require_manage_automations),
     session: AsyncSession = Depends(get_session),
 ) -> None:
     """Soft delete an automation."""
@@ -157,7 +159,7 @@ async def delete_automation(
 @router.post("/{automation_id}/dispatch", status_code=status.HTTP_201_CREATED)
 async def dispatch_automation(
     automation_id: uuid.UUID,
-    user: AuthenticatedUser = Depends(authenticate_request),
+    user: AuthenticatedUser = Depends(_require_manage_automations),
     session: AsyncSession = Depends(get_session),
 ) -> AutomationRunResponse:
     """Manually dispatch an automation run.
@@ -177,7 +179,7 @@ async def list_automation_runs(
     automation_id: uuid.UUID,
     limit: int = Query(default=50, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
-    user: AuthenticatedUser = Depends(authenticate_request),
+    user: AuthenticatedUser = Depends(_require_manage_automations),
     session: AsyncSession = Depends(get_session),
 ) -> AutomationRunListResponse:
     """List runs for a specific automation.
@@ -216,7 +218,7 @@ async def list_automation_runs(
 async def complete_run(
     run_id: uuid.UUID,
     body: RunCompleteRequest,
-    user: AuthenticatedUser = Depends(authenticate_request),
+    user: AuthenticatedUser = Depends(_require_manage_automations),
     session: AsyncSession = Depends(get_session),
 ) -> AutomationRunResponse:
     """Receive completion callback from the SDK running inside a sandbox.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,22 @@ def mock_authenticated_user():
         org_id=uuid.UUID("87654321-4321-8765-4321-876543218765"),
         email="test@example.com",
         role="owner",
+        permissions=["view_org_settings", "manage_automations"],
+        auth_method=AuthMethod.API_KEY,
+        api_key="test-api-key",
+    )
+
+
+@pytest.fixture
+def mock_readonly_user():
+    """Return a mock authenticated user without manage_automations permission."""
+    import uuid
+
+    return AuthenticatedUser(
+        user_id=uuid.UUID("12345678-1234-5678-1234-567812345678"),
+        org_id=uuid.UUID("87654321-4321-8765-4321-876543218765"),
+        email="test@example.com",
+        role="member",
         permissions=["view_org_settings"],
         auth_method=AuthMethod.API_KEY,
         api_key="test-api-key",
@@ -124,6 +140,35 @@ async def async_client(
     app.state.engine = async_engine
     app.state.session_factory = async_session_factory
     # Create a mock http_client for tests (auth is overridden, but state must exist)
+    app.state.http_client = create_http_client()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        yield client
+
+    await app.state.http_client.aclose()
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def readonly_client(
+    async_engine, async_session_factory, async_session, mock_readonly_user
+) -> AsyncGenerator[AsyncClient, None]:
+    """Create an async test client with a user lacking manage_automations permission."""
+
+    async def override_get_session():
+        yield async_session
+
+    async def override_authenticate():
+        return mock_readonly_user
+
+    app.dependency_overrides[get_session] = override_get_session
+    app.dependency_overrides[authenticate_request] = override_authenticate
+
+    app.state.engine = async_engine
+    app.state.session_factory = async_session_factory
     app.state.http_client = create_http_client()
 
     async with AsyncClient(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -17,6 +17,7 @@ from automation.auth import (
     _make_auth_request_with_retry,
     authenticate_request,
     clear_auth_cache,
+    require_permission,
 )
 from automation.db import get_session
 
@@ -31,7 +32,7 @@ MOCK_USERS_ME_RESPONSE = {
     "org_id": str(TEST_ORG_ID),
     "email": "test@example.com",
     "role": "owner",
-    "permissions": ["view_org_settings", "manage_api_keys"],
+    "permissions": ["view_org_settings", "manage_api_keys", "manage_automations"],
 }
 
 
@@ -82,7 +83,11 @@ class TestAuthentication:
         assert result.org_id == TEST_ORG_ID
         assert result.email == "test@example.com"
         assert result.role == "owner"
-        assert result.permissions == ["view_org_settings", "manage_api_keys"]
+        assert result.permissions == [
+            "view_org_settings",
+            "manage_api_keys",
+            "manage_automations",
+        ]
         assert result.auth_method == AuthMethod.API_KEY
         assert result.api_key == "valid-api-key"
 
@@ -660,3 +665,63 @@ class TestRetryMechanism:
         # Verify backoff increases (tenacity uses 2^x * multiplier pattern)
         calls = [call[0][0] for call in mock_sleep.call_args_list]
         assert calls[0] < calls[1] < calls[2]
+
+
+class TestRequirePermission:
+    """Tests for require_permission factory function."""
+
+    async def test_permission_present_returns_user(self):
+        """User with the required permission is returned successfully."""
+        user = AuthenticatedUser(
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            email="test@example.com",
+            role="owner",
+            permissions=["manage_automations", "view_org_settings"],
+            auth_method=AuthMethod.API_KEY,
+            api_key="key",
+        )
+
+        checker = require_permission("manage_automations")
+        result = await checker(user=user)
+
+        assert result is user
+
+    async def test_permission_missing_raises_403(self):
+        """User without the required permission gets HTTP 403."""
+        user = AuthenticatedUser(
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            email="test@example.com",
+            role="member",
+            permissions=["view_org_settings"],
+            auth_method=AuthMethod.API_KEY,
+            api_key="key",
+        )
+
+        checker = require_permission("manage_automations")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await checker(user=user)
+
+        assert exc_info.value.status_code == 403
+        assert "manage_automations" in exc_info.value.detail
+
+    async def test_different_permission_raises_403(self):
+        """Having a different permission does not satisfy the requirement."""
+        user = AuthenticatedUser(
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            email="test@example.com",
+            role="member",
+            permissions=["some_other_permission"],
+            auth_method=AuthMethod.API_KEY,
+            api_key="key",
+        )
+
+        checker = require_permission("manage_automations")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await checker(user=user)
+
+        assert exc_info.value.status_code == 403

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -2,6 +2,8 @@
 
 import uuid
 
+import pytest
+
 from automation.models import Automation
 from automation.utils import utcnow
 
@@ -11,6 +13,73 @@ TEST_USER_ID = uuid.UUID("12345678-1234-5678-1234-567812345678")
 TEST_ORG_ID = uuid.UUID("87654321-4321-8765-4321-876543218765")
 OTHER_USER_ID = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
 OTHER_ORG_ID = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+
+@pytest.fixture
+def _automation_for_permission_tests(async_session):
+    """Create an automation owned by the test user for permission tests."""
+
+    async def _create():
+        automation = Automation(
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            name="Permission Test Automation",
+            trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
+            tarball_path="s3://bucket/code.tar.gz",
+            entrypoint="uv run script.py",
+        )
+        async_session.add(automation)
+        await async_session.commit()
+        return automation
+
+    return _create
+
+
+class TestPermissionEnforcement:
+    """Tests for require_permission on mutating endpoints."""
+
+    async def test_update_without_permission_returns_403(
+        self, readonly_client, async_session
+    ):
+        """PATCH returns 403 when user lacks manage_automations permission."""
+        automation = Automation(
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            name="Test",
+            trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
+            tarball_path="s3://bucket/code.tar.gz",
+            entrypoint="uv run script.py",
+        )
+        async_session.add(automation)
+        await async_session.commit()
+
+        response = await readonly_client.patch(
+            f"/api/automation/v1/{automation.id}",
+            json={"name": "Updated"},
+        )
+
+        assert response.status_code == 403
+        assert "manage_automations" in response.json()["detail"]
+
+    async def test_delete_without_permission_returns_403(
+        self, readonly_client, async_session
+    ):
+        """DELETE returns 403 when user lacks manage_automations permission."""
+        automation = Automation(
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            name="Test",
+            trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
+            tarball_path="s3://bucket/code.tar.gz",
+            entrypoint="uv run script.py",
+        )
+        async_session.add(automation)
+        await async_session.commit()
+
+        response = await readonly_client.delete(f"/api/automation/v1/{automation.id}")
+
+        assert response.status_code == 403
+        assert "manage_automations" in response.json()["detail"]
 
 
 class TestCreateAutomation:
@@ -362,13 +431,14 @@ class TestListAutomations:
         assert data["automations"] == []
         assert data["total"] == 0
 
-    async def test_list_automations_only_own(self, async_client, async_session):
-        """User cannot see other users' automations."""
-        # Create automation for different user
+    async def test_list_automations_cross_org_returns_empty(
+        self, async_client, async_session
+    ):
+        """Automations from another organization are not visible."""
         automation = Automation(
             user_id=OTHER_USER_ID,
             org_id=OTHER_ORG_ID,
-            name="Other User Automation",
+            name="Other Org Automation",
             trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
             tarball_path="s3://bucket/path/to/code.tar.gz",
             entrypoint="uv run script.py",
@@ -456,12 +526,14 @@ class TestGetAutomation:
 
         assert response.status_code == 404
 
-    async def test_get_automation_wrong_user(self, async_client, async_session):
-        """Cannot access other user's automation."""
+    async def test_get_automation_cross_org_returns_404(
+        self, async_client, async_session
+    ):
+        """Cannot access automation from another organization."""
         automation = Automation(
             user_id=OTHER_USER_ID,
             org_id=OTHER_ORG_ID,
-            name="Other User Automation",
+            name="Other Org Automation",
             trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
             tarball_path="s3://bucket/path/to/code.tar.gz",
             entrypoint="uv run script.py",
@@ -506,6 +578,25 @@ class TestDeleteAutomation:
         fake_id = uuid.uuid4()
 
         response = await async_client.delete(f"/api/automation/v1/{fake_id}")
+
+        assert response.status_code == 404
+
+    async def test_delete_automation_cross_org_returns_404(
+        self, async_client, async_session
+    ):
+        """Cannot delete automation from another organization."""
+        automation = Automation(
+            user_id=OTHER_USER_ID,
+            org_id=OTHER_ORG_ID,
+            name="Other Org Automation",
+            trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
+            tarball_path="s3://bucket/path/to/code.tar.gz",
+            entrypoint="uv run script.py",
+        )
+        async_session.add(automation)
+        await async_session.commit()
+
+        response = await async_client.delete(f"/api/automation/v1/{automation.id}")
 
         assert response.status_code == 404
 
@@ -608,12 +699,14 @@ class TestUpdateAutomation:
 
         assert response.status_code == 404
 
-    async def test_update_automation_wrong_user(self, async_client, async_session):
-        """Cannot update another user's automation."""
+    async def test_update_automation_cross_org_returns_404(
+        self, async_client, async_session
+    ):
+        """Cannot update automation from another organization."""
         automation = Automation(
             user_id=OTHER_USER_ID,
             org_id=OTHER_ORG_ID,
-            name="Other User",
+            name="Other Org",
             trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
             tarball_path="s3://bucket/code.tar.gz",
             entrypoint="uv run script.py",
@@ -752,12 +845,14 @@ class TestDispatchAutomation:
 
         assert response.status_code == 404
 
-    async def test_dispatch_automation_wrong_user(self, async_client, async_session):
-        """Cannot dispatch another user's automation."""
+    async def test_dispatch_automation_cross_org_returns_404(
+        self, async_client, async_session
+    ):
+        """Cannot dispatch automation from another organization."""
         automation = Automation(
             user_id=OTHER_USER_ID,
             org_id=OTHER_ORG_ID,
-            name="Other User Automation",
+            name="Other Org Automation",
             trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
             tarball_path="s3://bucket/code.tar.gz",
             entrypoint="uv run script.py",
@@ -972,12 +1067,12 @@ class TestListAutomationRuns:
         assert response.status_code == 404
         assert "Automation not found" in response.json()["detail"]
 
-    async def test_list_runs_wrong_user(self, async_client, async_session):
-        """Cannot list runs for another user's automation."""
+    async def test_list_runs_cross_org_returns_404(self, async_client, async_session):
+        """Cannot list runs for automation from another organization."""
         automation = Automation(
             user_id=OTHER_USER_ID,
             org_id=OTHER_ORG_ID,
-            name="Other User Automation",
+            name="Other Org Automation",
             trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
             tarball_path="s3://bucket/code.tar.gz",
             entrypoint="uv run script.py",


### PR DESCRIPTION
## Summary

- Add require_permission() factory in automation/auth.py that returns a FastAPI dependency checking if the authenticated user has a given permission string, raising 403 if missing.
- Wire require_permission("manage_automations") to all API endpoints in automation/router.py (create, list, get, update, delete, dispatch, list runs, complete run).
- Change complete_run ownership check from returning 403 to 404 for cross-org/cross-user access, avoiding resource existence leakage.
- Rename cross-org denial tests for clarity and add explicit test_delete_automation_cross_org_returns_404.
- Add TestPermissionEnforcement tests verifying PATCH and DELETE return 403 when manage_automations permission is missing.
- Add TestRequirePermission unit tests covering permission present, missing, and mismatched cases.