### PR TITLE
feat: serve frontend SPA from Docker image via FastAPI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Version control
+.git
+.gitignore
+
+# CI/CD
+.github
+
+# Python
+.venv
+__pycache__
+*.pyc
+.pytest_cache
+.ruff_cache
+.mypy_cache
+
+# Frontend (built inside Docker via multi-stage)
+frontend/node_modules
+frontend/build
+frontend/coverage
+frontend/test-results
+frontend/playwright-report
+frontend/.react-router
+
+# IDE / editor
+.vscode
+.idea
+*.swp
+
+# Misc
+.pr
+.stakpak
+.pre-commit-config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,47 @@ OPENHANDS_API_KEY=sk-oh-... uv run pytest tests/integration/ -v
 OPENHANDS_API_KEY=sk-oh-... uv run python scripts/test_automation.py --api-url https://staging.all-hands.dev
 ```
 
+## Frontend Hosting
+
+The Docker image includes the built frontend SPA and serves it from FastAPI at `/automations`.
+
+### How It Works
+
+- **Multi-stage Dockerfile**: Stage 1 (`node:22-slim`) runs `npm run build` in `frontend/`. Stage 2 copies the output to `/app/frontend-dist`.
+- **Opt-in via env var**: `AUTOMATION_FRONTEND_DIR` controls whether the app serves static files. The Dockerfile sets it to `/app/frontend-dist` by default. Set to empty string to disable (API-only mode).
+- **SPA fallback**: A `StaticFiles` subclass (`_SPAStaticFiles`) serves real files when they exist and falls back to `index.html` for client-side routes.
+- **Cache headers**: Hashed assets under `assets/` get `Cache-Control: public, max-age=31536000, immutable`. `index.html` gets `no-cache, must-revalidate`.
+- **No conflict with API routes**: API routers are mounted on `/api/automation/*`; frontend is on `/automations/*`.
+
+### Local Development
+
+Frontend hosting is **disabled** locally (env var is empty by default). Use the normal Vite dev workflow:
+
+```bash
+# Terminal 1: Backend
+uvicorn automation.app:app --reload
+
+# Terminal 2: Frontend (Vite HMR on :3002)
+cd frontend && npm run dev
+
+# Terminal 3 (optional): Unified proxy on :3000
+cd frontend && npm run dev:proxy
+```
+
+### Docker Build
+
+```bash
+# Build image (includes frontend)
+make docker-build
+# or: docker build -t ghcr.io/openhands/automation:local -f containers/Dockerfile .
+
+# Run with frontend enabled (default)
+docker run -p 8000:8000 ghcr.io/openhands/automation:local
+
+# Run API-only (disable frontend)
+docker run -p 8000:8000 -e AUTOMATION_FRONTEND_DIR="" ghcr.io/openhands/automation:local
+```
+
 ## Dispatch Pipeline
 
 The dispatcher uses a **fire-and-forget** model. For each PENDING run:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,44 +84,12 @@ OPENHANDS_API_KEY=sk-oh-... uv run python scripts/test_automation.py --api-url h
 
 ## Frontend Hosting
 
-The Docker image includes the built frontend SPA and serves it from FastAPI at `/automations`.
+The Docker image includes the built frontend SPA and serves it via FastAPI.
 
-### How It Works
-
-- **Multi-stage Dockerfile**: Stage 1 (`node:22-slim`) runs `npm run build` in `frontend/`. Stage 2 copies the output to `/app/frontend-dist`.
-- **Opt-in via env var**: `AUTOMATION_FRONTEND_DIR` controls whether the app serves static files. The Dockerfile sets it to `/app/frontend-dist` by default. Set to empty string to disable (API-only mode).
-- **SPA fallback**: A `StaticFiles` subclass (`_SPAStaticFiles`) serves real files when they exist and falls back to `index.html` for client-side routes.
-- **Cache headers**: Hashed assets under `assets/` get `Cache-Control: public, max-age=31536000, immutable`. `index.html` gets `no-cache, must-revalidate`.
-- **No conflict with API routes**: API routers are mounted on `/api/automation/*`; frontend is on `/automations/*`.
-
-### Local Development
-
-Frontend hosting is **disabled** locally (env var is empty by default). Use the normal Vite dev workflow:
-
-```bash
-# Terminal 1: Backend
-uvicorn automation.app:app --reload
-
-# Terminal 2: Frontend (Vite HMR on :3002)
-cd frontend && npm run dev
-
-# Terminal 3 (optional): Unified proxy on :3000
-cd frontend && npm run dev:proxy
-```
-
-### Docker Build
-
-```bash
-# Build image (includes frontend)
-make docker-build
-# or: docker build -t ghcr.io/openhands/automation:local -f containers/Dockerfile .
-
-# Run with frontend enabled (default)
-docker run -p 8000:8000 ghcr.io/openhands/automation:local
-
-# Run API-only (disable frontend)
-docker run -p 8000:8000 -e AUTOMATION_FRONTEND_DIR="" ghcr.io/openhands/automation:local
-```
+- **Opt-in via `AUTOMATION_FRONTEND_DIR`** — set to the directory containing built assets. Empty = disabled (default locally). Dockerfile sets it to `/app/frontend-dist`.
+- **Mount path** derived from `base_url` via `Settings.frontend_path` (same pattern as `base_path`). Defaults to `/automations`.
+- **SPA fallback** via `_SPAStaticFiles.lookup_path` — unknown paths resolve to `index.html`.
+- **Cache**: `immutable` for hashed `assets/*`, `no-cache` for everything else.
 
 ## Dispatch Pipeline
 

--- a/automation/app.py
+++ b/automation/app.py
@@ -3,10 +3,12 @@
 import asyncio
 import logging
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
 from sqlalchemy import text
 
 from automation.auth import create_http_client
@@ -193,4 +195,37 @@ async def readiness():
         return JSONResponse(
             status_code=503,
             content={"status": "not_ready", "error": "database unavailable"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Frontend static file hosting (opt-in via AUTOMATION_FRONTEND_DIR)
+# ---------------------------------------------------------------------------
+_frontend_dir = get_settings().frontend_dir
+if _frontend_dir:
+    _frontend_path = Path(_frontend_dir)
+    if not _frontend_path.is_dir():
+        logger.warning(
+            "AUTOMATION_FRONTEND_DIR=%s is not a directory — frontend hosting disabled",
+            _frontend_dir,
+        )
+    else:
+        logger.info("Serving frontend from %s at /automations", _frontend_dir)
+
+        _index_html = _frontend_path / "index.html"
+
+        class _SPAStaticFiles(StaticFiles):
+            """StaticFiles subclass that falls back to index.html for SPA routing."""
+
+            async def get_response(self, path: str, scope):
+                try:
+                    return await super().get_response(path, scope)
+                except Exception:
+                    # File not found → serve index.html for client-side routing
+                    return FileResponse(_index_html)
+
+        app.mount(
+            "/automations",
+            _SPAStaticFiles(directory=_frontend_path, html=True),
+            name="frontend",
         )

--- a/automation/app.py
+++ b/automation/app.py
@@ -221,9 +221,7 @@ if _frontend_dir:
         class _SPAStaticFiles(StaticFiles):
             """StaticFiles that falls back to index.html for SPA client routes."""
 
-            def lookup_path(
-                self, path: str
-            ) -> tuple[str, os.stat_result | None]:
+            def lookup_path(self, path: str) -> tuple[str, os.stat_result | None]:
                 full_path, stat_result = super().lookup_path(path)
                 if stat_result is None:
                     # Unknown path → serve index.html for client-side routing

--- a/automation/app.py
+++ b/automation/app.py
@@ -2,12 +2,13 @@
 
 import asyncio
 import logging
+import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy import text
 
@@ -201,7 +202,8 @@ async def readiness():
 # ---------------------------------------------------------------------------
 # Frontend static file hosting (opt-in via AUTOMATION_FRONTEND_DIR)
 # ---------------------------------------------------------------------------
-_frontend_dir = get_settings().frontend_dir
+_settings = get_settings()
+_frontend_dir = _settings.frontend_dir
 if _frontend_dir:
     _frontend_path = Path(_frontend_dir)
     if not _frontend_path.is_dir():
@@ -210,26 +212,31 @@ if _frontend_dir:
             _frontend_dir,
         )
     else:
-        logger.info("Serving frontend from %s at /automations", _frontend_dir)
+        _frontend_mount = _settings.frontend_path
+        logger.info("Serving frontend from %s at %s", _frontend_dir, _frontend_mount)
 
-        _index_html = _frontend_path / "index.html"
+        _index_full_path = str(_frontend_path / "index.html")
+        _index_stat = os.stat(_index_full_path)
 
         class _SPAStaticFiles(StaticFiles):
-            """StaticFiles subclass that falls back to index.html for SPA routing."""
+            """StaticFiles that falls back to index.html for SPA client routes."""
 
-            async def get_response(self, path: str, scope):
-                try:
-                    response = await super().get_response(path, scope)
-                except Exception:
-                    # File not found → serve index.html for client-side routing
-                    return FileResponse(
-                        _index_html,
-                        headers={"Cache-Control": "no-cache, must-revalidate"},
-                    )
+            def lookup_path(
+                self, path: str
+            ) -> tuple[str, os.stat_result | None]:
+                full_path, stat_result = super().lookup_path(path)
+                if stat_result is None:
+                    # Unknown path → serve index.html for client-side routing
+                    return _index_full_path, _index_stat
+                return full_path, stat_result
 
-                # Hashed assets (assets/*.js, assets/*.css) are immutable —
-                # cache aggressively.  index.html must always be revalidated.
-                if path.startswith("assets/"):
+            def file_response(self, full_path, stat_result, scope, status_code=200):
+                response = super().file_response(
+                    full_path, stat_result, scope, status_code
+                )
+                # Hashed assets are immutable; everything else (especially
+                # index.html) must be revalidated on every request.
+                if "/assets/" in str(full_path):
                     response.headers["Cache-Control"] = (
                         "public, max-age=31536000, immutable"
                     )
@@ -237,11 +244,10 @@ if _frontend_dir:
                     response.headers.setdefault(
                         "Cache-Control", "no-cache, must-revalidate"
                     )
-
                 return response
 
         app.mount(
-            "/automations",
+            _frontend_mount,
             _SPAStaticFiles(directory=_frontend_path, html=True),
             name="frontend",
         )

--- a/automation/app.py
+++ b/automation/app.py
@@ -219,10 +219,26 @@ if _frontend_dir:
 
             async def get_response(self, path: str, scope):
                 try:
-                    return await super().get_response(path, scope)
+                    response = await super().get_response(path, scope)
                 except Exception:
                     # File not found → serve index.html for client-side routing
-                    return FileResponse(_index_html)
+                    return FileResponse(
+                        _index_html,
+                        headers={"Cache-Control": "no-cache, must-revalidate"},
+                    )
+
+                # Hashed assets (assets/*.js, assets/*.css) are immutable —
+                # cache aggressively.  index.html must always be revalidated.
+                if path.startswith("assets/"):
+                    response.headers["Cache-Control"] = (
+                        "public, max-age=31536000, immutable"
+                    )
+                else:
+                    response.headers.setdefault(
+                        "Cache-Control", "no-cache, must-revalidate"
+                    )
+
+                return response
 
         app.mount(
             "/automations",

--- a/automation/config.py
+++ b/automation/config.py
@@ -56,7 +56,7 @@ class Settings(BaseSettings):
     cors_origins: str = ""
 
     # Frontend static files directory.  When set, the app serves the built
-    # frontend SPA from this path under /automations.  Leave empty to disable.
+    # frontend SPA at the frontend_path.  Leave empty to disable.
     frontend_dir: str = ""
 
     # Event-based triggers: Shared secret for verifying webhook signatures
@@ -79,6 +79,21 @@ class Settings(BaseSettings):
         else:
             prefix = ""
         return f"{prefix}/api/automation"
+
+    @property
+    def frontend_path(self) -> str:
+        """Route prefix for the frontend SPA, derived from base_url.
+
+        Examples:
+            base_url=""                          -> /automations
+            base_url="https://domain"            -> /automations
+            base_url="https://domain/acmecorp"   -> /acmecorp/automations
+        """
+        if self.base_url:
+            prefix = urlparse(self.base_url).path.rstrip("/")
+        else:
+            prefix = ""
+        return f"{prefix}/automations"
 
     @property
     def resolved_base_url(self) -> str:

--- a/automation/config.py
+++ b/automation/config.py
@@ -55,6 +55,10 @@ class Settings(BaseSettings):
     # CORS origins (comma-separated list, defaults to openhands_api_base_url)
     cors_origins: str = ""
 
+    # Frontend static files directory.  When set, the app serves the built
+    # frontend SPA from this path under /automations.  Leave empty to disable.
+    frontend_dir: str = ""
+
     # Event-based triggers: Shared secret for verifying webhook signatures
     # Used by the OpenHands server when forwarding GitHub events
     webhook_secret: str = ""

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Stage 1: Build frontend ----
-FROM node:22-slim AS frontend-build
+FROM node:24-slim AS frontend-build
 WORKDIR /frontend
 COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,3 +1,12 @@
+# ---- Stage 1: Build frontend ----
+FROM node:22-slim AS frontend-build
+WORKDIR /frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ .
+RUN npm run build
+
+# ---- Stage 2: Python application ----
 FROM python:3.12-slim-bookworm
 
 WORKDIR /app
@@ -21,9 +30,15 @@ COPY alembic.ini .
 
 RUN uv pip install --system .
 
+# Copy built frontend assets from stage 1
+COPY --from=frontend-build /frontend/build /app/frontend-dist
+
 # Security: run as non-root (UID 42420 chosen arbitrarily)
 RUN groupadd -r automation && useradd -r -g automation -u 42420 automation
 USER automation
+
+# Enable frontend hosting — set to "" to serve API only
+ENV AUTOMATION_FRONTEND_DIR=/app/frontend-dist
 
 EXPOSE 8000
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig(({ mode }) => {
   const FE_PORT = Number.parseInt(VITE_FRONTEND_PORT, 10);
 
   return {
-    base: "/automations",
+    base: "/automations/",
     plugins: [
       !process.env.VITEST && reactRouter(),
       viteTsconfigPaths(),

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,0 +1,192 @@
+"""Tests for frontend static file hosting and frontend_path config."""
+
+import os
+
+import pytest
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from httpx import ASGITransport, AsyncClient
+
+from automation.config import Settings
+
+
+# ---------------------------------------------------------------------------
+# Settings.frontend_path
+# ---------------------------------------------------------------------------
+
+
+class TestFrontendPath:
+    """Verify frontend_path is derived from base_url, mirroring base_path."""
+
+    def test_no_base_url(self):
+        settings = Settings(base_url="")
+        assert settings.frontend_path == "/automations"
+
+    def test_domain_only(self):
+        settings = Settings(base_url="https://app.all-hands.dev")
+        assert settings.frontend_path == "/automations"
+
+    def test_with_subpath(self):
+        settings = Settings(base_url="https://domain/acmecorp")
+        assert settings.frontend_path == "/acmecorp/automations"
+
+    def test_strips_trailing_slash(self):
+        settings = Settings(base_url="https://domain/acmecorp/")
+        assert settings.frontend_path == "/acmecorp/automations"
+
+    def test_root_slash_only(self):
+        settings = Settings(base_url="https://domain/")
+        assert settings.frontend_path == "/automations"
+
+    def test_consistent_with_base_path(self):
+        """frontend_path and base_path share the same prefix logic."""
+        for url in ["", "https://domain", "https://domain/org"]:
+            s = Settings(base_url=url)
+            # Both should start with the same prefix (everything before the
+            # final path segment).
+            fp_prefix = s.frontend_path.rsplit("/automations", 1)[0]
+            bp_prefix = s.base_path.rsplit("/api/automation", 1)[0]
+            assert fp_prefix == bp_prefix, f"Mismatch for base_url={url!r}"
+
+
+# ---------------------------------------------------------------------------
+# _SPAStaticFiles serving behaviour
+# ---------------------------------------------------------------------------
+
+# Reproduce the same class from app.py so we can test it in isolation
+# without importing the module-level app (which requires DB env vars etc.)
+
+
+def _build_test_app(frontend_dir: str, mount_path: str = "/automations") -> FastAPI:
+    """Build a minimal FastAPI app with the SPA static files mount."""
+    from pathlib import Path
+
+    test_app = FastAPI()
+    frontend_path = Path(frontend_dir)
+    index_full_path = str(frontend_path / "index.html")
+    index_stat = os.stat(index_full_path)
+
+    class SPAStaticFiles(StaticFiles):
+        def lookup_path(self, path: str) -> tuple[str, os.stat_result | None]:
+            full_path, stat_result = super().lookup_path(path)
+            if stat_result is None:
+                return index_full_path, index_stat
+            return full_path, stat_result
+
+        def file_response(self, full_path, stat_result, scope, status_code=200):
+            response = super().file_response(
+                full_path, stat_result, scope, status_code
+            )
+            if "/assets/" in str(full_path):
+                response.headers["Cache-Control"] = (
+                    "public, max-age=31536000, immutable"
+                )
+            else:
+                response.headers.setdefault(
+                    "Cache-Control", "no-cache, must-revalidate"
+                )
+            return response
+
+    test_app.mount(
+        mount_path,
+        SPAStaticFiles(directory=frontend_path, html=True),
+        name="frontend",
+    )
+    return test_app
+
+
+@pytest.fixture()
+def frontend_dir(tmp_path):
+    """Create a minimal frontend build directory."""
+    (tmp_path / "index.html").write_text("<html><body>SPA</body></html>")
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    (assets / "app-abc123.js").write_text("console.log('hi')")
+    (assets / "style-def456.css").write_text("body{}")
+    (tmp_path / "locales" / "en").mkdir(parents=True)
+    (tmp_path / "locales" / "en" / "translation.json").write_text("{}")
+    return tmp_path
+
+
+@pytest.fixture()
+def spa_client(frontend_dir):
+    """AsyncClient wired to a test app with the SPA mount."""
+    test_app = _build_test_app(str(frontend_dir))
+    return AsyncClient(
+        transport=ASGITransport(app=test_app), base_url="http://test"
+    )
+
+
+class TestSPAStaticFiles:
+    """Integration tests for the SPA static file mount."""
+
+    async def test_index_html_served_at_root(self, spa_client):
+        r = await spa_client.get("/automations/")
+        assert r.status_code == 200
+        assert "SPA" in r.text
+
+    async def test_index_cache_control(self, spa_client):
+        r = await spa_client.get("/automations/")
+        assert r.headers["cache-control"] == "no-cache, must-revalidate"
+
+    async def test_js_asset_served(self, spa_client):
+        r = await spa_client.get("/automations/assets/app-abc123.js")
+        assert r.status_code == 200
+        assert "console" in r.text
+
+    async def test_asset_cache_immutable(self, spa_client):
+        r = await spa_client.get("/automations/assets/app-abc123.js")
+        assert r.headers["cache-control"] == "public, max-age=31536000, immutable"
+
+    async def test_css_asset_cache_immutable(self, spa_client):
+        r = await spa_client.get("/automations/assets/style-def456.css")
+        assert r.headers["cache-control"] == "public, max-age=31536000, immutable"
+
+    async def test_spa_fallback_returns_index(self, spa_client):
+        """Unknown paths should return index.html for client-side routing."""
+        r = await spa_client.get("/automations/some-automation-id")
+        assert r.status_code == 200
+        assert "SPA" in r.text
+
+    async def test_spa_fallback_cache_control(self, spa_client):
+        r = await spa_client.get("/automations/some-automation-id")
+        assert r.headers["cache-control"] == "no-cache, must-revalidate"
+
+    async def test_nested_spa_route_fallback(self, spa_client):
+        r = await spa_client.get("/automations/automations/abc/runs/123")
+        assert r.status_code == 200
+        assert "SPA" in r.text
+
+    async def test_non_asset_static_file(self, spa_client):
+        """Real non-asset files (e.g. locales) should be served directly."""
+        r = await spa_client.get("/automations/locales/en/translation.json")
+        assert r.status_code == 200
+        assert r.headers["cache-control"] == "no-cache, must-revalidate"
+
+    async def test_outside_mount_returns_404(self, spa_client):
+        """Paths outside /automations should not be handled."""
+        r = await spa_client.get("/other-path")
+        assert r.status_code == 404
+
+
+class TestSPAWithSubpath:
+    """Verify the mount works with a non-default prefix (like base_url subpath)."""
+
+    async def test_subpath_mount(self, frontend_dir):
+        test_app = _build_test_app(
+            str(frontend_dir), mount_path="/acmecorp/automations"
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=test_app), base_url="http://test"
+        ) as client:
+            r = await client.get("/acmecorp/automations/")
+            assert r.status_code == 200
+            assert "SPA" in r.text
+
+            r = await client.get("/acmecorp/automations/assets/app-abc123.js")
+            assert r.status_code == 200
+            assert r.headers["cache-control"] == "public, max-age=31536000, immutable"
+
+            r = await client.get("/acmecorp/automations/any-route")
+            assert r.status_code == 200
+            assert "SPA" in r.text

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -74,9 +74,7 @@ def _build_test_app(frontend_dir: str, mount_path: str = "/automations") -> Fast
             return full_path, stat_result
 
         def file_response(self, full_path, stat_result, scope, status_code=200):
-            response = super().file_response(
-                full_path, stat_result, scope, status_code
-            )
+            response = super().file_response(full_path, stat_result, scope, status_code)
             if "/assets/" in str(full_path):
                 response.headers["Cache-Control"] = (
                     "public, max-age=31536000, immutable"
@@ -112,9 +110,7 @@ def frontend_dir(tmp_path):
 def spa_client(frontend_dir):
     """AsyncClient wired to a test app with the SPA mount."""
     test_app = _build_test_app(str(frontend_dir))
-    return AsyncClient(
-        transport=ASGITransport(app=test_app), base_url="http://test"
-    )
+    return AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test")
 
 
 class TestSPAStaticFiles:


### PR DESCRIPTION
Human: This bundles the front-end assets with the backend dockerfile, so that the existing deployment and hosting should cover both.

TIcket: PLTF-1240 deployment piece, continued from #54.

I also experimented with docker-compose to make local testing with postgres easier, but I'd propose that for a future PR.

## Agent Summary

Bundles the built frontend into the Docker image and serves it from FastAPI at `/automations`.

## Changes

### Multi-stage Dockerfile
- Stage 1: `node:24-slim` builds the frontend (`npm ci && npm run build`)
- Stage 2: copies built assets to `/app/frontend-dist` in the Python image

### FastAPI static file hosting (opt-in)
- New setting `AUTOMATION_FRONTEND_DIR` (env var, empty by default = disabled)
- `_SPAStaticFiles` mount at `/automations` with `index.html` fallback for client-side routing
- Cache headers: `immutable` for hashed assets, `no-cache` for everything else
- Dockerfile sets `AUTOMATION_FRONTEND_DIR=/app/frontend-dist` — override to `""` for API-only mode

### Vite config fix
- `base: '/automations'` → `base: '/automations/'` so asset URLs resolve correctly (`/automations/assets/...` not `/automationsassets/...`)

### Supporting files
- `.dockerignore` — excludes `node_modules`, `.venv`, `.git`, build artifacts
- `AGENTS.md` — new "Frontend Hosting" section documenting the env var, local dev, and Docker usage

## Local dev impact
None. `AUTOMATION_FRONTEND_DIR` defaults to empty, so the static mount is inactive. Vite dev server + proxy workflow is unchanged.

## Testing
```bash
docker build -t ghcr.io/openhands/automation:local -f containers/Dockerfile .
docker compose up -d  # postgres + automation
curl http://localhost:8000/automations/       # → index.html (200, no-cache)
curl http://localhost:8000/automations/assets/root-*.css  # → 200, immutable
curl http://localhost:8000/automations/any-id  # → SPA fallback (200, no-cache)
curl http://localhost:8000/api/automation/health  # → {"status":"ok"}
```