### PR TITLE
chore: rename ALLHANDS_BOT_GITHUB_PAT to PAT_TOKEN

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -112,4 +112,4 @@ jobs:
             head_sha: ${{ github.event.pull_request.head.sha }}
             pr_title: ${{ github.event.pull_request.title }}
         secrets:
-            ALLHANDS_BOT_GITHUB_PAT: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+            PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -44,5 +44,5 @@ jobs:
                   llm-base-url: https://llm-proxy.app.all-hands.dev
                   review-style: roasted
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  github-token: ${{ secrets.PAT_TOKEN }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/.github/workflows/trigger-deploy-preview.yml
+++ b/.github/workflows/trigger-deploy-preview.yml
@@ -19,7 +19,7 @@ on:
                 required: true
                 type: string
         secrets:
-            ALLHANDS_BOT_GITHUB_PAT:
+            PAT_TOKEN:
                 required: true
 
 concurrency:
@@ -43,7 +43,7 @@ jobs:
               with:
                   repository: ${{ env.DEPLOY_REPO }}
                   ref: ${{ env.BASE_BRANCH }}
-                  token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  token: ${{ secrets.PAT_TOKEN }}
                   fetch-depth: 0
                   path: deploy-repo
 
@@ -122,7 +122,7 @@ jobs:
             - name: Create or get deploy PR
               id: manage-pr
               env:
-                  GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  GH_TOKEN: ${{ secrets.PAT_TOKEN }}
                   BRANCH_NAME: ${{ steps.deploy-pr.outputs.branch_name }}
                   PR_TITLE: ${{ inputs.pr_title }}
               run: |


### PR DESCRIPTION
## Summary

Renames \`ALLHANDS_BOT_GITHUB_PAT\` → \`PAT_TOKEN\` in workflow files to standardise on the org-wide \`PAT_TOKEN\` secret name.

This is a mechanical rename only — no behaviour changes. Part of OpenHands/evaluation#428 (PAT_TOKEN blast radius reduction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)