### PR TITLE
feat(frontend): broadcast organization selection to localStorage

### DIFF
--- a/frontend/src/__tests__/hooks/use-org-sync.test.ts
+++ b/frontend/src/__tests__/hooks/use-org-sync.test.ts
@@ -1,0 +1,129 @@
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import { useOrgSync } from "#/hooks/use-org-sync";
+import { LOCAL_STORAGE_KEYS } from "#/utils/local-storage";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return {
+    queryClient,
+    Wrapper: function Wrapper({ children }: { children: React.ReactNode }) {
+      return React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        children,
+      );
+    },
+  };
+}
+
+describe("useOrgSync", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it("invalidates all queries on storage event with different org", () => {
+    const { Wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    renderHook(() => useOrgSync("o1"), { wrapper: Wrapper });
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: LOCAL_STORAGE_KEYS.SELECTED_ORG,
+          newValue: "o2",
+        }),
+      );
+    });
+
+    expect(invalidateSpy).toHaveBeenCalled();
+  });
+
+  it("does not invalidate when storage event has same org as current", () => {
+    const { Wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    renderHook(() => useOrgSync("o1"), { wrapper: Wrapper });
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: LOCAL_STORAGE_KEYS.SELECTED_ORG,
+          newValue: "o1",
+        }),
+      );
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not invalidate for unrelated storage keys", () => {
+    const { Wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    renderHook(() => useOrgSync("o1"), { wrapper: Wrapper });
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "some_other_key",
+          newValue: "o2",
+        }),
+      );
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not invalidate when newValue is null", () => {
+    const { Wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    renderHook(() => useOrgSync("o1"), { wrapper: Wrapper });
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: LOCAL_STORAGE_KEYS.SELECTED_ORG,
+          newValue: null,
+        }),
+      );
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("invalidates on window focus when stored org differs from current", () => {
+    const { Wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    localStorage.setItem(LOCAL_STORAGE_KEYS.SELECTED_ORG, "o2");
+
+    renderHook(() => useOrgSync("o1"), { wrapper: Wrapper });
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(invalidateSpy).toHaveBeenCalled();
+  });
+
+  it("does not invalidate on window focus when stored org matches current", () => {
+    const { Wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    localStorage.setItem(LOCAL_STORAGE_KEYS.SELECTED_ORG, "o1");
+
+    renderHook(() => useOrgSync("o1"), { wrapper: Wrapper });
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/hooks/use-theme-sync.test.ts
+++ b/frontend/src/__tests__/hooks/use-theme-sync.test.ts
@@ -1,0 +1,114 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useThemeSync } from "#/hooks/use-theme-sync";
+import { LOCAL_STORAGE_KEYS } from "#/utils/local-storage";
+
+describe("useThemeSync", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    document.documentElement.className = "";
+  });
+
+  it("adds dark class on mount when no theme key in localStorage", () => {
+    renderHook(() => useThemeSync());
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("adds dark class on mount when localStorage value is dark", () => {
+    localStorage.setItem(LOCAL_STORAGE_KEYS.THEME, "dark");
+
+    renderHook(() => useThemeSync());
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("removes dark class on mount when localStorage value is light", () => {
+    document.documentElement.classList.add("dark");
+    localStorage.setItem(LOCAL_STORAGE_KEYS.THEME, "light");
+
+    renderHook(() => useThemeSync());
+
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("removes dark class on storage event with light value", () => {
+    document.documentElement.classList.add("dark");
+
+    renderHook(() => useThemeSync());
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: LOCAL_STORAGE_KEYS.THEME,
+          newValue: "light",
+        }),
+      );
+    });
+
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("adds dark class on storage event with dark value", () => {
+    renderHook(() => useThemeSync());
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: LOCAL_STORAGE_KEYS.THEME,
+          newValue: "dark",
+        }),
+      );
+    });
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("defaults to dark on storage event with null value", () => {
+    document.documentElement.className = "";
+
+    renderHook(() => useThemeSync());
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: LOCAL_STORAGE_KEYS.THEME,
+          newValue: null,
+        }),
+      );
+    });
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("ignores storage events for unrelated keys", () => {
+    document.documentElement.classList.add("dark");
+
+    renderHook(() => useThemeSync());
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "some_other_key",
+          newValue: "light",
+        }),
+      );
+    });
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("re-reads localStorage on window focus", () => {
+    document.documentElement.classList.add("dark");
+    localStorage.setItem(LOCAL_STORAGE_KEYS.THEME, "light");
+
+    renderHook(() => useThemeSync());
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/routes/root-layout.test.tsx
+++ b/frontend/src/__tests__/routes/root-layout.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
@@ -101,6 +101,49 @@ describe("RootLayout", () => {
     await waitFor(() => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
       expect(screen.getByText("AUTH$LOGGING_BACK_IN")).toBeInTheDocument();
+    });
+  });
+
+  it("redirects to login when login method is removed via cross-tab storage event", async () => {
+    const hrefSetter = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: {
+        ...window.location,
+        pathname: "/automations",
+        get href() {
+          return "http://localhost/automations";
+        },
+        set href(url: string) {
+          hrefSetter(url);
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    localStorage.setItem(LOCAL_STORAGE_KEYS.LOGIN_METHOD, "github");
+
+    vi.spyOn(OpenHandsService, "authenticate").mockResolvedValue(true);
+    vi.spyOn(OpenHandsService, "getMe").mockResolvedValue(mockUser);
+
+    renderLayout();
+
+    await waitFor(() => {
+      expect(screen.getByRole("main")).toBeInTheDocument();
+    });
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: LOCAL_STORAGE_KEYS.LOGIN_METHOD,
+          newValue: null,
+          oldValue: "github",
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(hrefSetter).toHaveBeenCalledWith("/login?redirect=%2Fautomations");
     });
   });
 

--- a/frontend/src/__tests__/utils/local-storage.test.ts
+++ b/frontend/src/__tests__/utils/local-storage.test.ts
@@ -5,6 +5,8 @@ import {
   clearLoginData,
   LoginMethod,
   LOCAL_STORAGE_KEYS,
+  getSelectedOrg,
+  getTheme,
 } from "#/utils/local-storage";
 
 describe("local-storage", () => {
@@ -30,5 +32,29 @@ describe("local-storage", () => {
     clearLoginData();
 
     expect(getLoginMethod()).toBeNull();
+  });
+
+  describe("getSelectedOrg", () => {
+    it("returns null when no org is stored", () => {
+      expect(getSelectedOrg()).toBeNull();
+    });
+
+    it("returns stored org id", () => {
+      localStorage.setItem(LOCAL_STORAGE_KEYS.SELECTED_ORG, "org-123");
+
+      expect(getSelectedOrg()).toBe("org-123");
+    });
+  });
+
+  describe("getTheme", () => {
+    it("returns null when no theme is stored", () => {
+      expect(getTheme()).toBeNull();
+    });
+
+    it("returns stored theme value", () => {
+      localStorage.setItem(LOCAL_STORAGE_KEYS.THEME, "light");
+
+      expect(getTheme()).toBe("light");
+    });
   });
 });

--- a/frontend/src/hooks/use-org-sync.ts
+++ b/frontend/src/hooks/use-org-sync.ts
@@ -1,0 +1,37 @@
+import React from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCrossTabState } from "./use-cross-tab-state";
+import { LOCAL_STORAGE_KEYS, getSelectedOrg } from "#/utils/local-storage";
+
+/**
+ * Synchronises the active organization across browser tabs by listening to
+ * changes on the `openhands_selected_org` localStorage key.
+ *
+ * When the org changes (via storage event or window focus), all React Query
+ * caches are invalidated so automation data re-fetches under the new org.
+ */
+export function useOrgSync(currentOrgId: string | undefined) {
+  const queryClient = useQueryClient();
+
+  const handleStorageChange = React.useCallback(
+    (event: StorageEvent) => {
+      if (
+        event.key === LOCAL_STORAGE_KEYS.SELECTED_ORG &&
+        event.newValue !== null &&
+        event.newValue !== currentOrgId
+      ) {
+        queryClient.invalidateQueries();
+      }
+    },
+    [currentOrgId, queryClient],
+  );
+
+  const handleWindowFocus = React.useCallback(() => {
+    const storedOrg = getSelectedOrg();
+    if (storedOrg && storedOrg !== currentOrgId) {
+      queryClient.invalidateQueries();
+    }
+  }, [currentOrgId, queryClient]);
+
+  useCrossTabState(handleStorageChange, handleWindowFocus);
+}

