### PR TITLE
chore: use OPENHANDS_BOT_GITHUB_PAT_PRIVATE

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -112,4 +112,4 @@ jobs:
             head_sha: ${{ github.event.pull_request.head.sha }}
             pr_title: ${{ github.event.pull_request.title }}
         secrets:
-            ALLHANDS_BOT_GITHUB_PAT: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PRIVATE }}
+            OPENHANDS_BOT_GITHUB_PAT_PRIVATE: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PRIVATE }}

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -112,4 +112,4 @@ jobs:
             head_sha: ${{ github.event.pull_request.head.sha }}
             pr_title: ${{ github.event.pull_request.title }}
         secrets:
-            ALLHANDS_BOT_GITHUB_PAT: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+            ALLHANDS_BOT_GITHUB_PAT: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PRIVATE }}

--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -44,5 +44,5 @@ jobs:
                   llm-base-url: https://llm-proxy.app.all-hands.dev
                   review-style: roasted
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PRIVATE }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/.github/workflows/trigger-deploy-preview.yml
+++ b/.github/workflows/trigger-deploy-preview.yml
@@ -43,7 +43,7 @@ jobs:
               with:
                   repository: ${{ env.DEPLOY_REPO }}
                   ref: ${{ env.BASE_BRANCH }}
-                  token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PRIVATE }}
                   fetch-depth: 0
                   path: deploy-repo
 
@@ -122,7 +122,7 @@ jobs:
             - name: Create or get deploy PR
               id: manage-pr
               env:
-                  GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  GH_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PRIVATE }}
                   BRANCH_NAME: ${{ steps.deploy-pr.outputs.branch_name }}
                   PR_TITLE: ${{ inputs.pr_title }}
               run: |

--- a/.github/workflows/trigger-deploy-preview.yml
+++ b/.github/workflows/trigger-deploy-preview.yml
@@ -19,7 +19,7 @@ on:
                 required: true
                 type: string
         secrets:
-            ALLHANDS_BOT_GITHUB_PAT:
+            OPENHANDS_BOT_GITHUB_PAT_PRIVATE:
                 required: true
 
 concurrency:


### PR DESCRIPTION
## Summary

Renames PAT secret references in workflow files to the scoped secret `OPENHANDS_BOT_GITHUB_PAT_PRIVATE` as part of [OpenHands/evaluation#428](https://github.com/OpenHands/evaluation/issues/428) (PAT blast-radius reduction).

- Replaces `secrets.PAT_TOKEN` / `secrets.ALLHANDS_BOT_GITHUB_PAT` → `secrets.OPENHANDS_BOT_GITHUB_PAT_PRIVATE`
- No logic changes

**Three scoped PAT identities:**
| Secret | Scope |
|---|---|
| `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` | Public repos |
| `OPENHANDS_BOT_GITHUB_PAT_PRIVATE` | Private repos |
| `OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH` | Cross-repo workflow dispatch |