### PR TITLE
feat(frontend): add permission-based UI gating for automation actions

### DIFF
--- a/frontend/src/__tests__/components/automations/automation-card.test.tsx
+++ b/frontend/src/__tests__/components/automations/automation-card.test.tsx
@@ -1,9 +1,20 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { vi, describe, it, expect } from "vitest";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { MemoryRouter } from "react-router";
 import { AutomationCard } from "#/components/automations/automation-card";
+import { useUserStore } from "#/stores/user-store";
 import type { Automation } from "#/types/automation";
+import type { User } from "#/types/user";
+
+const mockUser: User = {
+  user_id: "u1",
+  email: "test@example.com",
+  org_id: "o1",
+  org_name: "Test Org",
+  role: "owner",
+  permissions: ["manage_secrets"],
+};
 
 const mockNavigate = vi.fn();
 vi.mock("react-router", async (importOriginal) => ({
@@ -40,6 +51,13 @@ function renderCard(
 }
 
 describe("AutomationCard", () => {
+  beforeEach(() => {
+    useUserStore.setState({ user: mockUser, isInitialized: true });
+  });
+
+  afterEach(() => {
+    useUserStore.setState({ user: null, isInitialized: false });
+  });
   it("renders automation name, description, and metadata chips", () => {
     renderCard();
 
@@ -94,5 +112,12 @@ describe("AutomationCard", () => {
     renderCard(automation);
 
     expect(screen.getByText("cron")).toBeInTheDocument();
+  });
+
+  it("shows toggle and kebab with baseline permissions", () => {
+    renderCard();
+
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    expect(screen.getByLabelText("Automation actions")).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/components/automations/detail/detail-header.test.tsx
+++ b/frontend/src/__tests__/components/automations/detail/detail-header.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
-import { vi, describe, it, expect } from "vitest";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { Automation } from "#/types/automation";
+import type { User } from "#/types/user";
+import { useUserStore } from "#/stores/user-store";
 import { DetailHeader } from "#/components/automations/detail/detail-header";
 
 const mockAutomation: Automation = {
@@ -17,7 +19,23 @@ const mockAutomation: Automation = {
   updated_at: "2026-03-23T09:00:00Z",
 };
 
+const mockUser: User = {
+  user_id: "u1",
+  email: "test@example.com",
+  org_id: "o1",
+  org_name: "Test Org",
+  role: "owner",
+  permissions: ["manage_secrets"],
+};
+
 describe("DetailHeader", () => {
+  beforeEach(() => {
+    useUserStore.setState({ user: mockUser, isInitialized: true });
+  });
+
+  afterEach(() => {
+    useUserStore.setState({ user: null, isInitialized: false });
+  });
   it("renders automation name and description", () => {
     render(
       <MemoryRouter>
@@ -84,5 +102,20 @@ describe("DetailHeader", () => {
     await user.click(screen.getByLabelText("Automation actions"));
     await user.click(screen.getByText("AUTOMATIONS$DELETE"));
     expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows toggle and kebab with baseline permissions", () => {
+    render(
+      <MemoryRouter>
+        <DetailHeader
+          automation={mockAutomation}
+          onToggle={vi.fn()}
+          onDelete={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    expect(screen.getByLabelText("Automation actions")).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/components/automations/permission-gating.test.tsx
+++ b/frontend/src/__tests__/components/automations/permission-gating.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { MemoryRouter } from "react-router";
+import { useUserStore } from "#/stores/user-store";
+import type { Automation } from "#/types/automation";
+import type { User } from "#/types/user";
+
+vi.mock("react-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-router")>()),
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("#/utils/permissions", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("#/utils/permissions")>()),
+  ENFORCED_PERMISSIONS: new Set(["manage_automations"]),
+}));
+
+const mockAutomation: Automation = {
+  id: "1",
+  name: "PR Triage Digest",
+  description: "Summarize new pull requests.",
+  trigger: { type: "cron", schedule_human: "Weekdays at 09:00" },
+  enabled: true,
+  repository: "acme/frontend-app",
+  model: "Claude Opus",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-03-01T00:00:00Z",
+};
+
+const baseUser: User = {
+  user_id: "u1",
+  email: "test@example.com",
+  org_id: "o1",
+  org_name: "Test Org",
+  role: "member",
+  permissions: [],
+};
+
+describe("Permission gating when manage_automations is enforced", () => {
+  afterEach(() => {
+    useUserStore.setState({ user: null, isInitialized: false });
+  });
+
+  describe("AutomationCard", () => {
+    let AutomationCard: typeof import("#/components/automations/automation-card").AutomationCard;
+
+    beforeEach(async () => {
+      ({ AutomationCard } =
+        await import("#/components/automations/automation-card"));
+    });
+
+    it("hides toggle and kebab when user lacks manage_automations", () => {
+      useUserStore.setState({ user: baseUser, isInitialized: true });
+
+      render(
+        <MemoryRouter>
+          <AutomationCard
+            automation={mockAutomation}
+            onToggle={vi.fn()}
+            onDelete={vi.fn()}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Automation actions"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows toggle and kebab when user has manage_automations", () => {
+      const userWithPerm: User = {
+        ...baseUser,
+        permissions: ["manage_automations"],
+      };
+      useUserStore.setState({ user: userWithPerm, isInitialized: true });
+
+      render(
+        <MemoryRouter>
+          <AutomationCard
+            automation={mockAutomation}
+            onToggle={vi.fn()}
+            onDelete={vi.fn()}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(screen.getByRole("switch")).toBeInTheDocument();
+      expect(screen.getByLabelText("Automation actions")).toBeInTheDocument();
+    });
+  });
+
+  describe("DetailHeader", () => {
+    let DetailHeader: typeof import("#/components/automations/detail/detail-header").DetailHeader;
+
+    beforeEach(async () => {
+      ({ DetailHeader } =
+        await import("#/components/automations/detail/detail-header"));
+    });
+
+    it("hides toggle and kebab when user lacks manage_automations", () => {
+      useUserStore.setState({ user: baseUser, isInitialized: true });
+
+      render(
+        <MemoryRouter>
+          <DetailHeader
+            automation={mockAutomation}
+            onToggle={vi.fn()}
+            onDelete={vi.fn()}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Automation actions"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows toggle and kebab when user has manage_automations", () => {
+      const userWithPerm: User = {
+        ...baseUser,
+        permissions: ["manage_automations"],
+      };
+      useUserStore.setState({ user: userWithPerm, isInitialized: true });
+
+      render(
+        <MemoryRouter>
+          <DetailHeader
+            automation={mockAutomation}
+            onToggle={vi.fn()}
+            onDelete={vi.fn()}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(screen.getByRole("switch")).toBeInTheDocument();
+      expect(screen.getByLabelText("Automation actions")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/__tests__/hooks/use-has-permission.test.ts
+++ b/frontend/src/__tests__/hooks/use-has-permission.test.ts
@@ -1,0 +1,75 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useUserStore } from "#/stores/user-store";
+import type { User } from "#/types/user";
+
+const mockUser: User = {
+  user_id: "u1",
+  email: "test@example.com",
+  org_id: "o1",
+  org_name: "Test Org",
+  role: "owner",
+  permissions: ["manage_secrets"],
+};
+
+describe("useHasPermission", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useUserStore.setState({ user: null, isInitialized: false });
+  });
+
+  describe("when permission is not enforced (baseline)", () => {
+    it("returns false when user is not authenticated", async () => {
+      const { useHasPermission } = await import("#/hooks/use-has-permission");
+      const { result } = renderHook(() =>
+        useHasPermission("manage_automations"),
+      );
+      expect(result.current).toBe(false);
+    });
+
+    it("returns true when user is authenticated", async () => {
+      useUserStore.setState({ user: mockUser, isInitialized: true });
+      const { useHasPermission } = await import("#/hooks/use-has-permission");
+      const { result } = renderHook(() =>
+        useHasPermission("manage_automations"),
+      );
+      expect(result.current).toBe(true);
+    });
+  });
+
+  describe("when permission is enforced", () => {
+    beforeEach(() => {
+      vi.resetModules();
+      vi.doMock("#/utils/permissions", () => ({
+        ENFORCED_PERMISSIONS: new Set(["manage_automations"]),
+      }));
+    });
+
+    it("returns true when user has the permission", async () => {
+      const userWithPermission: User = {
+        ...mockUser,
+        permissions: ["manage_automations"],
+      };
+
+      const { useUserStore: freshStore } = await import("#/stores/user-store");
+      freshStore.setState({ user: userWithPermission, isInitialized: true });
+
+      const { useHasPermission } = await import("#/hooks/use-has-permission");
+      const { result } = renderHook(() =>
+        useHasPermission("manage_automations"),
+      );
+      expect(result.current).toBe(true);
+    });
+
+    it("returns false when user lacks the permission", async () => {
+      const { useUserStore: freshStore } = await import("#/stores/user-store");
+      freshStore.setState({ user: mockUser, isInitialized: true });
+
+      const { useHasPermission } = await import("#/hooks/use-has-permission");
+      const { result } = renderHook(() =>
+        useHasPermission("manage_automations"),
+      );
+      expect(result.current).toBe(false);
+    });
+  });
+});

--- a/frontend/src/__tests__/routes/automation-detail.test.tsx
+++ b/frontend/src/__tests__/routes/automation-detail.test.tsx
@@ -2,9 +2,10 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Routes, Route } from "react-router";
-import { vi, describe, it, expect, beforeEach } from "vitest";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { AxiosError } from "axios";
 import AutomationService from "#/api/automation-service";
+import { useUserStore } from "#/stores/user-store";
 import type { Automation, AutomationRunsResponse } from "#/types/automation";
 import AutomationDetail from "#/routes/automation-detail";
 
@@ -75,8 +76,23 @@ describe("AutomationDetail", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    useUserStore.setState({
+      user: {
+        user_id: "u1",
+        email: "test@example.com",
+        org_id: "o1",
+        org_name: "Test Org",
+        role: "owner",
+        permissions: ["manage_secrets"],
+      },
+      isInitialized: true,
+    });
     getAutomationSpy = vi.spyOn(AutomationService, "getAutomation");
     getRunsSpy = vi.spyOn(AutomationService, "getAutomationRuns");
+  });
+
+  afterEach(() => {
+    useUserStore.setState({ user: null, isInitialized: false });
   });
 
   it("shows loading skeleton while fetching", () => {

--- a/frontend/src/__tests__/routes/automations-list.test.tsx
+++ b/frontend/src/__tests__/routes/automations-list.test.tsx
@@ -2,8 +2,9 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
-import { vi, describe, it, expect, beforeEach } from "vitest";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import AutomationService from "#/api/automation-service";
+import { useUserStore } from "#/stores/user-store";
 import type { AutomationsResponse } from "#/types/automation";
 import AutomationsList from "#/routes/automations-list";
 
@@ -75,7 +76,22 @@ describe("AutomationsList", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    useUserStore.setState({
+      user: {
+        user_id: "u1",
+        email: "test@example.com",
+        org_id: "o1",
+        org_name: "Test Org",
+        role: "owner",
+        permissions: ["manage_secrets"],
+      },
+      isInitialized: true,
+    });
     getAutomationsSpy = vi.spyOn(AutomationService, "getAutomations");
+  });
+
+  afterEach(() => {
+    useUserStore.setState({ user: null, isInitialized: false });
   });
 
   it("shows loading skeletons while data is being fetched", () => {

--- a/frontend/src/components/automations/automation-card.tsx
+++ b/frontend/src/components/automations/automation-card.tsx
@@ -6,6 +6,7 @@ import { ToggleSwitch } from "./toggle-switch";
 import { MetadataChip } from "./metadata-chip";
 import { KebabMenu } from "./kebab-menu";
 import type { KebabMenuItem } from "./kebab-menu";
+import { useHasPermission } from "#/hooks/use-has-permission";
 import FolderIcon from "#/icons/folder.svg?react";
 import ClockIcon from "#/icons/clock.svg?react";
 import SparkleIcon from "#/icons/sparkle.svg?react";
@@ -25,6 +26,7 @@ export function AutomationCard({
 }: AutomationCardProps) {
   const navigate = useNavigate();
   const { t } = useTranslation();
+  const canManage = useHasPermission("manage_automations");
 
   const scheduleLabel =
     automation.trigger.schedule_human || automation.trigger.type;
@@ -66,12 +68,14 @@ export function AutomationCard({
         </div>
 
         <div className="ml-4 flex shrink-0 items-center gap-2">
-          <ToggleSwitch
-            enabled={automation.enabled}
-            label={`Toggle ${automation.name}`}
-            onToggle={() => onToggle(automation.id, automation.enabled)}
-          />
-          <KebabMenu items={menuItems} />
+          {canManage && (
+            <ToggleSwitch
+              enabled={automation.enabled}
+              label={`Toggle ${automation.name}`}
+              onToggle={() => onToggle(automation.id, automation.enabled)}
+            />
+          )}
+          {canManage && <KebabMenu items={menuItems} />}
         </div>
       </div>
 

--- a/frontend/src/components/automations/detail/detail-header.tsx
+++ b/frontend/src/components/automations/detail/detail-header.tsx
@@ -5,6 +5,7 @@ import { ToggleSwitch } from "#/components/automations/toggle-switch";
 import { KebabMenu } from "#/components/automations/kebab-menu";
 import PowerIcon from "#/icons/power.svg?react";
 import TrashIcon from "#/icons/trash.svg?react";
+import { useHasPermission } from "#/hooks/use-has-permission";
 import { ActiveStatusBadge } from "./active-status-badge";
 
 interface DetailHeaderProps {
@@ -19,6 +20,7 @@ export function DetailHeader({
   onDelete,
 }: DetailHeaderProps) {
   const { t } = useTranslation();
+  const canManage = useHasPermission("manage_automations");
 
   const kebabItems = [
     {
@@ -46,16 +48,18 @@ export function DetailHeader({
           <ActiveStatusBadge active={automation.enabled} />
         </div>
         <div className="flex items-center gap-2">
-          <ToggleSwitch
-            enabled={automation.enabled}
-            label={
-              automation.enabled
-                ? t(I18nKey.AUTOMATIONS$TURN_OFF)
-                : t(I18nKey.AUTOMATIONS$TURN_ON)
-            }
-            onToggle={onToggle}
-          />
-          <KebabMenu items={kebabItems} />
+          {canManage && (
+            <ToggleSwitch
+              enabled={automation.enabled}
+              label={
+                automation.enabled
+                  ? t(I18nKey.AUTOMATIONS$TURN_OFF)
+                  : t(I18nKey.AUTOMATIONS$TURN_ON)
+              }
+              onToggle={onToggle}
+            />
+          )}
+          {canManage && <KebabMenu items={kebabItems} />}
         </div>
       </div>
       <p className="text-sm text-content-muted">{automation.description}</p>

--- a/frontend/src/hooks/use-has-permission.ts
+++ b/frontend/src/hooks/use-has-permission.ts
@@ -1,0 +1,9 @@
+import { useUserStore } from "#/stores/user-store";
+import { type PermissionKey, ENFORCED_PERMISSIONS } from "#/utils/permissions";
+
+export function useHasPermission(permission: PermissionKey): boolean {
+  const user = useUserStore((state) => state.user);
+  if (!user) return false;
+  if (!ENFORCED_PERMISSIONS.has(permission)) return true;
+  return user.permissions.includes(permission);
+}

--- a/frontend/src/utils/permissions.ts
+++ b/frontend/src/utils/permissions.ts
@@ -1,0 +1,8 @@
+export type PermissionKey = "manage_automations";
+
+// Permissions actively enforced by the UI.
+// Empty = all authenticated users have full access (baseline).
+// Add "manage_automations" here when backend begins sending it.
+export const ENFORCED_PERMISSIONS: ReadonlySet<PermissionKey> = new Set([
+  "manage_automations",
+]);


### PR DESCRIPTION
Gate toggle, delete, and context menu controls behind useHasPermission hook that reads from the Zustand user store. Uses an ENFORCED_PERMISSIONS set to control when permissions are actively checked — currently enforcing manage_automations so UI elements are hidden when the permission is missing.

## Summary

- Add useHasPermission hook and permissions.ts utility for permission-based conditional rendering of automation UI controls.
- Gate toggle switches, delete actions, and kebab menus in AutomationCard and DetailHeader behind manage_automations permission.
- Follow the same structural pattern as OpenHands' permissions.ts + usePermission hook, adapted for the Automation frontend's API-provided permissions array.