--- a/frontend/src/hooks/use-org-sync.ts
+++ b/frontend/src/hooks/use-org-sync.ts
@@ -20,6 +20,8 @@ export function useOrgSync(currentOrgId: string | undefined) {
         event.newValue !== null &&
         event.newValue !== currentOrgId
       ) {
+        // Invalidate all queries — all automation data is org-scoped, so
+        // every cached response is stale after an org switch.
         queryClient.invalidateQueries();
       }
     },
@@ -29,6 +31,7 @@ export function useOrgSync(currentOrgId: string | undefined) {
   const handleWindowFocus = React.useCallback(() => {
     const storedOrg = getSelectedOrg();
     if (storedOrg && storedOrg !== currentOrgId) {
+      // See comment above — full invalidation is intentional.
       queryClient.invalidateQueries();
     }
   }, [currentOrgId, queryClient]);

--- a/frontend/src/hooks/use-theme-sync.ts
+++ b/frontend/src/hooks/use-theme-sync.ts
@@ -13,6 +13,7 @@ export function useThemeSync() {
     if (theme === "light") {
       document.documentElement.classList.remove("dark");
     } else {
+      // Default to dark theme when no preference is stored
       document.documentElement.classList.add("dark");
     }
   }, []);

--- a/frontend/src/hooks/use-theme-sync.ts
+++ b/frontend/src/hooks/use-theme-sync.ts
@@ -1,0 +1,38 @@
+import React from "react";
+import { useCrossTabState } from "./use-cross-tab-state";
+import { LOCAL_STORAGE_KEYS, getTheme } from "#/utils/local-storage";
+import type { Theme } from "#/utils/local-storage";
+
+/**
+ * Synchronises the dark/light theme across browser tabs by reading the
+ * `openhands_theme` localStorage key and toggling the `dark` CSS class
+ * on `<html>`. Defaults to dark when no preference is stored.
+ */
+export function useThemeSync() {
+  const applyTheme = React.useCallback((theme: Theme | null) => {
+    if (theme === "light") {
+      document.documentElement.classList.remove("dark");
+    } else {
+      document.documentElement.classList.add("dark");
+    }
+  }, []);
+
+  React.useEffect(() => {
+    applyTheme(getTheme());
+  }, [applyTheme]);
+
+  const handleStorageChange = React.useCallback(
+    (event: StorageEvent) => {
+      if (event.key === LOCAL_STORAGE_KEYS.THEME) {
+        applyTheme(event.newValue as Theme | null);
+      }
+    },
+    [applyTheme],
+  );
+
+  const handleWindowFocus = React.useCallback(() => {
+    applyTheme(getTheme());
+  }, [applyTheme]);
+
+  useCrossTabState(handleStorageChange, handleWindowFocus);
+}

