### PR TITLE
feat(frontend): sync language preference between Automation UI and OpenHands UI

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -51,6 +51,52 @@ The dev server proxies API requests to:
 - `/api/automation/*` → Automation Service (`127.0.0.1:8000`)
 - `/api/*` → OpenHands Backend (`127.0.0.1:3030`)
 
+### Running with OpenHands (Cross-Tab Sync)
+
+To test features that require cross-tab communication with the OpenHands frontend (e.g., language synchronization via `localStorage`), both apps must be served from the same origin. A local reverse proxy script is included for this purpose.
+
+**1. Start both dev servers:**
+
+```sh
+# Terminal 1 — OpenHands frontend (port 3030)
+cd /path/to/OpenHands/frontend
+npm run dev
+
+# Terminal 2 — Automation frontend (port 3002)
+cd /path/to/automation/frontend
+npm run dev
+```
+
+**2. Start the reverse proxy:**
+
+```sh
+# Terminal 3
+npm run dev:proxy
+```
+
+**3. Access both apps via the proxy:**
+
+- OpenHands: [http://localhost:3000](http://localhost:3000)
+- Automations: [http://localhost:3000/automations](http://localhost:3000/automations)
+
+Both apps now share the same origin (`localhost:3000`), so `localStorage` and `storage` events work across tabs.
+
+The proxy routes requests as follows:
+
+| Path | Target |
+| --- | --- |
+| `/automations/*` | `localhost:3002` (Automation frontend) |
+| `/api/automation/*` | `localhost:3002` (→ Vite proxy → Automation backend) |
+| `/api/*` | `localhost:3030` (OpenHands backend) |
+| `/*` | `localhost:3030` (OpenHands frontend) |
+
+Port defaults can be overridden via CLI arguments:
+
+```sh
+node scripts/dev-proxy.mjs [proxyPort] [ohPort] [autoPort]
+# e.g., node scripts/dev-proxy.mjs 3000 3030 3002
+```
+
 ### Running with Mocked APIs (No Backend Required)
 
 For frontend development without running any backend services, use the mock development mode:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
   },
   "scripts": {
     "dev": "npm run make-i18n && cross-env VITE_MOCK_API=false react-router dev",
+    "dev:proxy": "node scripts/dev-proxy.mjs",
     "dev:mock": "npm run make-i18n && cross-env VITE_MOCK_API=true react-router dev",
     "build": "npm run make-i18n && react-router build",
     "start": "npx sirv-cli build/ --single",

--- a/frontend/scripts/dev-proxy.mjs
+++ b/frontend/scripts/dev-proxy.mjs
@@ -1,0 +1,101 @@
+/**
+ * Local reverse proxy that serves both the OpenHands frontend and the
+ * Automation frontend under a single origin, enabling cross-tab
+ * localStorage sharing and storage events — mirroring production routing.
+ *
+ * Routing (evaluated in order):
+ *   /automations/*     →  localhost:3002  (Automation frontend)
+ *   /api/automation/*  →  localhost:3002  (→ Vite proxy → Automation backend)
+ *   /api/*             →  localhost:3030  (OpenHands backend)
+ *   /*                 →  localhost:3030  (OpenHands frontend)
+ *
+ * Usage:
+ *   node scripts/dev-proxy.mjs                    # defaults: proxy=3000, OH=3030, auto=3002
+ *   node scripts/dev-proxy.mjs 3000 3030 3002     # explicit ports
+ *
+ * Then access both apps via http://localhost:3000
+ */
+
+import { createServer, request as httpRequest } from "node:http";
+
+const [proxyPort, ohPort, autoPort] = [
+  parseInt(process.argv[2] || "3000", 10),
+  parseInt(process.argv[3] || "3030", 10),
+  parseInt(process.argv[4] || "3002", 10),
+];
+
+function routeToPort(url) {
+  if (url.startsWith("/automations") || url.startsWith("/api/automation")) {
+    return autoPort;
+  }
+  return ohPort;
+}
+
+function proxy(req, res, targetPort) {
+  const options = {
+    hostname: "localhost",
+    port: targetPort,
+    path: req.url,
+    method: req.method,
+    headers: req.headers,
+  };
+
+  const proxyReq = httpRequest(options, (proxyRes) => {
+    res.writeHead(proxyRes.statusCode, proxyRes.headers);
+    proxyRes.pipe(res, { end: true });
+  });
+
+  proxyReq.on("error", (err) => {
+    res.writeHead(502);
+    res.end(`Proxy error: cannot reach localhost:${targetPort} — ${err.message}`);
+  });
+
+  req.pipe(proxyReq, { end: true });
+}
+
+const server = createServer((req, res) => {
+  proxy(req, res, routeToPort(req.url));
+});
+
+// Handle WebSocket upgrades (HMR for both Vite dev servers)
+server.on("upgrade", (req, socket, head) => {
+  const targetPort = routeToPort(req.url);
+
+  const options = {
+    hostname: "localhost",
+    port: targetPort,
+    path: req.url,
+    method: req.method,
+    headers: req.headers,
+  };
+
+  const proxyReq = httpRequest(options);
+
+  proxyReq.on("upgrade", (proxyRes, proxySocket, proxyHead) => {
+    socket.write(
+      `HTTP/${proxyRes.httpVersion} ${proxyRes.statusCode} ${proxyRes.statusMessage}\r\n`,
+    );
+    for (let i = 0; i < proxyRes.rawHeaders.length; i += 2) {
+      socket.write(`${proxyRes.rawHeaders[i]}: ${proxyRes.rawHeaders[i + 1]}\r\n`);
+    }
+    socket.write("\r\n");
+
+    if (proxyHead.length > 0) socket.write(proxyHead);
+
+    proxySocket.pipe(socket, { end: true });
+    socket.pipe(proxySocket, { end: true });
+  });
+
+  proxyReq.on("error", () => {
+    socket.destroy();
+  });
+
+  proxyReq.end();
+});
+
+server.listen(proxyPort, () => {
+  console.log(`\nDev proxy running on http://localhost:${proxyPort}`);
+  console.log(`  /automations/*     →  http://localhost:${autoPort}`);
+  console.log(`  /api/automation/*  →  http://localhost:${autoPort}`);
+  console.log(`  /*                 →  http://localhost:${ohPort}\n`);
+});

--- a/frontend/src/__tests__/hooks/use-language-sync.test.ts
+++ b/frontend/src/__tests__/hooks/use-language-sync.test.ts
@@ -1,0 +1,122 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import { useLanguageSync } from "#/hooks/use-language-sync";
+import { LOCAL_STORAGE_KEYS } from "#/utils/local-storage";
+import type { User } from "#/types/user";
+
+const changeLanguageMock = vi.fn();
+
+vi.mock("react-i18next", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-i18next")>()),
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: {
+      language: "en",
+      changeLanguage: changeLanguageMock,
+      exists: () => false,
+    },
+  }),
+}));
+
+const mockUser: User = {
+  user_id: "u1",
+  email: "test@example.com",
+  org_id: "o1",
+  org_name: "Test Org",
+  role: "owner",
+  permissions: [],
+  language: "ja",
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return {
+    queryClient,
+    Wrapper: function Wrapper({ children }: { children: React.ReactNode }) {
+      return React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        children,
+      );
+    },
+  };
+}
+
+describe("useLanguageSync", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    changeLanguageMock.mockReset();
+  });
+
+  it("calls i18n.changeLanguage with user language when user data arrives", async () => {
+    const { Wrapper } = createWrapper();
+
+    renderHook(() => useLanguageSync(mockUser), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(changeLanguageMock).toHaveBeenCalledWith("ja");
+    });
+  });
+
+  it("does not call i18n.changeLanguage when user has no language field", () => {
+    const { Wrapper } = createWrapper();
+    const userWithoutLanguage: User = { ...mockUser, language: undefined };
+
+    renderHook(() => useLanguageSync(userWithoutLanguage), {
+      wrapper: Wrapper,
+    });
+
+    expect(changeLanguageMock).not.toHaveBeenCalled();
+  });
+
+  it("does not call i18n.changeLanguage when user language matches current language", () => {
+    const { Wrapper } = createWrapper();
+    const sameLanguageUser: User = { ...mockUser, language: "en" };
+
+    renderHook(() => useLanguageSync(sameLanguageUser), { wrapper: Wrapper });
+
+    expect(changeLanguageMock).not.toHaveBeenCalled();
+  });
+
+  it("applies language from storage event and invalidates the me query", () => {
+    const { Wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    renderHook(() => useLanguageSync(undefined), { wrapper: Wrapper });
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: LOCAL_STORAGE_KEYS.I18N_LANGUAGE,
+          newValue: "fr",
+        }),
+      );
+    });
+
+    expect(changeLanguageMock).toHaveBeenCalledWith("fr");
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["user", "me"] }),
+    );
+  });
+
+  it("ignores storage events for unrelated keys", () => {
+    const { Wrapper } = createWrapper();
+
+    renderHook(() => useLanguageSync(undefined), { wrapper: Wrapper });
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "some_other_key",
+          newValue: "de",
+        }),
+      );
+    });
+
+    expect(changeLanguageMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/hooks/use-language-sync.test.ts
+++ b/frontend/src/__tests__/hooks/use-language-sync.test.ts
@@ -16,6 +16,9 @@ vi.mock("react-i18next", async (importOriginal) => ({
       language: "en",
       changeLanguage: changeLanguageMock,
       exists: () => false,
+      options: {
+        supportedLngs: ["en", "ja", "zh-CN", "fr", "de"],
+      },
     },
   }),
 }));
