### PR TITLE
fix: Use query params for file upload to avoid proxy path normalization

### DIFF
--- a/automation/execution.py
+++ b/automation/execution.py
@@ -172,11 +172,16 @@ async def _upload(
 ) -> None:
     """Upload bytes to the sandbox via the agent-server file API.
 
-    The agent-server expects the absolute path in the URL, e.g.
-    ``POST /api/file/upload//tmp/file.tar.gz`` (double-slash is correct).
+    Uses query parameter for the path to avoid URL normalization issues
+    with proxies that collapse double-slashes (e.g. //tmp -> /tmp).
+    See: https://github.com/All-Hands-AI/OpenHands/commit/a14158e
     """
+    # Use query param instead of path param to avoid double-slash normalization
+    from urllib.parse import urlencode
+
+    params = urlencode({"path": dest})
     resp = await client.post(
-        f"{agent_url}/api/file/upload/{dest}",
+        f"{agent_url}/api/file/upload?{params}",
         files={"file": ("upload", data)},
         headers={"X-Session-API-Key": session_key},
     )

--- a/scripts/test_tarball/setup.sh
+++ b/scripts/test_tarball/setup.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
-# Install the OpenHands SDK from the saas-runtime-mode feature branch.
-# Once merged, switch to a released version or @main.
+# Install the OpenHands SDK from main branch.
 set -e
 
-SDK_REF="feat/saas-runtime-mode"
+SDK_REF="main"
 echo "[setup] installing openhands SDK ($SDK_REF)"
 pip install -q --no-cache-dir \
   "openhands-workspace @ git+https://github.com/OpenHands/software-agent-sdk.git@${SDK_REF}#subdirectory=openhands-workspace" \

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -7,7 +7,7 @@ scripts/test_automation.py.
 
 import io
 import tarfile
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -18,6 +18,7 @@ from automation.execution import (
     AutomationResult,
     DispatchResult,
     _shell_quote,
+    _upload,
     build_tarball,
     dispatch_automation,
 )
@@ -141,6 +142,71 @@ class TestExternalDownloadConstants:
     def test_max_filesize_is_reasonable(self):
         """Max filesize should be reasonable (10MB - 500MB)."""
         assert 10 * 1024 * 1024 <= EXTERNAL_MAX_FILESIZE <= 500 * 1024 * 1024
+
+
+class TestUploadUsesQueryParams:
+    """Tests for _upload using query parameters instead of path parameters.
+
+    This prevents URL normalization issues with proxies (e.g., Traefik) that
+    collapse double-slashes in paths. See:
+    - https://github.com/All-Hands-AI/OpenHands/commit/a14158e
+    - https://github.com/OpenHands/software-agent-sdk/pull/2404
+    """
+
+    @pytest.mark.asyncio
+    async def test_upload_uses_query_param_for_path(self):
+        """_upload should use ?path= query param, not path in URL."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        await _upload(
+            client=mock_client,
+            agent_url="https://agent.example.com",
+            session_key="test-session-key",
+            data=b"test data",
+            dest="/tmp/automation.tar.gz",
+        )
+
+        # Verify post was called with query param, not path param
+        mock_client.post.assert_called_once()
+        call_args = mock_client.post.call_args
+
+        url = call_args[0][0]
+        # URL should use query param format
+        assert "?path=" in url, f"Expected query param in URL, got: {url}"
+        assert "/tmp/automation.tar.gz" not in url.split("?")[0], (
+            f"Path should not be in URL path segment: {url}"
+        )
+        # Verify the path is properly encoded in query string
+        assert (
+            "path=%2Ftmp%2Fautomation.tar.gz" in url
+            or "path=/tmp/automation.tar.gz" in url
+        )
+
+    @pytest.mark.asyncio
+    async def test_upload_preserves_absolute_path(self):
+        """_upload should preserve leading slash in path via query param."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        await _upload(
+            client=mock_client,
+            agent_url="https://agent.example.com",
+            session_key="test-session-key",
+            data=b"test data",
+            dest="/workspace/file.txt",
+        )
+
+        url = mock_client.post.call_args[0][0]
+        # The path in query param should preserve the leading slash
+        # (either URL-encoded as %2F or literal /)
+        assert "%2Fworkspace" in url or "/workspace" in url.split("?")[1]
 
 
 class TestDispatchAutomationPermanentErrors:


### PR DESCRIPTION
## Problem

When testing with path-based routing (common in self-hosted/enterprise deployments), proxies like Traefik normalize URL paths and collapse double-slashes. This causes file uploads to fail:

```
/api/file/upload//tmp/file.tar.gz
```

becomes:

```
/api/file/upload/tmp/file.tar.gz
```

The agent-server extracts `tmp/file.tar.gz` (no leading slash) and rejects it with:

```json
{"detail": "Path must be absolute"}
```

## Solution

Use query parameters instead of path parameters:

```python
# Before
f"{agent_url}/api/file/upload/{dest}"

# After  
f"{agent_url}/api/file/upload?path={dest}"
```

## Prior Art

This matches fixes applied elsewhere in OpenHands codebases:

- **OpenHands**: https://github.com/OpenHands/OpenHands/pull/13376
- **Agent-server SDK**: https://github.com/OpenHands/software-agent-sdk/pull/2404

## Testing

Tested on self-hosted OpenHands Enterprise deployment (jps01.r9.all-hands.dev) with Traefik ingress and path-based routing. File uploads now work correctly.

---
*This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford.*