--- a/frontend/src/routes/root-layout.tsx
+++ b/frontend/src/routes/root-layout.tsx
@@ -5,6 +5,8 @@ import { useMe } from "#/hooks/use-me";
 import { useAutoLogin } from "#/hooks/use-auto-login";
 import { useCrossTabState } from "#/hooks/use-cross-tab-state";
 import { useLanguageSync } from "#/hooks/use-language-sync";
+import { useOrgSync } from "#/hooks/use-org-sync";
+import { useThemeSync } from "#/hooks/use-theme-sync";
 import { ReauthModal } from "#/components/reauth-modal";
 import { LOCAL_STORAGE_KEYS } from "#/utils/local-storage";
 
@@ -21,6 +23,8 @@ export default function RootLayout() {
   const { data: user } = useMe(isAuthed === true);
   useAutoLogin();
   useLanguageSync(user);
+  useOrgSync(user?.org_id);
+  useThemeSync();
 
   const checkLoginMethodExists = React.useCallback(
     () =>

--- a/frontend/src/routes/root-layout.tsx
+++ b/frontend/src/routes/root-layout.tsx
@@ -40,6 +40,11 @@ export default function RootLayout() {
   const handleStorageChange = React.useCallback(
     (event: StorageEvent) => {
       if (event.key === LOCAL_STORAGE_KEYS.LOGIN_METHOD) {
+        if (event.newValue === null) {
+          const redirectUrl = encodeURIComponent(window.location.pathname);
+          window.location.href = `/login?redirect=${redirectUrl}`;
+          return;
+        }
         setLoginMethodExists(checkLoginMethodExists());
       }
     },

--- a/frontend/src/utils/local-storage.ts
+++ b/frontend/src/utils/local-storage.ts
@@ -1,6 +1,8 @@
 export const LOCAL_STORAGE_KEYS = {
   LOGIN_METHOD: "openhands_login_method",
   I18N_LANGUAGE: "i18nextLng",
+  SELECTED_ORG: "openhands_selected_org",
+  THEME: "openhands_theme",
 };
 
 export enum LoginMethod {
@@ -24,3 +26,11 @@ export const getLoginMethod = (): LoginMethod | null => {
 export const clearLoginData = (): void => {
   localStorage.removeItem(LOCAL_STORAGE_KEYS.LOGIN_METHOD);
 };
+
+export const getSelectedOrg = (): string | null =>
+  localStorage.getItem(LOCAL_STORAGE_KEYS.SELECTED_ORG);
+
+export type Theme = "dark" | "light";
+
+export const getTheme = (): Theme | null =>
+  localStorage.getItem(LOCAL_STORAGE_KEYS.THEME) as Theme | null;


### PR DESCRIPTION
Write the selected org ID to localStorage when switching or auto-selecting an organization, enabling cross-app synchronization with the Automations frontend on the same domain.

## Summary

- Add cross-tab organization sync: listen for `openhands_selected_org` localStorage changes and invalidate all React Query caches to re-fetch automation data under the new org context.
- Add cross-tab logout detection: immediately redirect to login when `openhands_login_method` is removed in another tab (e.g. user logs out in OpenHands).
- Add cross-tab theme sync: read `openhands_theme` from localStorage and toggle the `dark` CSS class on `<html>`, defaulting to dark when absent.
- Broadcast org selection from OpenHands to localStorage in both `useSwitchOrganization` (explicit switch) and `useAutoSelectOrganization` (initial load).

## Demo Video/Screenshot


https://github.com/user-attachments/assets/df841cf5-4b0c-4ea1-b270-3cceef49b468