@@ -113,6 +116,23 @@ describe("useLanguageSync", () => {
         new StorageEvent("storage", {
           key: "some_other_key",
           newValue: "de",
+        }),
+      );
+    });
+
+    expect(changeLanguageMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores storage events with unsupported language codes", () => {
+    const { Wrapper } = createWrapper();
+
+    renderHook(() => useLanguageSync(undefined), { wrapper: Wrapper });
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: LOCAL_STORAGE_KEYS.I18N_LANGUAGE,
+          newValue: "invalid-lang-xyz",
         }),
       );
     });

--- a/frontend/src/hooks/use-cross-tab-state.ts
+++ b/frontend/src/hooks/use-cross-tab-state.ts
@@ -2,14 +2,14 @@ import React from "react";
 
 /**
  * Hook that synchronizes state across browser tabs by listening to
- * `storage` events and re-checking on window `focus`.
+ * `storage` events and optionally re-checking on window `focus`.
  *
  * @param onStorageChange - Called when a `storage` event fires.
- * @param onWindowFocus   - Called when the window regains focus.
+ * @param onWindowFocus   - Called when the window regains focus (optional).
  */
 export function useCrossTabState(
   onStorageChange: (event: StorageEvent) => void,
-  onWindowFocus: () => void,
+  onWindowFocus?: () => void,
 ) {
   const storageRef = React.useRef(onStorageChange);
   const focusRef = React.useRef(onWindowFocus);
@@ -27,16 +27,22 @@ export function useCrossTabState(
       storageRef.current(event);
     };
 
-    const handleFocus = () => {
-      focusRef.current();
-    };
+    const handleFocus = focusRef.current
+      ? () => {
+          focusRef.current?.();
+        }
+      : undefined;
 
     window.addEventListener("storage", handleStorage);
-    window.addEventListener("focus", handleFocus);
+    if (handleFocus) {
+      window.addEventListener("focus", handleFocus);
+    }
 
     return () => {
       window.removeEventListener("storage", handleStorage);
-      window.removeEventListener("focus", handleFocus);
+      if (handleFocus) {
+        window.removeEventListener("focus", handleFocus);
+      }
     };
   }, []);
 }

