### PR TITLE
fix(frontend): read last_triggered_at from API so Last Run shows real time

### DIFF
--- a/frontend/src/__tests__/routes/automation-detail.test.tsx
+++ b/frontend/src/__tests__/routes/automation-detail.test.tsx
@@ -53,7 +53,7 @@ const mockAutomation: Automation = {
   plugins: ["GitHub", "Slack"],
   notification: "Slack digest to #eng-reviews",
   timezone: "America/Los_Angeles",
-  last_run_at: "2026-03-23T09:00:00Z",
+  last_triggered_at: "2026-03-23T09:00:00Z",
 };
 
 const mockRuns: AutomationRunsResponse = {
@@ -139,6 +139,24 @@ describe("AutomationDetail", () => {
     expect(
       screen.getByText("AUTOMATIONS$DETAIL$BACK_TO_LIST"),
     ).toBeInTheDocument();
+  });
+
+  it("renders the last-triggered time (not 'Never') when API returns last_triggered_at", async () => {
+    const recentIso = new Date(Date.now() - 5 * 60_000).toISOString();
+    getAutomationSpy.mockResolvedValue({
+      ...mockAutomation,
+      last_triggered_at: recentIso,
+    });
+    getRunsSpy.mockResolvedValue(mockRuns);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("PR Triage Digest")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText("AUTOMATIONS$DETAIL$TIME_NEVER"),
+    ).not.toBeInTheDocument();
   });
 
   it("does not render prompt section when prompt is absent", async () => {

--- a/frontend/src/mocks/automations.mock.ts
+++ b/frontend/src/mocks/automations.mock.ts
@@ -36,7 +36,7 @@ export const MOCK_AUTOMATIONS_RESPONSE: AutomationsResponse = {
       plugins: ["GitHub", "Slack", "Linear"],
       notification: "Slack digest to #eng-reviews",
       timezone: "America/Los_Angeles",
-      last_run_at: daysAgo(0),
+      last_triggered_at: daysAgo(0),
     },
     {
       id: "a1000000-0000-0000-0000-000000000002",
@@ -57,7 +57,7 @@ export const MOCK_AUTOMATIONS_RESPONSE: AutomationsResponse = {
       plugins: ["GitHub"],
       notification: "Email to security-team@acme.com",
       timezone: "UTC",
-      last_run_at: daysAgo(0),
+      last_triggered_at: daysAgo(0),
     },
     {
       id: "a1000000-0000-0000-0000-000000000003",
@@ -78,7 +78,7 @@ export const MOCK_AUTOMATIONS_RESPONSE: AutomationsResponse = {
       plugins: ["GitHub", "Slack"],
       notification: "Slack to #docs-updates",
       timezone: "America/New_York",
-      last_run_at: daysAgo(1),
+      last_triggered_at: daysAgo(1),
     },
     {
       id: "a1000000-0000-0000-0000-000000000004",
@@ -99,7 +99,7 @@ export const MOCK_AUTOMATIONS_RESPONSE: AutomationsResponse = {
       plugins: ["GitHub", "Linear"],
       notification: "Slack to #releases",
       timezone: "America/Chicago",
-      last_run_at: daysAgo(14),
+      last_triggered_at: daysAgo(14),
     },
     {
       id: "a1000000-0000-0000-0000-000000000005",
@@ -120,7 +120,7 @@ export const MOCK_AUTOMATIONS_RESPONSE: AutomationsResponse = {
       plugins: ["Slack"],
       notification: "Slack to #oncall",
       timezone: "UTC",
-      last_run_at: null,
+      last_triggered_at: null,
     },
   ],
   total: 5,

--- a/frontend/src/routes/automation-detail.tsx
+++ b/frontend/src/routes/automation-detail.tsx
@@ -79,7 +79,7 @@ export default function AutomationDetail() {
       )}
       <ActivitySection
         createdAt={automation.created_at}
-        lastRunAt={automation.last_run_at}
+        lastRunAt={automation.last_triggered_at}
       />
       <ActivityLogSection automationId={automation.id} />
       <DeleteConfirmationModal

--- a/frontend/src/types/automation.ts
+++ b/frontend/src/types/automation.ts
@@ -18,7 +18,7 @@ export interface Automation {
   plugins?: string[];
   notification?: string;
   timezone?: string;
-  last_run_at?: string | null;
+  last_triggered_at?: string | null;
 }
 
 export interface AutomationsResponse {


### PR DESCRIPTION
## Summary

- Fix a bug where the **Last Run** field on the Automation Details page always rendered as **"Never"** when using the real API.
- Root cause: the frontend read `automation.last_run_at`, but the backend (DB + Pydantic schema) returns `last_triggered_at`. The field was always `undefined`, triggering the "Never" fallback.
- Aligned the frontend with the backend contract — renamed the frontend field and updated mocks, tests, and the detail page.