### PR TITLE
fix: serve OpenAPI docs at base path for correct proxy routing

### DIFF
--- a/automation/app.py
+++ b/automation/app.py
@@ -139,6 +139,9 @@ def _build_cors_origins() -> list[str]:
 
 def _create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
+    # Serve OpenAPI docs under the base path so they're accessible when the app
+    # is mounted at /api/automation (e.g., /api/automation/docs).
+    base_path = get_settings().base_path
     return FastAPI(
         title="OpenHands Automations Service",
         description=(
@@ -146,6 +149,9 @@ def _create_app() -> FastAPI:
         ),
         version="0.1.0",
         lifespan=lifespan,
+        docs_url=f"{base_path}/docs",
+        openapi_url=f"{base_path}/openapi.json",
+        redoc_url=f"{base_path}/redoc",
     )
 
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,0 +1,30 @@
+"""Tests for OpenAPI documentation endpoints."""
+
+
+class TestOpenAPIEndpoints:
+    """Tests for OpenAPI spec and documentation UI endpoints."""
+
+    def test_openapi_json_accessible(self, sync_client):
+        """GET /api/automation/openapi.json returns the OpenAPI spec."""
+        response = sync_client.get("/api/automation/openapi.json")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["info"]["title"] == "OpenHands Automations Service"
+        assert "paths" in data
+
+    def test_swagger_ui_accessible(self, sync_client):
+        """GET /api/automation/docs returns Swagger UI HTML."""
+        response = sync_client.get("/api/automation/docs")
+
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+        assert b"swagger" in response.content.lower()
+
+    def test_redoc_accessible(self, sync_client):
+        """GET /api/automation/redoc returns ReDoc HTML."""
+        response = sync_client.get("/api/automation/redoc")
+
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+        assert b"redoc" in response.content.lower()


### PR DESCRIPTION
## Problem

The OpenAPI documentation endpoints (`/openapi.json`, `/docs`, `/redoc`) are not accessible when the automation service is deployed behind a reverse proxy at `/api/automation`. 

This regression was introduced in PR #37 when `root_path` was removed.

## Solution

Set `docs_url`, `openapi_url`, and `redoc_url` explicitly to include the base path (`/api/automation`), making the OpenAPI spec and documentation UIs accessible at:

- `/api/automation/openapi.json`
- `/api/automation/docs` (Swagger UI)
- `/api/automation/redoc`

## Why this approach?

This is consistent with PR #37's direction of having the app **own all its paths directly**, rather than relying on `root_path`. The original fix in PR #30 used `root_path`, but PR #37 removed it because:

> "The `root_path` config property has been removed — it was only needed when a reverse proxy stripped the prefix before forwarding. Since the app now owns the path, `root_path` would cause double-prefixing in Swagger UI."

By explicitly setting the docs URLs, we maintain Joe's architectural direction while fixing the accessibility issue.

## Testing

Added `tests/test_openapi.py` with tests verifying all three endpoints are accessible.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f5e9894c-52a2-4578-8393-7c431ad04dd0)