--- a/frontend/src/hooks/use-language-sync.ts
+++ b/frontend/src/hooks/use-language-sync.ts
@@ -1,0 +1,44 @@
+import React from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { useCrossTabState } from "./use-cross-tab-state";
+import { ME_QUERY_KEY } from "./use-me";
+import { LOCAL_STORAGE_KEYS } from "#/utils/local-storage";
+import type { User } from "#/types/user";
+
+/**
+ * Synchronises the active i18n language with:
+ *  1. The language from the user profile (GET /api/v1/users/me).
+ *  2. Changes to the `i18nextLng` localStorage key made in other tabs.
+ *
+ * Priority: API response > localStorage (cross-tab) > browser detection
+ * (browser detection is handled by i18next-browser-languagedetector at init).
+ */
+export function useLanguageSync(user: User | undefined) {
+  const { i18n } = useTranslation();
+  const queryClient = useQueryClient();
+
+  React.useEffect(() => {
+    if (user?.language && user.language !== i18n.language) {
+      i18n.changeLanguage(user.language);
+    }
+  }, [user?.language, i18n]);
+
+  const handleStorageChange = React.useCallback(
+    (event: StorageEvent) => {
+      if (
+        event.key === LOCAL_STORAGE_KEYS.I18N_LANGUAGE &&
+        event.newValue &&
+        event.newValue !== i18n.language
+      ) {
+        i18n.changeLanguage(event.newValue);
+        queryClient.invalidateQueries({ queryKey: ME_QUERY_KEY });
+      }
+    },
+    [i18n, queryClient],
+  );
+
+  const handleWindowFocus = React.useCallback(() => {}, []);
+
+  useCrossTabState(handleStorageChange, handleWindowFocus);
+}

--- a/frontend/src/hooks/use-language-sync.ts
+++ b/frontend/src/hooks/use-language-sync.ts
@@ -18,6 +18,10 @@ export function useLanguageSync(user: User | undefined) {
   const { i18n } = useTranslation();
   const queryClient = useQueryClient();
 
+  // Priority 1: Apply language from API response whenever user data arrives.
+  // If a cross-tab storage event fires before user data loads, the refetch
+  // triggered by invalidateQueries will return the updated language from the
+  // API, so this effect self-corrects any transient mismatch.
   React.useEffect(() => {
     if (user?.language && user.language !== i18n.language) {
       i18n.changeLanguage(user.language);
@@ -31,6 +35,14 @@ export function useLanguageSync(user: User | undefined) {
         event.newValue &&
         event.newValue !== i18n.language
       ) {
+        const { supportedLngs } = i18n.options;
+        if (
+          Array.isArray(supportedLngs) &&
+          !supportedLngs.includes(event.newValue)
+        ) {
+          return;
+        }
+
         i18n.changeLanguage(event.newValue);
         queryClient.invalidateQueries({ queryKey: ME_QUERY_KEY });
       }
@@ -38,7 +50,5 @@ export function useLanguageSync(user: User | undefined) {
     [i18n, queryClient],
   );
 
-  const handleWindowFocus = React.useCallback(() => {}, []);
-
-  useCrossTabState(handleStorageChange, handleWindowFocus);
+  useCrossTabState(handleStorageChange);
 }

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -30,6 +30,9 @@ i18n
     debug: import.meta.env.NODE_ENV === "development",
     supportedLngs: AvailableLanguages.map((lang) => lang.value),
     nonExplicitSupportedLngs: false,
+    backend: {
+      loadPath: "/automations/locales/{{lng}}/{{ns}}.json",
+    },
   });
 
 export default i18n;

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -31,7 +31,7 @@ i18n
     supportedLngs: AvailableLanguages.map((lang) => lang.value),
     nonExplicitSupportedLngs: false,
     backend: {
-      loadPath: "/automations/locales/{{lng}}/{{ns}}.json",
+      loadPath: `${import.meta.env.BASE_URL}locales/{{lng}}/{{ns}}.json`,
     },
   });
 

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -31,7 +31,7 @@ i18n
     supportedLngs: AvailableLanguages.map((lang) => lang.value),
     nonExplicitSupportedLngs: false,
     backend: {
-      loadPath: `${import.meta.env.BASE_URL}locales/{{lng}}/{{ns}}.json`,
+      loadPath: "/automations/locales/{{lng}}/{{ns}}.json",
     },
   });
 

--- a/frontend/src/mocks/auth-handlers.ts
+++ b/frontend/src/mocks/auth-handlers.ts
@@ -14,6 +14,7 @@ export const authHandlers = [
       org_id: "00000000-0000-0000-0000-000000000001",
       org_name: "Acme Corp",
       role: "owner",
+      language: "en",
       permissions: [
         "manage_secrets",
         "manage_mcp",

--- a/frontend/src/routes/root-layout.tsx
+++ b/frontend/src/routes/root-layout.tsx
@@ -4,6 +4,7 @@ import { useIsAuthed } from "#/hooks/use-is-authed";
 import { useMe } from "#/hooks/use-me";
 import { useAutoLogin } from "#/hooks/use-auto-login";
 import { useCrossTabState } from "#/hooks/use-cross-tab-state";
+import { useLanguageSync } from "#/hooks/use-language-sync";
 import { ReauthModal } from "#/components/reauth-modal";
 import { LOCAL_STORAGE_KEYS } from "#/utils/local-storage";
 
@@ -17,8 +18,9 @@ export default function RootLayout() {
     isFetching: isFetchingAuth,
   } = useIsAuthed();
 
-  useMe(isAuthed === true);
+  const { data: user } = useMe(isAuthed === true);
   useAutoLogin();
+  useLanguageSync(user);
 
   const checkLoginMethodExists = React.useCallback(
     () =>

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -5,4 +5,5 @@ export interface User {
   org_name: string;
   role: string;
   permissions: string[];
+  language?: string;
 }

--- a/frontend/src/utils/local-storage.ts
+++ b/frontend/src/utils/local-storage.ts
@@ -1,5 +1,6 @@
 export const LOCAL_STORAGE_KEYS = {
   LOGIN_METHOD: "openhands_login_method",
+  I18N_LANGUAGE: "i18nextLng",
 };
 
 export enum LoginMethod {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig(({ mode }) => {
   const FE_PORT = Number.parseInt(VITE_FRONTEND_PORT, 10);
 
   return {
+    base: "/automations",
     plugins: [
       !process.env.VITEST && reactRouter(),
       viteTsconfigPaths(),

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -90,6 +90,7 @@ class TestAuthentication:
         ]
         assert result.auth_method == AuthMethod.API_KEY
         assert result.api_key == "valid-api-key"
+        assert result.cookie is None
 
     async def test_authenticate_missing_header(self, mock_request, mock_http_client):
         """Missing Authorization header and no cookie raises 401."""
@@ -227,10 +228,6 @@ class TestCookieAuthentication:
 
         assert result.auth_method == AuthMethod.API_KEY
         assert result.api_key == "api-key-value"
-
-        # Verify outbound request used Authorization header
-        call_args = mock_http_client.get.call_args
-        headers = call_args[1]["headers"]
         assert "Authorization" in headers
         assert "Cookie" not in headers
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -90,7 +90,6 @@ class TestAuthentication:
         ]
         assert result.auth_method == AuthMethod.API_KEY
         assert result.api_key == "valid-api-key"
-        assert result.cookie is None
 
     async def test_authenticate_missing_header(self, mock_request, mock_http_client):
         """Missing Authorization header and no cookie raises 401."""
@@ -228,6 +227,10 @@ class TestCookieAuthentication:
 
         assert result.auth_method == AuthMethod.API_KEY
         assert result.api_key == "api-key-value"
+
+        # Verify outbound request used Authorization header
+        call_args = mock_http_client.get.call_args
+        headers = call_args[1]["headers"]
         assert "Authorization" in headers
         assert "Cookie" not in headers
 


### PR DESCRIPTION
Add cross-tab language synchronization so that language changes made in OpenHands are reflected in the Automation UI. The priority chain is: API response (/api/v1/users/me) > localStorage (i18nextLng) > browser detection. A local reverse proxy script enables same-origin testing of cross-tab storage events during development.

## Summary

- Add `useLanguageSync` hook that applies the user's language from the API response on load and listens for cross-tab `i18nextLng` localStorage changes via `storage` events.
- Add `language` field to the `User` type and MSW mock handler to match the `/api/v1/users/me` response shape.
- Set Vite `base: "/automations"` and i18next `loadPath` to align asset and translation loading with the app's base path.
- Add a zero-dependency local reverse proxy (`npm run dev:proxy`) that serves both frontends under a single origin for cross-tab testing.

## Demo Video/Screenshot

https://github.com/user-attachments/assets/91ee6c0a-28a0-4ddc-8d31-e72a8dca0c06