### PR TITLE
PR6b: Combined Docker image + documentation for self-hosted deployments

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,44 @@
+# Environment file for self-hosted local deployment
+# Copy this file to .env.local and fill in your values
+
+# =============================================================================
+# REQUIRED: LLM Configuration
+# =============================================================================
+# The LLM model to use for automation runs
+OPENHANDS_LLM_MODEL=anthropic/claude-sonnet-4-20250514
+
+# Your LLM API key
+OPENHANDS_LLM_API_KEY=sk-ant-...
+
+# =============================================================================
+# OPTIONAL: Hybrid Mode (use OpenHands Cloud for secrets/MCP)
+# =============================================================================
+# Uncomment these to enable hybrid mode where execution happens locally
+# but LLM config, secrets, and MCP servers are fetched from OpenHands Cloud
+#
+# AUTOMATION_OPENHANDS_API_BASE_URL=https://app.all-hands.dev
+# OPENHANDS_API_KEY=sk-oh-...
+
+# =============================================================================
+# OPTIONAL: Service Configuration
+# =============================================================================
+# Base URL for webhook callbacks (default: http://localhost:8000/api/automation)
+# Set this to your external URL if the service is behind a reverse proxy
+# AUTOMATION_BASE_URL=https://your-domain.com/api/automation
+
+# =============================================================================
+# OPTIONAL: Agent Server Configuration (usually not needed to change)
+# =============================================================================
+# AUTOMATION_AGENT_SERVER_URL=http://localhost:3000
+# AUTOMATION_AGENT_SERVER_API_KEY=local-embedded
+
+# =============================================================================
+# OPTIONAL: Database Configuration (usually not needed to change)
+# =============================================================================
+# SQLite database path (default: /data/automations.db in container)
+# AUTOMATION_DB_URL=sqlite+aiosqlite:////data/automations.db
+
+# =============================================================================
+# OPTIONAL: Logging
+# =============================================================================
+# AUTOMATION_LOG_LEVEL=INFO

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,18 @@
 # Automations Service
 
-Self-contained microservice that schedules and dispatches automation runs inside OpenHands Cloud sandboxes.
+Self-contained microservice that schedules and dispatches automation runs. Supports both OpenHands Cloud sandboxes (default) and self-hosted local agent servers.
+
+## Execution Modes
+
+| Feature | Cloud Mode (default) | Local Mode (self-hosted) |
+|---------|---------------------|--------------------------|
+| Execution environment | Fresh Cloud sandbox per run | Persistent local agent server |
+| Database | PostgreSQL (Cloud SQL) | SQLite or PostgreSQL |
+| Auth | Per-user API keys via service key | Config-level API key |
+| Sandbox cleanup | Automatic after run | Not needed (persistent server) |
+| Config flag | `AUTOMATION_AGENT_SERVER_URL` not set | `AUTOMATION_AGENT_SERVER_URL` set |
+
+See `docs/self-hosted.md` for detailed self-hosted deployment instructions.
 
 ## Repository Structure
 
@@ -11,9 +23,9 @@ automation/
 │   ├── auth.py             # Auth via OpenHands /api/v1/users/me (API key + cookie)
 │   ├── config.py           # Pydantic settings (Settings, env prefix AUTOMATION_)
 │   ├── constants.py        # Timeouts, polling intervals, sandbox constants
-│   ├── db.py               # Database engine and session factory (asyncpg / Cloud SQL)
-│   ├── dispatcher.py       # Polls PENDING runs, dispatches to sandbox (fire-and-forget)
-│   ├── execution.py        # Sandbox lifecycle: create → upload → execute → delete
+│   ├── db.py               # Database engine and session factory (asyncpg / aiosqlite)
+│   ├── dispatcher.py       # Polls PENDING runs, dispatches to execution backend
+│   ├── execution.py        # Agent server interaction: upload → execute
 │   ├── logger.py           # JSON structured logging configuration
 │   ├── models.py           # SQLAlchemy models (Automation, AutomationRun, TarballUpload)
 │   ├── router.py           # API routes (CRUD, trigger, callback, runs list)
@@ -21,19 +33,29 @@ automation/
 │   ├── schemas.py          # Pydantic request/response schemas
 │   ├── uploads.py          # Tarball upload router
 │   ├── watchdog.py         # Staleness watchdog — marks hung runs as FAILED
+│   ├── backends/           # Pluggable execution backends
+│   │   ├── base.py         # Abstract ExecutionBackend interface
+│   │   ├── cloud.py        # CloudSandboxBackend (creates Cloud sandbox per run)
+│   │   └── local.py        # LocalAgentServerBackend (uses persistent agent server)
 │   ├── storage/            # File storage abstraction
 │   │   ├── file_store.py   # Abstract base class for file storage
 │   │   └── google_cloud.py # GCS implementation
+│   ├── presets/            # Pre-built automation templates
+│   │   ├── prompt/         # Prompt-based automation (sdk_main.py, setup.sh)
+│   │   └── plugin/         # Plugin-based automation (sdk_main.py, setup.sh)
 │   └── utils/              # Utility modules
+│       ├── agent_server.py # Shared agent server queries (verification)
 │       ├── api_key.py      # Per-user API key minting via service key
 │       ├── cron.py         # Cron schedule utilities (next/prev fire time)
 │       ├── run.py          # Run status transitions (create, mark, update)
-│       ├── sandbox.py      # Sandbox verification and cleanup
+│       ├── sandbox.py      # Cloud sandbox verification and cleanup
 │       ├── tarball_validation.py  # Tarball path validation (internal/external)
 │       └── time.py         # UTC time helpers
 ├── containers/
 │   └── Dockerfile          # Container image definition
-├── migrations/              # Alembic migrations
+├── docs/
+│   └── self-hosted.md      # Self-hosted deployment guide
+├── migrations/              # Alembic migrations (cross-DB compatible)
 ├── scripts/
 │   ├── test_automation.py  # E2E test (sandbox lifecycle with live streaming)
 │   └── test_tarball/       # Tarball contents uploaded to sandbox during test
@@ -42,8 +64,10 @@ automation/
 ├── tests/                   # Unit tests (flat structure, no external deps)
 │   ├── integration/        # Integration tests (require OPENHANDS_API_KEY)
 │   ├── test_auth.py
+│   ├── test_backends.py    # Backend abstraction tests
 │   ├── test_dispatcher.py
 │   ├── test_execution.py
+│   ├── test_local_mode.py  # Local mode specific tests
 │   ├── test_router.py
 │   ├── test_scheduler.py
 │   └── ...
@@ -93,22 +117,27 @@ The Docker image includes the built frontend SPA and serves it via FastAPI.
 
 ## Dispatch Pipeline
 
-The dispatcher uses a **fire-and-forget** model. For each PENDING run:
+The dispatcher uses a **fire-and-forget** model via pluggable **execution backends**. For each PENDING run:
 
-1. **Fetch per-user API key** — `get_api_key_for_automation_run()` mints a key via the service key
-2. **Resolve tarball** — Internal (`oh-internal://`) downloads from GCS; external (HTTP) URLs are downloaded inside the sandbox
-3. **Create sandbox** — `POST /api/v1/sandboxes` (Cloud API, Bearer token auth)
-4. **Wait for RUNNING** — Poll `GET /api/v1/sandboxes?id=<id>` until status=RUNNING
-5. **Upload/download tarball** — `POST /api/file/upload/<path>` (agent-server) or `curl` inside sandbox
-6. **Start entrypoint** — `POST /api/bash/start_bash_command` (agent-server)
+1. **Get backend** — `get_backend()` returns `CloudSandboxBackend` or `LocalAgentServerBackend` based on config
+2. **Get API key** — `backend.get_api_key(run)` mints per-user key (Cloud) or returns config key (local)
+3. **Resolve tarball** — Internal (`oh-internal://`) downloads from GCS; external (HTTP) URLs are downloaded inside sandbox
+4. **Acquire execution context** — `backend.acquire(client)`:
+   - **Cloud**: Create sandbox → poll until RUNNING → extract agent-server URL
+   - **Local**: Return pre-configured agent server URL
+5. **Build env vars** — `backend.build_env_vars(api_key)` returns mode-specific env vars
+6. **Upload/download tarball** — `POST /api/file/upload/<path>` (agent-server) or `curl` inside sandbox
+7. **Start entrypoint** — `POST /api/bash/start_bash_command` (agent-server)
    - Extracts tarball, runs setup.sh (if present), exports env vars, runs entrypoint
-7. **Return immediately** — Dispatcher does not wait for completion
+8. **Return immediately** — Dispatcher does not wait for completion
 
 Completion is handled asynchronously:
 - **Happy path**: SDK inside sandbox POSTs to `POST /api/v1/automations/runs/{id}/complete`
-- **Fallback**: Watchdog scans for runs past their `timeout_at` deadline, verifies status via sandbox bash history, and marks as COMPLETED or FAILED
+- **Fallback**: Watchdog calls `backend.verify_run()` for runs past their `timeout_at` deadline
 
-### Env Vars Injected Into Sandbox
+### Env Vars Injected Into Execution Environment
+
+**Cloud Mode:**
 
 | Variable | Source | Purpose |
 |----------|--------|---------|
@@ -116,11 +145,24 @@ Completion is handled asynchronously:
 | `OPENHANDS_CLOUD_API_URL` | Config (`openhands_api_base_url`) | Cloud API base URL |
 | `SANDBOX_ID` | From sandbox creation response | SDK reads for settings API calls |
 | `SESSION_API_KEY` | From sandbox creation response | SDK reads for settings API auth |
+
+**Local Mode:**
+
+| Variable | Source | Purpose |
+|----------|--------|---------|
+| `AGENT_SERVER_URL` | Config (`agent_server_url`) | SDK uses RemoteWorkspace |
+| `OPENHANDS_CLOUD_API_URL` | Config (optional) | For hybrid mode LLM/secrets/MCP |
+| `OPENHANDS_API_KEY` | Config (optional) | For hybrid mode Cloud API auth |
+
+**Common (both modes):**
+
+| Variable | Source | Purpose |
+|----------|--------|---------|
 | `AUTOMATION_CALLBACK_URL` | Constructed by dispatcher | SDK posts completion status here |
 | `AUTOMATION_RUN_ID` | Run ID | Included in callback payload |
 | `AUTOMATION_EVENT_PAYLOAD` | Trigger context JSON | Available to user's script |
 
-The SDK's `OpenHandsCloudWorkspace(local_agent_server_mode=True)` reads `SANDBOX_ID`, `SESSION_API_KEY`, and `AGENT_SERVER_PORT` from env vars automatically.
+The preset scripts detect mode via `AGENT_SERVER_URL` presence and use `RemoteWorkspace` (local) or `OpenHandsCloudWorkspace` (Cloud) accordingly.
 
 ## Callback & Race Condition Handling
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,22 @@ Self-contained microservice that schedules and dispatches automation runs. Suppo
 
 See `docs/self-hosted.md` for detailed self-hosted deployment instructions.
 
+### Docker Images
+
+| Image | Contents | Use Case |
+|-------|----------|----------|
+| `ghcr.io/openhands/automation:latest` | Automation service only | Cloud/production deployments |
+| `ghcr.io/openhands/automation-local:latest` | Automation + Agent Server + SQLite | Local/self-hosted deployments |
+
+**Quick Start (self-hosted):**
+```bash
+docker run -p 8000:8000 \
+  -v ./workspace:/workspace \
+  -e OPENHANDS_LLM_MODEL=anthropic/claude-sonnet-4-20250514 \
+  -e OPENHANDS_LLM_API_KEY=sk-ant-... \
+  ghcr.io/openhands/automation-local:latest
+```
+
 ## Repository Structure
 
 ```

--- a/automation/backends/__init__.py
+++ b/automation/backends/__init__.py
@@ -45,6 +45,9 @@ def get_backend(api_key: str | None = None) -> ExecutionBackend:
             agent_server_url=settings.agent_server_url,
             api_key=settings.agent_server_api_key,
             cloud_api_url=settings.openhands_api_base_url or None,
+            llm_model=settings.llm_model or None,
+            llm_api_key=settings.llm_api_key or None,
+            llm_base_url=settings.llm_base_url or None,
         )
     else:
         if not api_key:

--- a/automation/backends/local.py
+++ b/automation/backends/local.py
@@ -38,6 +38,9 @@ class LocalAgentServerBackend(ExecutionBackend):
         agent_server_url: str,
         api_key: str,
         cloud_api_url: str | None = None,
+        llm_model: str | None = None,
+        llm_api_key: str | None = None,
+        llm_base_url: str | None = None,
     ):
         """Initialize the local agent-server backend.
 
@@ -46,10 +49,16 @@ class LocalAgentServerBackend(ExecutionBackend):
                 (e.g., "http://localhost:3000")
             api_key: API key for authenticating with the agent server
             cloud_api_url: Optional Cloud API URL for LLM/secrets access
+            llm_model: LLM model identifier (e.g., anthropic/claude-sonnet-4-20250514)
+            llm_api_key: LLM provider API key
+            llm_base_url: Optional custom LLM base URL
         """
         self.agent_server_url = agent_server_url.rstrip("/")
         self.api_key = api_key
         self.cloud_api_url = cloud_api_url
+        self.llm_model = llm_model
+        self.llm_api_key = llm_api_key
+        self.llm_base_url = llm_base_url
 
     @property
     def is_local_mode(self) -> bool:
@@ -106,6 +115,13 @@ class LocalAgentServerBackend(ExecutionBackend):
         # Optionally include Cloud API URL for LLM/secrets access
         if self.cloud_api_url:
             env_vars["OPENHANDS_CLOUD_API_URL"] = self.cloud_api_url
+        # LLM configuration for preset scripts
+        if self.llm_model:
+            env_vars["LLM_MODEL"] = self.llm_model
+        if self.llm_api_key:
+            env_vars["LLM_API_KEY"] = self.llm_api_key
+        if self.llm_base_url:
+            env_vars["LLM_BASE_URL"] = self.llm_base_url
         return env_vars
 
     async def verify_run(

--- a/automation/config.py
+++ b/automation/config.py
@@ -309,6 +309,12 @@ class ServiceSettings(BaseSettings):
     agent_server_api_key: str = ""
     workspace_base: str = "/workspace"
 
+    # LLM configuration for local mode (passed to preset scripts)
+    # These are only used in local mode; Cloud mode fetches LLM config from user's account
+    llm_model: str = ""
+    llm_api_key: str = ""
+    llm_base_url: str = ""
+
     # OpenHands SaaS API
     openhands_api_base_url: str = "https://app.all-hands.dev"
 

--- a/automation/presets/prompt/sdk_main.py
+++ b/automation/presets/prompt/sdk_main.py
@@ -126,12 +126,14 @@ if IS_LOCAL_MODE:
         if port_str.isdigit():
             port = int(port_str)
     print(f"  using OpenHandsCloudWorkspace (local mode) on port {port}")
+    # Use SESSION_API_KEY for callback auth (auth is disabled in local mode,
+    # but the SDK still sends a Bearer token, so we need a non-empty value)
     workspace_ctx = OpenHandsCloudWorkspace(
         local_agent_server_mode=True,
         agent_server_port=port,
-        # Empty strings for Cloud API (not used in local mode)
+        # Empty URL (not used in local mode), but provide a key for callback auth
         cloud_api_url="",
-        cloud_api_key="",
+        cloud_api_key=session_key or "local-mode",
     )
 else:
     # Cloud mode: connect to sandbox's agent server with full Cloud API features

--- a/automation/presets/prompt/sdk_main.py
+++ b/automation/presets/prompt/sdk_main.py
@@ -10,7 +10,7 @@ This script is auto-generated from a user's prompt. It supports two modes:
 **Local Mode** (self-hosted):
   Uses OpenHandsCloudWorkspace with local_agent_server_mode=True.
   Requires: AGENT_SERVER_URL (presence triggers local mode)
-  LLM configured from env vars: OPENHANDS_LLM_MODEL, OPENHANDS_LLM_API_KEY, OPENHANDS_LLM_BASE_URL
+  LLM configured from env vars: LLM_MODEL, LLM_API_KEY, LLM_BASE_URL
   No secrets/MCP support in local mode (configure at container level).
 
 The script:
@@ -39,9 +39,9 @@ Env vars (Cloud mode - all required):
 Env vars (Local mode):
   AGENT_SERVER_URL           - local agent server URL (presence = local mode)
   SESSION_API_KEY            - API key for agent server auth (optional)
-  OPENHANDS_LLM_MODEL        - LLM model identifier (e.g., anthropic/claude-sonnet-4-20250514)
-  OPENHANDS_LLM_API_KEY      - LLM provider API key
-  OPENHANDS_LLM_BASE_URL     - optional, custom LLM base URL
+  LLM_MODEL                  - LLM model identifier (e.g., anthropic/claude-sonnet-4-20250514)
+  LLM_API_KEY                - LLM provider API key
+  LLM_BASE_URL               - optional, custom LLM base URL
 
 Common env vars:
   AUTOMATION_CALLBACK_URL    - completion callback endpoint (optional)
@@ -66,9 +66,9 @@ sandbox_id = os.environ.get("SANDBOX_ID", "")
 session_key = os.environ.get("SESSION_API_KEY", "")
 
 # Local mode env vars
-llm_model = os.environ.get("OPENHANDS_LLM_MODEL", "")
-llm_api_key = os.environ.get("OPENHANDS_LLM_API_KEY", "")
-llm_base_url = os.environ.get("OPENHANDS_LLM_BASE_URL", "")
+llm_model = os.environ.get("LLM_MODEL", "")
+llm_api_key = os.environ.get("LLM_API_KEY", "")
+llm_base_url = os.environ.get("LLM_BASE_URL", "")
 
 print("=== EXECUTION MODE ===")
 print(f"  mode: {'LOCAL' if IS_LOCAL_MODE else 'CLOUD'}")
@@ -78,15 +78,15 @@ if IS_LOCAL_MODE:
     # Local mode: AGENT_SERVER_URL + LLM config required
     print(f"  AGENT_SERVER_URL: {'OK' if agent_server_url else 'MISSING'}")
     print(f"  SESSION_API_KEY: {'OK' if session_key else 'NONE (may fail auth)'}")
-    print(f"  OPENHANDS_LLM_MODEL: {'OK' if llm_model else 'MISSING'}")
-    print(f"  OPENHANDS_LLM_API_KEY: {'OK' if llm_api_key else 'MISSING'}")
-    print(f"  OPENHANDS_LLM_BASE_URL: {'OK' if llm_base_url else 'NONE (using default)'}")
+    print(f"  LLM_MODEL: {'OK' if llm_model else 'MISSING'}")
+    print(f"  LLM_API_KEY: {'OK' if llm_api_key else 'MISSING'}")
+    print(f"  LLM_BASE_URL: {'OK' if llm_base_url else 'NONE (using default)'}")
     if not agent_server_url:
         print("FAIL: AGENT_SERVER_URL not set for local mode", file=sys.stderr)
         sys.exit(1)
     if not llm_model or not llm_api_key:
         print(
-            "FAIL: OPENHANDS_LLM_MODEL and OPENHANDS_LLM_API_KEY required for local mode",
+            "FAIL: LLM_MODEL and LLM_API_KEY required for local mode",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/containers/Dockerfile.combined
+++ b/containers/Dockerfile.combined
@@ -105,8 +105,8 @@ RUN rm -f /etc/nginx/sites-enabled/default
 # OpenHands App Server configuration
 # Use 'local' runtime for self-hosted deployments (not docker/kubernetes)
 ENV RUNTIME=local
-ENV OH_PERSISTENCE_DIR=/data/openhands
-ENV FILE_STORE_PATH=/data/sessions
+ENV OH_PERSISTENCE_DIR=/root/.openhands
+ENV FILE_STORE_PATH=/root/.openhands
 ENV SERVE_FRONTEND=false
 # Skip browser dependency check since Chromium isn't installed in this image
 # Browser operations will fail but basic functionality works

--- a/containers/Dockerfile.combined
+++ b/containers/Dockerfile.combined
@@ -1,0 +1,137 @@
+# Combined OpenHands GUI + Automation Service — self-hosted image
+#
+# This image bundles everything needed for local/self-hosted deployments:
+# - OpenHands GUI (conversation interface) at /
+# - Automation service (scheduler, dispatcher, API) at /automations, /api/automation
+# - OpenHands App Server (manages conversation sandboxes)
+# - Agent server for automation runs
+# - SQLite databases (no external database required)
+#
+# Architecture:
+# - Nginx on port 8000 (reverse proxy)
+# - OpenHands App Server on port 3000 (GUI + conversation API) - uses /app/.venv
+# - Automation Service on port 8001 (automation API) - uses /app/automation-venv
+# - Agent Server on port 3002 (for automation runs only)
+#
+# Key Design: SEPARATE VENVS
+#   OpenHands uses /app/.venv (openhands-sdk 1.15.0)
+#   Automation uses /app/automation-venv (openhands-sdk 1.18.1)
+#   This avoids version conflicts between the two services.
+#
+# Usage:
+#   docker build -f containers/Dockerfile.combined -t openhands-local .
+#   docker run -p 8000:8000 \
+#     -v ./workspace:/workspace \
+#     -v ./data:/data \
+#     -e LLM_MODEL=anthropic/claude-sonnet-4-20250514 \
+#     -e LLM_API_KEY=sk-ant-... \
+#     openhands-local
+
+# ---- Stage 1: Build Automation frontend ----
+FROM node:24-slim AS automation-frontend
+WORKDIR /frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ .
+# Build with base path for /automations subpath
+ENV VITE_BASE_PATH=/automations
+RUN npm run build
+
+# ---- Stage 2: Agent server binary from SDK ----
+FROM ghcr.io/openhands/agent-server:latest-python AS agent-server
+
+# ---- Stage 3: Combined local image (based on OpenHands) ----
+# Use OpenHands image as base since it has the GUI frontend and server code
+FROM docker.openhands.dev/openhands/openhands:1.6
+
+USER root
+WORKDIR /app
+
+LABEL org.opencontainers.image.title="OpenHands Local (GUI + Automations)"
+LABEL org.opencontainers.image.description="Self-contained OpenHands with GUI, automations, and embedded services"
+LABEL org.opencontainers.image.source="https://github.com/OpenHands/automation"
+
+# Install additional system deps
+# tmux is required for OpenHands local runtime
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        supervisor \
+        nginx \
+        libpq-dev \
+        procps \
+        tmux \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy agent server binary from SDK image (for automation runs)
+COPY --from=agent-server /usr/local/bin/openhands-agent-server /usr/local/bin/openhands-agent-server
+
+# ---- Create separate venv for Automation Service ----
+# This isolates it from OpenHands to avoid SDK version conflicts
+RUN python3.13 -m venv /app/automation-venv && \
+    /app/automation-venv/bin/pip install --upgrade pip
+
+# Copy automation service source code
+COPY pyproject.toml /app/automation-src/pyproject.toml
+COPY README.md /app/automation-src/README.md
+COPY automation/ /app/automation-src/automation/
+COPY migrations/ /app/automation-src/migrations/
+COPY alembic.ini /app/automation-src/
+
+# Install automation service in its own venv (with all its dependencies)
+RUN cd /app/automation-src && \
+    /app/automation-venv/bin/pip install --no-cache-dir .
+
+# Copy built automation frontend assets
+COPY --from=automation-frontend /frontend/build /app/automation-frontend
+
+# Move OpenHands frontend to separate directory (it's at /app/frontend/build)
+RUN mv /app/frontend/build /app/openhands-frontend
+
+# Copy configuration files
+COPY containers/nginx.conf /etc/nginx/nginx.conf
+COPY containers/supervisord.combined.conf /etc/supervisor/supervisord.conf
+COPY containers/entrypoint.combined.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Create directories for data persistence
+RUN mkdir -p /data /workspace/runs /tmp/openhands-sandboxes && \
+    chmod 755 /data /workspace /tmp/openhands-sandboxes
+
+# Remove default nginx site
+RUN rm -f /etc/nginx/sites-enabled/default
+
+# ---- Environment Configuration ----
+
+# OpenHands App Server configuration
+# Use 'local' runtime for self-hosted deployments (not docker/kubernetes)
+ENV RUNTIME=local
+ENV OH_PERSISTENCE_DIR=/data/openhands
+ENV SERVE_FRONTEND=false
+
+# Automation service configuration  
+ENV AUTOMATION_AGENT_SERVER_URL=http://localhost:3002
+ENV AUTOMATION_DB_URL=sqlite+aiosqlite:////data/automations.db
+ENV AUTOMATION_BASE_URL=http://localhost:8000
+ENV AUTOMATION_WORKSPACE_BASE=/workspace
+ENV AUTOMATION_FRONTEND_DIR=/app/automation-frontend
+
+# Local file storage for tarballs
+ENV FILE_STORE=local
+ENV LOCAL_STORAGE_PATH=/data/storage
+
+# Agent server for automation runs (separate from GUI sandboxes)
+ENV AGENT_SERVER_PORT=3002
+
+# Volumes for data persistence
+VOLUME /data
+VOLUME /workspace
+
+# Expose nginx (main entry point)
+EXPOSE 8000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:8000/health || exit 1
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/containers/Dockerfile.combined
+++ b/containers/Dockerfile.combined
@@ -107,6 +107,9 @@ RUN rm -f /etc/nginx/sites-enabled/default
 ENV RUNTIME=local
 ENV OH_PERSISTENCE_DIR=/data/openhands
 ENV SERVE_FRONTEND=false
+# Skip browser dependency check since Chromium isn't installed in this image
+# Browser operations will fail but basic functionality works
+ENV SKIP_DEPENDENCY_CHECK=1
 
 # Automation service configuration  
 ENV AUTOMATION_AGENT_SERVER_URL=http://localhost:3002

--- a/containers/Dockerfile.combined
+++ b/containers/Dockerfile.combined
@@ -106,6 +106,7 @@ RUN rm -f /etc/nginx/sites-enabled/default
 # Use 'local' runtime for self-hosted deployments (not docker/kubernetes)
 ENV RUNTIME=local
 ENV OH_PERSISTENCE_DIR=/data/openhands
+ENV FILE_STORE_PATH=/data/sessions
 ENV SERVE_FRONTEND=false
 # Skip browser dependency check since Chromium isn't installed in this image
 # Browser operations will fail but basic functionality works

--- a/containers/Dockerfile.local
+++ b/containers/Dockerfile.local
@@ -72,9 +72,16 @@ RUN mkdir -p /data /workspace/runs && \
 ENV AUTOMATION_AGENT_SERVER_URL=http://localhost:3000
 ENV AUTOMATION_AGENT_SERVER_API_KEY=local-embedded
 ENV AUTOMATION_DB_URL=sqlite+aiosqlite:////data/automations.db
-ENV AUTOMATION_BASE_URL=http://localhost:8000/api/automation
+ENV AUTOMATION_BASE_URL=http://localhost:8000
 ENV AUTOMATION_WORKSPACE_BASE=/workspace
 ENV AUTOMATION_FRONTEND_DIR=/app/frontend-dist
+
+# Auth bypass for self-hosted mode (no OpenHands Cloud auth required)
+ENV AUTOMATION_AUTH_DISABLED=true
+
+# Local file storage for tarballs (instead of GCS/S3)
+ENV FILE_STORE=local
+ENV LOCAL_STORAGE_PATH=/data/storage
 
 # Agent server configuration
 ENV SESSION_API_KEY=local-embedded

--- a/containers/Dockerfile.local
+++ b/containers/Dockerfile.local
@@ -8,8 +8,8 @@
 # Usage:
 #   docker run -p 8000:8000 \
 #     -v ./workspace:/workspace \
-#     -e OPENHANDS_LLM_MODEL=anthropic/claude-sonnet-4-20250514 \
-#     -e OPENHANDS_LLM_API_KEY=sk-ant-... \
+#     -e LLM_MODEL=anthropic/claude-sonnet-4-20250514 \
+#     -e LLM_API_KEY=sk-ant-... \
 #     ghcr.io/openhands/automation-local:latest
 
 # ---- Stage 1: Build frontend ----

--- a/containers/Dockerfile.local
+++ b/containers/Dockerfile.local
@@ -61,30 +61,29 @@ RUN uv pip install --system .
 # Copy built frontend assets
 COPY --from=frontend-build /frontend/build /app/frontend-dist
 
-# Copy supervisord configuration
+# Copy supervisord configuration and entrypoint
 COPY containers/supervisord.conf /etc/supervisor/supervisord.conf
+COPY containers/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 # Create directories for data persistence
 RUN mkdir -p /data /workspace/runs && \
     chmod 755 /data /workspace
 
 # Pre-configure for local mode (all can be overridden at runtime)
+# NOTE: Sensitive defaults (API keys, auth settings) are set in entrypoint.sh
+#       to avoid baking them into image layers.
 ENV AUTOMATION_AGENT_SERVER_URL=http://localhost:3000
-ENV AUTOMATION_AGENT_SERVER_API_KEY=local-embedded
 ENV AUTOMATION_DB_URL=sqlite+aiosqlite:////data/automations.db
 ENV AUTOMATION_BASE_URL=http://localhost:8000
 ENV AUTOMATION_WORKSPACE_BASE=/workspace
 ENV AUTOMATION_FRONTEND_DIR=/app/frontend-dist
-
-# Auth bypass for self-hosted mode (no OpenHands Cloud auth required)
-ENV AUTOMATION_AUTH_DISABLED=true
 
 # Local file storage for tarballs (instead of GCS/S3)
 ENV FILE_STORE=local
 ENV LOCAL_STORAGE_PATH=/data/storage
 
 # Agent server configuration
-ENV SESSION_API_KEY=local-embedded
 ENV AGENT_SERVER_PORT=3000
 
 # Volumes for data persistence and workspace mounting
@@ -98,5 +97,6 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/api/automation/health || exit 1
 
-# Use supervisord to run both services
+# Entrypoint sets secure defaults, then runs the command
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/containers/Dockerfile.local
+++ b/containers/Dockerfile.local
@@ -1,0 +1,95 @@
+# Self-hosted automation service — combined image with agent server + SQLite
+#
+# This image bundles everything needed for local/self-hosted deployments:
+# - Automation service (scheduler, dispatcher, watchdog, API)
+# - Agent server from OpenHands SDK
+# - SQLite database (no external database required)
+#
+# Usage:
+#   docker run -p 8000:8000 \
+#     -v ./workspace:/workspace \
+#     -e OPENHANDS_LLM_MODEL=anthropic/claude-sonnet-4-20250514 \
+#     -e OPENHANDS_LLM_API_KEY=sk-ant-... \
+#     ghcr.io/openhands/automation-local:latest
+
+# ---- Stage 1: Build frontend ----
+FROM node:24-slim AS frontend-build
+WORKDIR /frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ .
+RUN npm run build
+
+# ---- Stage 2: Agent server from SDK ----
+FROM ghcr.io/openhands/agent-server:latest-python AS agent-server
+
+# ---- Stage 3: Combined local image ----
+FROM python:3.12-slim-bookworm
+
+WORKDIR /app
+ENV PYTHONPATH='/app'
+
+LABEL org.opencontainers.image.title="OpenHands Automation (Self-Hosted)"
+LABEL org.opencontainers.image.description="Self-contained automation service with embedded agent server"
+LABEL org.opencontainers.image.source="https://github.com/OpenHands/automation"
+
+# Install system deps
+# - supervisor: process manager for running both services
+# - libpq-dev: PostgreSQL client libs (optional, for hybrid mode)
+# - git: for SDK git dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        supervisor \
+        libpq-dev \
+        git \
+        curl \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir uv
+
+# Copy agent server from SDK image
+COPY --from=agent-server /agent-server /agent-server
+
+# Install automation service
+COPY pyproject.toml ./
+COPY README.md ./
+COPY automation/ automation/
+COPY migrations/ migrations/
+COPY alembic.ini .
+
+RUN uv pip install --system .
+
+# Copy built frontend assets
+COPY --from=frontend-build /frontend/build /app/frontend-dist
+
+# Copy supervisord configuration
+COPY containers/supervisord.conf /etc/supervisor/supervisord.conf
+
+# Create directories for data persistence
+RUN mkdir -p /data /workspace/runs && \
+    chmod 755 /data /workspace
+
+# Pre-configure for local mode (all can be overridden at runtime)
+ENV AUTOMATION_AGENT_SERVER_URL=http://localhost:3000
+ENV AUTOMATION_AGENT_SERVER_API_KEY=local-embedded
+ENV AUTOMATION_DB_URL=sqlite+aiosqlite:////data/automations.db
+ENV AUTOMATION_BASE_URL=http://localhost:8000/api/automation
+ENV AUTOMATION_WORKSPACE_BASE=/workspace
+ENV AUTOMATION_FRONTEND_DIR=/app/frontend-dist
+
+# Agent server configuration
+ENV SESSION_API_KEY=local-embedded
+ENV AGENT_SERVER_PORT=3000
+
+# Volumes for data persistence and workspace mounting
+VOLUME /data
+VOLUME /workspace
+
+# Expose automation service API (agent server is internal only)
+EXPOSE 8000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8000/api/automation/health || exit 1
+
+# Use supervisord to run both services
+CMD ["supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/containers/Dockerfile.local
+++ b/containers/Dockerfile.local
@@ -46,8 +46,8 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir uv
 
-# Copy agent server from SDK image
-COPY --from=agent-server /agent-server /agent-server
+# Copy agent server binary from SDK image (it's a compiled standalone binary)
+COPY --from=agent-server /usr/local/bin/openhands-agent-server /usr/local/bin/openhands-agent-server
 
 # Install automation service
 COPY pyproject.toml ./

--- a/containers/entrypoint.combined.sh
+++ b/containers/entrypoint.combined.sh
@@ -38,8 +38,10 @@ if [[ -n "${LLM_BASE_URL}" ]]; then
 fi
 
 # ---- Create data directories ----
-mkdir -p /data/openhands /data/storage /data/sessions /root/.openhands/conversations /tmp/openhands-sandboxes
-chmod 755 /data/openhands /data/storage /data/sessions /root/.openhands /root/.openhands/conversations /tmp/openhands-sandboxes
+# /root/.openhands - shared between OpenHands GUI and automation agent-server
+# /data/storage - automation tarball uploads
+mkdir -p /root/.openhands/conversations /data/storage /tmp/openhands-sandboxes
+chmod 755 /root/.openhands /root/.openhands/conversations /data/storage /tmp/openhands-sandboxes
 
 # ---- Run database migrations ----
 

--- a/containers/entrypoint.combined.sh
+++ b/containers/entrypoint.combined.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Entrypoint script for combined OpenHands + Automation container
+#
+# Sets sensible defaults for local mode while allowing runtime overrides.
+
+set -e
+
+# ---- Local mode defaults ----
+
+# API key for automation service to communicate with embedded agent server
+export AUTOMATION_AGENT_SERVER_API_KEY="${AUTOMATION_AGENT_SERVER_API_KEY:-local-embedded}"
+
+# Session API key for agent server authentication
+export SESSION_API_KEY="${SESSION_API_KEY:-local-embedded}"
+
+# Auth bypass for self-hosted mode (no OpenHands Cloud auth required)
+export AUTOMATION_AUTH_DISABLED="${AUTOMATION_AUTH_DISABLED:-true}"
+
+# ---- LLM Configuration ----
+# Support simplified env var names (LLM_MODEL, LLM_API_KEY, LLM_BASE_URL)
+# and propagate to both OpenHands and Automation services
+
+if [[ -n "${LLM_MODEL}" ]]; then
+    # For OpenHands App Server settings API
+    export OPENHANDS_LLM_MODEL="${LLM_MODEL}"
+    # For Automation Service preset scripts
+    export AUTOMATION_LLM_MODEL="${LLM_MODEL}"
+fi
+
+if [[ -n "${LLM_API_KEY}" ]]; then
+    export OPENHANDS_LLM_API_KEY="${LLM_API_KEY}"
+    export AUTOMATION_LLM_API_KEY="${LLM_API_KEY}"
+fi
+
+if [[ -n "${LLM_BASE_URL}" ]]; then
+    export OPENHANDS_LLM_BASE_URL="${LLM_BASE_URL}"
+    export AUTOMATION_LLM_BASE_URL="${LLM_BASE_URL}"
+fi
+
+# ---- Create data directories ----
+mkdir -p /data/openhands /data/storage /tmp/openhands-sandboxes
+chmod 755 /data/openhands /data/storage /tmp/openhands-sandboxes
+
+# ---- Run database migrations ----
+
+# Automation service migrations (using automation venv)
+if [[ "${AUTOMATION_DB_URL}" == sqlite* ]] && [[ ! -f /data/automations.db ]]; then
+    echo "Initializing Automation SQLite database..."
+    cd /app/automation-src && /app/automation-venv/bin/alembic upgrade head
+fi
+
+# OpenHands migrations are handled by the app's lifespan startup
+
+# ---- Validation warnings ----
+if [[ "${AUTOMATION_AGENT_SERVER_API_KEY}" == "local-embedded" ]] && \
+   [[ -n "${PRODUCTION}" || -n "${OPENHANDS_API_KEY}" ]]; then
+    echo "WARNING: Using default API keys in what appears to be a production setup."
+    echo "         Consider setting AUTOMATION_AGENT_SERVER_API_KEY and SESSION_API_KEY."
+fi
+
+if [[ -z "${LLM_MODEL}" ]] && [[ -z "${OPENHANDS_LLM_MODEL}" ]]; then
+    echo "WARNING: No LLM model configured. Set LLM_MODEL environment variable."
+    echo "         Example: -e LLM_MODEL=anthropic/claude-sonnet-4-20250514"
+fi
+
+if [[ -z "${LLM_API_KEY}" ]] && [[ -z "${OPENHANDS_LLM_API_KEY}" ]]; then
+    echo "WARNING: No LLM API key configured. Set LLM_API_KEY environment variable."
+fi
+
+echo "Starting OpenHands Local (GUI + Automations)..."
+echo "  - GUI:         http://localhost:8000/"
+echo "  - Automations: http://localhost:8000/automations/"
+echo "  - API Docs:    http://localhost:8000/api/automation/docs"
+
+# ---- Execute the main command ----
+exec "$@"

--- a/containers/entrypoint.combined.sh
+++ b/containers/entrypoint.combined.sh
@@ -11,7 +11,11 @@ set -e
 export AUTOMATION_AGENT_SERVER_API_KEY="${AUTOMATION_AGENT_SERVER_API_KEY:-local-embedded}"
 
 # Session API key for agent server authentication
-export SESSION_API_KEY="${SESSION_API_KEY:-local-embedded}"
+# Note: This is set via supervisord environment for agent-server ONLY.
+# Do NOT export here - it would require X-Session-API-Key header for all
+# browser requests to OpenHands GUI, breaking the frontend.
+# The value is passed to supervisord as AGENT_SERVER_SESSION_API_KEY
+export AGENT_SERVER_SESSION_API_KEY="${SESSION_API_KEY:-local-embedded}"
 
 # Auth bypass for self-hosted mode (no OpenHands Cloud auth required)
 export AUTOMATION_AUTH_DISABLED="${AUTOMATION_AUTH_DISABLED:-true}"

--- a/containers/entrypoint.combined.sh
+++ b/containers/entrypoint.combined.sh
@@ -38,8 +38,8 @@ if [[ -n "${LLM_BASE_URL}" ]]; then
 fi
 
 # ---- Create data directories ----
-mkdir -p /data/openhands /data/storage /data/sessions /tmp/openhands-sandboxes
-chmod 755 /data/openhands /data/storage /data/sessions /tmp/openhands-sandboxes
+mkdir -p /data/openhands /data/storage /data/sessions /root/.openhands/conversations /tmp/openhands-sandboxes
+chmod 755 /data/openhands /data/storage /data/sessions /root/.openhands /root/.openhands/conversations /tmp/openhands-sandboxes
 
 # ---- Run database migrations ----
 

--- a/containers/entrypoint.combined.sh
+++ b/containers/entrypoint.combined.sh
@@ -38,8 +38,8 @@ if [[ -n "${LLM_BASE_URL}" ]]; then
 fi
 
 # ---- Create data directories ----
-mkdir -p /data/openhands /data/storage /tmp/openhands-sandboxes
-chmod 755 /data/openhands /data/storage /tmp/openhands-sandboxes
+mkdir -p /data/openhands /data/storage /data/sessions /tmp/openhands-sandboxes
+chmod 755 /data/openhands /data/storage /data/sessions /tmp/openhands-sandboxes
 
 # ---- Run database migrations ----
 

--- a/containers/entrypoint.sh
+++ b/containers/entrypoint.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Entrypoint script for self-hosted automation container
+#
+# Sets sensible defaults for local mode while allowing runtime overrides.
+# This avoids baking sensitive-looking values into Docker image layers.
+
+set -e
+
+# ---- Local mode defaults ----
+# These are safe defaults for self-hosted deployments where the agent server
+# is embedded in the same container. Override with real secrets for production.
+
+# API key for automation service to communicate with embedded agent server
+export AUTOMATION_AGENT_SERVER_API_KEY="${AUTOMATION_AGENT_SERVER_API_KEY:-local-embedded}"
+
+# Session API key for agent server authentication
+export SESSION_API_KEY="${SESSION_API_KEY:-local-embedded}"
+
+# Auth bypass for self-hosted mode (no OpenHands Cloud auth required)
+# Set to "false" to require authentication
+export AUTOMATION_AUTH_DISABLED="${AUTOMATION_AUTH_DISABLED:-true}"
+
+# ---- Validation ----
+# Warn if using defaults in what looks like a production setup
+if [[ "${AUTOMATION_AGENT_SERVER_API_KEY}" == "local-embedded" ]] && \
+   [[ -n "${PRODUCTION}" || -n "${OPENHANDS_API_KEY}" ]]; then
+    echo "WARNING: Using default API keys in what appears to be a production setup."
+    echo "         Consider setting AUTOMATION_AGENT_SERVER_API_KEY and SESSION_API_KEY."
+fi
+
+# ---- Run migrations if database doesn't exist ----
+if [[ "${AUTOMATION_DB_URL}" == sqlite* ]] && [[ ! -f /data/automations.db ]]; then
+    echo "Initializing SQLite database..."
+    cd /app && alembic upgrade head
+fi
+
+# ---- Execute the main command ----
+exec "$@"

--- a/containers/nginx.conf
+++ b/containers/nginx.conf
@@ -2,11 +2,11 @@
 #
 # Routes:
 #   /                     -> OpenHands GUI (static files)
-#   /api/v1/*             -> OpenHands App Server (port 3000)
+#   /api/*                -> OpenHands App Server (port 3000)
 #   /mcp/*                -> OpenHands MCP endpoint (port 3000)
 #   /health               -> OpenHands health check (port 3000)
 #   /automations/*        -> Automation GUI (static files)
-#   /api/automation/*     -> Automation Service (port 8001)
+#   /api/automation/*     -> Automation Service (port 8001) [higher priority]
 
 user root;
 worker_processes auto;
@@ -90,9 +90,10 @@ http {
 
         # ---- OpenHands App Server Routes ----
         
-        # OpenHands API
-        location /api/v1/ {
-            proxy_pass http://openhands/api/v1/;
+        # OpenHands API (all /api/* except /api/automation/*)
+        # Must come after /api/automation/ which has higher priority
+        location /api/ {
+            proxy_pass http://openhands/api/;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;

--- a/containers/nginx.conf
+++ b/containers/nginx.conf
@@ -1,0 +1,147 @@
+# Nginx configuration for combined OpenHands + Automation service
+#
+# Routes:
+#   /                     -> OpenHands GUI (static files)
+#   /api/v1/*             -> OpenHands App Server (port 3000)
+#   /mcp/*                -> OpenHands MCP endpoint (port 3000)
+#   /health               -> OpenHands health check (port 3000)
+#   /automations/*        -> Automation GUI (static files)
+#   /api/automation/*     -> Automation Service (port 8001)
+
+user root;
+worker_processes auto;
+pid /tmp/nginx.pid;
+error_log /dev/stderr warn;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent"';
+
+    access_log /dev/stdout main;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+
+    # Gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml;
+
+    # Upstream servers
+    upstream openhands {
+        server 127.0.0.1:3000;
+    }
+
+    upstream automation {
+        server 127.0.0.1:8001;
+    }
+
+    server {
+        listen 8000 default_server;
+        server_name _;
+
+        # Client body size for file uploads
+        client_max_body_size 100M;
+
+        # ---- Automation Service Routes ----
+        
+        # Automation API
+        location /api/automation/ {
+            proxy_pass http://automation/api/automation/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # WebSocket support (for SSE/streaming)
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_read_timeout 300s;
+            proxy_buffering off;
+        }
+
+        # Automation GUI (static files with SPA fallback)
+        location /automations/ {
+            alias /app/automation-frontend/;
+            try_files $uri $uri/ /automations/index.html;
+            
+            # Cache static assets
+            location ~* /automations/assets/ {
+                expires 1y;
+                add_header Cache-Control "public, immutable";
+            }
+        }
+        
+        # Redirect /automations to /automations/
+        location = /automations {
+            return 301 /automations/;
+        }
+
+        # ---- OpenHands App Server Routes ----
+        
+        # OpenHands API
+        location /api/v1/ {
+            proxy_pass http://openhands/api/v1/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # WebSocket/SSE support
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_read_timeout 300s;
+            proxy_buffering off;
+        }
+
+        # MCP endpoint
+        location /mcp/ {
+            proxy_pass http://openhands/mcp/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 300s;
+            proxy_buffering off;
+        }
+
+        # Health check (proxied to OpenHands for now)
+        location = /health {
+            proxy_pass http://openhands/health;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+        }
+
+        # ---- OpenHands GUI (default) ----
+        
+        # Serve OpenHands frontend as the main UI
+        location / {
+            root /app/openhands-frontend;
+            try_files $uri $uri/ /index.html;
+            
+            # Cache static assets
+            location ~* /assets/ {
+                expires 1y;
+                add_header Cache-Control "public, immutable";
+            }
+            
+            # Don't cache index.html
+            location = /index.html {
+                add_header Cache-Control "no-cache, must-revalidate";
+            }
+        }
+    }
+}

--- a/containers/supervisord.combined.conf
+++ b/containers/supervisord.combined.conf
@@ -32,7 +32,7 @@ priority=5
 [program:openhands]
 command=/app/.venv/bin/python -m uvicorn openhands.server.listen:app --host 127.0.0.1 --port 3000
 directory=/app
-environment=PYTHONPATH="/app",VIRTUAL_ENV="/app/.venv",PATH="/app/.venv/bin:%(ENV_PATH)s",OPENHANDS_SUPPRESS_BANNER="1",RUNTIME="local",OH_PERSISTENCE_DIR="/data/openhands",SERVE_FRONTEND="false"
+environment=PYTHONPATH="/app",VIRTUAL_ENV="/app/.venv",PATH="/app/.venv/bin:%(ENV_PATH)s",OPENHANDS_SUPPRESS_BANNER="1",RUNTIME="local",OH_PERSISTENCE_DIR="/data/openhands",SERVE_FRONTEND="false",SKIP_DEPENDENCY_CHECK="1"
 autostart=true
 autorestart=true
 startretries=3

--- a/containers/supervisord.combined.conf
+++ b/containers/supervisord.combined.conf
@@ -1,0 +1,77 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/stdout
+logfile_maxbytes=0
+pidfile=/tmp/supervisord.pid
+user=root
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+# ---- Nginx (main entry point on port 8000) ----
+[program:nginx]
+command=nginx -g "daemon off;"
+autostart=true
+autorestart=true
+startretries=3
+startsecs=2
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+priority=5
+
+# ---- OpenHands App Server (port 3000) ----
+# Serves the GUI frontend and manages conversation sandboxes
+[program:openhands]
+command=/app/.venv/bin/python -m uvicorn openhands.server.listen:app --host 127.0.0.1 --port 3000
+directory=/app
+environment=PYTHONPATH="/app",VIRTUAL_ENV="/app/.venv",PATH="/app/.venv/bin:%(ENV_PATH)s",OPENHANDS_SUPPRESS_BANNER="1",RUNTIME="local",OH_PERSISTENCE_DIR="/data/openhands",SERVE_FRONTEND="false"
+autostart=true
+autorestart=true
+startretries=3
+startsecs=5
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+priority=10
+
+# ---- Agent Server for Automations (port 3002) ----
+# This is the embedded agent server used by automation runs
+# (separate from ProcessSandboxService which spawns its own)
+[program:agent-server]
+command=/usr/local/bin/openhands-agent-server --port %(ENV_AGENT_SERVER_PORT)s
+directory=/workspace
+environment=SESSION_API_KEY="%(ENV_SESSION_API_KEY)s",OPENHANDS_SUPPRESS_BANNER="1"
+autostart=true
+autorestart=true
+startretries=3
+startsecs=5
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+priority=15
+
+# ---- Automation Service (port 8001) ----
+# Uses its own venv at /app/automation-venv to avoid SDK version conflicts
+[program:automation]
+command=/app/automation-venv/bin/uvicorn automation.app:app --host 127.0.0.1 --port 8001
+directory=/app/automation-src
+environment=PYTHONPATH="/app/automation-src",VIRTUAL_ENV="/app/automation-venv",PATH="/app/automation-venv/bin:%(ENV_PATH)s",OPENHANDS_SUPPRESS_BANNER="1"
+autostart=true
+autorestart=true
+startretries=3
+startsecs=10
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+priority=20

--- a/containers/supervisord.combined.conf
+++ b/containers/supervisord.combined.conf
@@ -46,10 +46,11 @@ priority=10
 # ---- Agent Server for Automations (port 3002) ----
 # This is the embedded agent server used by automation runs
 # (separate from ProcessSandboxService which spawns its own)
+# Conversations are saved to ~/.openhands/conversations (mount your ~/.openhands)
 [program:agent-server]
 command=/usr/local/bin/openhands-agent-server --port %(ENV_AGENT_SERVER_PORT)s
 directory=/workspace
-environment=SESSION_API_KEY="%(ENV_SESSION_API_KEY)s",OPENHANDS_SUPPRESS_BANNER="1"
+environment=SESSION_API_KEY="%(ENV_SESSION_API_KEY)s",OH_CONVERSATIONS_PATH="/root/.openhands/conversations",OPENHANDS_SUPPRESS_BANNER="1"
 autostart=true
 autorestart=true
 startretries=3

--- a/containers/supervisord.combined.conf
+++ b/containers/supervisord.combined.conf
@@ -29,10 +29,12 @@ priority=5
 
 # ---- OpenHands App Server (port 3000) ----
 # Serves the GUI frontend and manages conversation sandboxes
+# Note: SESSION_API_KEY is explicitly NOT set here - if set, it would require
+# X-Session-API-Key header on all browser requests, breaking the GUI
 [program:openhands]
 command=/app/.venv/bin/python -m uvicorn openhands.server.listen:app --host 127.0.0.1 --port 3000
 directory=/app
-environment=PYTHONPATH="/app",VIRTUAL_ENV="/app/.venv",PATH="/app/.venv/bin:%(ENV_PATH)s",OPENHANDS_SUPPRESS_BANNER="1",RUNTIME="local",OH_PERSISTENCE_DIR="/data/openhands",SERVE_FRONTEND="false",SKIP_DEPENDENCY_CHECK="1"
+environment=PYTHONPATH="/app",VIRTUAL_ENV="/app/.venv",PATH="/app/.venv/bin:%(ENV_PATH)s",OPENHANDS_SUPPRESS_BANNER="1",RUNTIME="local",SERVE_FRONTEND="false",SKIP_DEPENDENCY_CHECK="1",FILE_STORE_PATH="/root/.openhands",OH_PERSISTENCE_DIR="/root/.openhands"
 autostart=true
 autorestart=true
 startretries=3
@@ -50,7 +52,7 @@ priority=10
 [program:agent-server]
 command=/usr/local/bin/openhands-agent-server --port %(ENV_AGENT_SERVER_PORT)s
 directory=/workspace
-environment=SESSION_API_KEY="%(ENV_SESSION_API_KEY)s",OH_CONVERSATIONS_PATH="/root/.openhands/conversations",OPENHANDS_SUPPRESS_BANNER="1"
+environment=SESSION_API_KEY="%(ENV_AGENT_SERVER_SESSION_API_KEY)s",OH_CONVERSATIONS_PATH="/root/.openhands/conversations",OPENHANDS_SUPPRESS_BANNER="1"
 autostart=true
 autorestart=true
 startretries=3

--- a/containers/supervisord.conf
+++ b/containers/supervisord.conf
@@ -1,0 +1,33 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/stdout
+logfile_maxbytes=0
+pidfile=/tmp/supervisord.pid
+user=root
+
+[program:agent-server]
+command=/agent-server/.venv/bin/python -m openhands.agent_server --port %(ENV_AGENT_SERVER_PORT)s
+directory=/agent-server
+environment=SESSION_API_KEY="%(ENV_SESSION_API_KEY)s"
+autostart=true
+autorestart=true
+startretries=3
+startsecs=5
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+priority=10
+
+[program:automation]
+command=uvicorn automation.app:app --host 0.0.0.0 --port 8000
+directory=/app
+autostart=true
+autorestart=true
+startretries=3
+startsecs=10
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+priority=20

--- a/containers/supervisord.conf
+++ b/containers/supervisord.conf
@@ -5,10 +5,19 @@ logfile_maxbytes=0
 pidfile=/tmp/supervisord.pid
 user=root
 
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
 [program:agent-server]
-command=/agent-server/.venv/bin/python -m openhands.agent_server --port %(ENV_AGENT_SERVER_PORT)s
-directory=/agent-server
-environment=SESSION_API_KEY="%(ENV_SESSION_API_KEY)s"
+command=/usr/local/bin/openhands-agent-server --port %(ENV_AGENT_SERVER_PORT)s
+directory=/workspace
+environment=SESSION_API_KEY="%(ENV_SESSION_API_KEY)s",OPENHANDS_SUPPRESS_BANNER="1"
 autostart=true
 autorestart=true
 startretries=3
@@ -22,6 +31,7 @@ priority=10
 [program:automation]
 command=uvicorn automation.app:app --host 0.0.0.0 --port 8000
 directory=/app
+environment=OPENHANDS_SUPPRESS_BANNER="1"
 autostart=true
 autorestart=true
 startretries=3

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -14,97 +14,205 @@ The automation service supports two execution modes:
 | Auth | Per-user API keys via service key | Config-level API key |
 | Sandbox cleanup | Automatic after run | Not needed (persistent server) |
 
-## Prerequisites
+---
+
+## Quick Start with Docker (Recommended)
+
+The easiest way to run self-hosted is using the combined Docker image that packages everything:
+- Automation service (scheduler, dispatcher, API)
+- Agent server (from OpenHands SDK)
+- SQLite database
+
+### 1. Create Environment File
+
+```bash
+# Copy the example file
+cp .env.local.example .env.local
+
+# Edit with your LLM configuration
+cat > .env.local << 'EOF'
+OPENHANDS_LLM_MODEL=anthropic/claude-sonnet-4-20250514
+OPENHANDS_LLM_API_KEY=sk-ant-your-key-here
+EOF
+```
+
+### 2. Run the Combined Container
+
+```bash
+docker run -d \
+  --name automation \
+  -p 8000:8000 \
+  -v ./workspace:/workspace \
+  -v ./data:/data \
+  --env-file .env.local \
+  ghcr.io/openhands/automation-local:latest
+```
+
+### 3. Verify the Service
+
+```bash
+# Wait for startup (about 10 seconds)
+sleep 10
+
+# Health check
+curl http://localhost:8000/api/automation/health
+
+# Open the UI
+open http://localhost:8000/automations
+```
+
+### What's in the Container?
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│              Combined Local Container                        │
+│                                                              │
+│  ┌──────────────────┐    ┌──────────────────────────┐       │
+│  │  Automation      │    │  Agent Server            │       │
+│  │  Service :8000   │───▶│  (from SDK) :3000        │       │
+│  │                  │    │                          │       │
+│  │  - Scheduler     │    │  - Bash execution        │       │
+│  │  - Dispatcher    │    │  - File operations       │       │
+│  │  - API routes    │    │  - SDK workspace         │       │
+│  └──────────────────┘    └──────────────────────────┘       │
+│                                                              │
+│  /workspace ──── user's project files (volume)              │
+│  /data/automations.db ──── SQLite database (volume)         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Building the Docker Image Locally
+
+If you want to build the combined image yourself:
+
+### Prerequisites
+
+- Docker 20.10+
+- Git
+
+### Build Steps
+
+```bash
+# Clone the repository
+git clone https://github.com/OpenHands/automation.git
+cd automation
+
+# Build the combined local image
+docker build -f containers/Dockerfile.local -t automation-local:dev .
+
+# Run your local build
+docker run -d \
+  --name automation \
+  -p 8000:8000 \
+  -v ./workspace:/workspace \
+  -v ./data:/data \
+  -e OPENHANDS_LLM_MODEL=anthropic/claude-sonnet-4-20250514 \
+  -e OPENHANDS_LLM_API_KEY=sk-ant-your-key-here \
+  automation-local:dev
+```
+
+### Build Options
+
+The `Dockerfile.local` uses multi-stage builds:
+
+1. **Stage 1** (`frontend-build`): Builds the frontend SPA
+2. **Stage 2** (`agent-server`): Pulls the agent server from `ghcr.io/openhands/agent-server`
+3. **Stage 3**: Combines everything into the final image
+
+### Troubleshooting Build Issues
+
+**"Cannot pull agent-server image"**
+```bash
+# Try pulling the base image manually first
+docker pull ghcr.io/openhands/agent-server:latest-python
+
+# If that fails, check your Docker authentication
+docker login ghcr.io
+```
+
+**"Frontend build fails"**
+```bash
+# Ensure the frontend directory exists
+ls frontend/package.json
+
+# If no frontend, build without it (API only mode)
+# Edit Dockerfile.local to remove the frontend stage
+```
+
+---
+
+## Manual Installation (Without Docker)
+
+For development or when Docker isn't available.
+
+### Prerequisites
 
 - Python 3.12+
 - [uv](https://github.com/astral-sh/uv) package manager
-- A running OpenHands agent server (see [Running Agent Server](#running-agent-server))
+- A running OpenHands agent server
 
-## Quick Start
-
-### 1. Clone the Repository
+### 1. Clone and Install
 
 ```bash
 git clone https://github.com/OpenHands/automation.git
 cd automation
-```
-
-### 2. Install Dependencies
-
-```bash
 uv sync
 ```
 
-### 3. Configure Environment
-
-Create a `.env` file or export environment variables:
+### 2. Configure Environment
 
 ```bash
 # Required: Agent server connection
 export AUTOMATION_AGENT_SERVER_URL="http://localhost:3000"
 export AUTOMATION_AGENT_SERVER_API_KEY="your-agent-server-key"
 
-# Required: SQLite database (or use PostgreSQL)
+# Required: SQLite database
 export AUTOMATION_DB_URL="sqlite+aiosqlite:///./automation.db"
 
-# Required: Base URL for callbacks (use your external URL)
+# Required: Base URL for callbacks
 export AUTOMATION_BASE_URL="http://localhost:8000/api/automation"
 
-# Optional: OpenHands Cloud API for LLM/secrets/MCP (hybrid mode)
-# export AUTOMATION_OPENHANDS_API_BASE_URL="https://app.all-hands.dev"
-# export OPENHANDS_API_KEY="sk-oh-..."
+# Required: LLM configuration (for preset automations)
+export OPENHANDS_LLM_MODEL="anthropic/claude-sonnet-4-20250514"
+export OPENHANDS_LLM_API_KEY="sk-ant-..."
 ```
 
-### 4. Start the Service
+### 3. Start Agent Server
+
+The agent server is part of the [OpenHands SDK](https://github.com/OpenHands/software-agent-sdk):
+
+```bash
+# Option A: Run from SDK repository
+git clone https://github.com/OpenHands/software-agent-sdk.git
+cd software-agent-sdk/openhands-agent-server
+uv sync
+SESSION_API_KEY=your-key uv run python -m openhands.agent_server --port 3000
+```
+
+```bash
+# Option B: Use Docker
+docker run -p 3000:3000 \
+  -e SESSION_API_KEY=your-key \
+  ghcr.io/openhands/agent-server:latest-python
+```
+
+### 4. Start Automation Service
 
 ```bash
 uv run uvicorn automation.app:app --host 0.0.0.0 --port 8000
 ```
 
-The service will:
-- Create SQLite tables automatically on first startup
-- Start the scheduler (creates PENDING runs from cron triggers)
-- Start the dispatcher (executes PENDING runs on the agent server)
-- Start the watchdog (marks stale RUNNING runs as FAILED)
-
-### 5. Verify the Service
+### 5. Verify
 
 ```bash
 # Health check
 curl http://localhost:8000/api/automation/health
 
-# List automations (requires auth in production)
+# List automations
 curl http://localhost:8000/api/automation/v1
 ```
-
----
-
-## Running Agent Server
-
-The automation service dispatches work to an OpenHands agent server. You need a running agent server accessible via HTTP.
-
-### Option A: Run Agent Server Locally
-
-```bash
-# Clone OpenHands
-git clone https://github.com/All-Hands-AI/OpenHands.git
-cd OpenHands
-
-# Start agent server (see OpenHands docs for full setup)
-poetry run python -m openhands.server
-```
-
-The agent server typically runs on `http://localhost:3000`.
-
-### Option B: Use Docker
-
-```bash
-docker run -p 3000:3000 ghcr.io/all-hands-ai/openhands:latest
-```
-
-### Option C: Use Existing Deployment
-
-Point `AUTOMATION_AGENT_SERVER_URL` to any accessible OpenHands agent server.
 
 ---
 

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -1,0 +1,311 @@
+# Self-Hosted Deployment Guide
+
+This guide explains how to run the Automation Service in self-hosted mode, using a local agent server and SQLite database instead of OpenHands Cloud infrastructure.
+
+## Overview
+
+The automation service supports two execution modes:
+
+| Feature | Cloud Mode (default) | Local Mode (self-hosted) |
+|---------|---------------------|--------------------------|
+| Execution environment | Fresh Cloud sandbox per run | Persistent local agent server |
+| Database | PostgreSQL (Cloud SQL) | SQLite or PostgreSQL |
+| LLM/Secrets/MCP config | OpenHands Cloud API | Optional Cloud API or manual config |
+| Auth | Per-user API keys via service key | Config-level API key |
+| Sandbox cleanup | Automatic after run | Not needed (persistent server) |
+
+## Prerequisites
+
+- Python 3.12+
+- [uv](https://github.com/astral-sh/uv) package manager
+- A running OpenHands agent server (see [Running Agent Server](#running-agent-server))
+
+## Quick Start
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/OpenHands/automation.git
+cd automation
+```
+
+### 2. Install Dependencies
+
+```bash
+uv sync
+```
+
+### 3. Configure Environment
+
+Create a `.env` file or export environment variables:
+
+```bash
+# Required: Agent server connection
+export AUTOMATION_AGENT_SERVER_URL="http://localhost:3000"
+export AUTOMATION_AGENT_SERVER_API_KEY="your-agent-server-key"
+
+# Required: SQLite database (or use PostgreSQL)
+export AUTOMATION_DB_URL="sqlite+aiosqlite:///./automation.db"
+
+# Required: Base URL for callbacks (use your external URL)
+export AUTOMATION_BASE_URL="http://localhost:8000/api/automation"
+
+# Optional: OpenHands Cloud API for LLM/secrets/MCP (hybrid mode)
+# export AUTOMATION_OPENHANDS_API_BASE_URL="https://app.all-hands.dev"
+# export OPENHANDS_API_KEY="sk-oh-..."
+```
+
+### 4. Start the Service
+
+```bash
+uv run uvicorn automation.app:app --host 0.0.0.0 --port 8000
+```
+
+The service will:
+- Create SQLite tables automatically on first startup
+- Start the scheduler (creates PENDING runs from cron triggers)
+- Start the dispatcher (executes PENDING runs on the agent server)
+- Start the watchdog (marks stale RUNNING runs as FAILED)
+
+### 5. Verify the Service
+
+```bash
+# Health check
+curl http://localhost:8000/api/automation/health
+
+# List automations (requires auth in production)
+curl http://localhost:8000/api/automation/v1
+```
+
+---
+
+## Running Agent Server
+
+The automation service dispatches work to an OpenHands agent server. You need a running agent server accessible via HTTP.
+
+### Option A: Run Agent Server Locally
+
+```bash
+# Clone OpenHands
+git clone https://github.com/All-Hands-AI/OpenHands.git
+cd OpenHands
+
+# Start agent server (see OpenHands docs for full setup)
+poetry run python -m openhands.server
+```
+
+The agent server typically runs on `http://localhost:3000`.
+
+### Option B: Use Docker
+
+```bash
+docker run -p 3000:3000 ghcr.io/all-hands-ai/openhands:latest
+```
+
+### Option C: Use Existing Deployment
+
+Point `AUTOMATION_AGENT_SERVER_URL` to any accessible OpenHands agent server.
+
+---
+
+## Configuration Reference
+
+### Required Settings
+
+| Environment Variable | Description | Example |
+|---------------------|-------------|---------|
+| `AUTOMATION_AGENT_SERVER_URL` | Agent server URL | `http://localhost:3000` |
+| `AUTOMATION_AGENT_SERVER_API_KEY` | Agent server API key | `your-secret-key` |
+| `AUTOMATION_DB_URL` | Database URL | `sqlite+aiosqlite:///./automation.db` |
+| `AUTOMATION_BASE_URL` | Service base URL (for callbacks) | `http://localhost:8000/api/automation` |
+
+### Optional Settings
+
+| Environment Variable | Description | Default |
+|---------------------|-------------|---------|
+| `AUTOMATION_OPENHANDS_API_BASE_URL` | Cloud API for LLM/secrets/MCP | (none) |
+| `OPENHANDS_API_KEY` | Cloud API key | (none) |
+| `AUTOMATION_SCHEDULER_INTERVAL` | Scheduler poll interval (seconds) | `10` |
+| `AUTOMATION_DISPATCHER_INTERVAL` | Dispatcher poll interval (seconds) | `5` |
+| `AUTOMATION_WATCHDOG_INTERVAL` | Watchdog poll interval (seconds) | `30` |
+
+### Database Options
+
+**SQLite** (recommended for local/single-instance):
+```bash
+AUTOMATION_DB_URL="sqlite+aiosqlite:///./automation.db"
+```
+
+**PostgreSQL** (recommended for production):
+```bash
+AUTOMATION_DB_URL="postgresql+asyncpg://user:pass@localhost:5432/automation"
+```
+
+---
+
+## Creating Automations
+
+### Using the API
+
+```bash
+# Create a cron-triggered automation
+curl -X POST http://localhost:8000/api/automation/v1/preset/prompt \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Daily Report",
+    "prompt": "Generate a status report and save it to /tmp/report.txt",
+    "trigger": {
+      "type": "cron",
+      "schedule": "0 9 * * *",
+      "timezone": "UTC"
+    }
+  }'
+
+# Manually trigger a run
+curl -X POST http://localhost:8000/api/automation/v1/{automation_id}/dispatch
+
+# List runs
+curl http://localhost:8000/api/automation/v1/{automation_id}/runs
+```
+
+### Run Lifecycle
+
+1. **PENDING** - Run created by scheduler or manual trigger
+2. **RUNNING** - Dispatcher picked up run and started execution
+3. **COMPLETED** - Run finished successfully (callback received)
+4. **FAILED** - Run failed (error or timeout)
+
+---
+
+## Hybrid Mode
+
+Hybrid mode uses a local agent server for execution but connects to OpenHands Cloud for:
+- LLM configuration (`workspace.get_llm()`)
+- Secrets (`workspace.get_secrets()`)
+- MCP server config (`workspace.get_mcp_config()`)
+
+To enable hybrid mode, set both agent server AND Cloud API config:
+
+```bash
+# Local execution
+export AUTOMATION_AGENT_SERVER_URL="http://localhost:3000"
+export AUTOMATION_AGENT_SERVER_API_KEY="local-key"
+
+# Cloud API for LLM/secrets/MCP
+export AUTOMATION_OPENHANDS_API_BASE_URL="https://app.all-hands.dev"
+export OPENHANDS_API_KEY="sk-oh-your-cloud-key"
+```
+
+---
+
+## Development
+
+### Running Tests
+
+```bash
+# Unit tests (no external dependencies)
+uv run pytest tests/ -v --ignore=tests/integration
+
+# Integration tests (requires OPENHANDS_API_KEY)
+OPENHANDS_API_KEY=sk-oh-... uv run pytest tests/integration/ -v
+```
+
+### Pre-commit Checks
+
+```bash
+uv run pre-commit run --all-files
+```
+
+### Local Development with Hot Reload
+
+```bash
+uv run uvicorn automation.app:app --reload --host 0.0.0.0 --port 8000
+```
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Automation Service                        │
+│  ┌──────────────┐  ┌─────────────┐  ┌──────────────┐        │
+│  │  Scheduler   │  │  Dispatcher │  │   Watchdog   │        │
+│  │ (cron→PEND)  │  │ (PEND→RUN)  │  │ (stale→FAIL) │        │
+│  └──────┬───────┘  └──────┬──────┘  └──────┬───────┘        │
+│         │                 │                 │                │
+│         └─────────────────┼─────────────────┘                │
+│                           │                                  │
+│                    ┌──────▼──────┐                           │
+│                    │  SQLite DB  │                           │
+│                    └─────────────┘                           │
+└───────────────────────────┬─────────────────────────────────┘
+                            │
+                            │ HTTP (tarball upload, bash commands)
+                            ▼
+                    ┌───────────────┐
+                    │ Agent Server  │
+                    │ (persistent)  │
+                    └───────────────┘
+```
+
+### Components
+
+- **Scheduler**: Polls automations table, creates PENDING runs for due cron schedules
+- **Dispatcher**: Polls PENDING runs, uploads tarball, starts entrypoint on agent server
+- **Watchdog**: Scans for RUNNING runs past timeout, verifies status, marks as FAILED if needed
+- **Backend Abstraction**: `LocalAgentServerBackend` handles all local-mode specifics
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+**"Agent server not reachable"**
+- Verify `AUTOMATION_AGENT_SERVER_URL` is correct
+- Check agent server is running: `curl http://localhost:3000/api/health`
+- Check network connectivity
+
+**"Database locked" (SQLite)**
+- SQLite doesn't support concurrent writes well
+- For production, use PostgreSQL
+- Ensure only one instance of the service is running
+
+**"Run stuck in RUNNING"**
+- Watchdog will mark as FAILED after timeout
+- Check agent server logs for errors
+- Verify callback URL is reachable from agent server
+
+**"No LLM config" (hybrid mode)**
+- Verify `AUTOMATION_OPENHANDS_API_BASE_URL` and `OPENHANDS_API_KEY` are set
+- Check Cloud API key is valid: `curl -H "Authorization: Bearer $OPENHANDS_API_KEY" https://app.all-hands.dev/api/v1/users/me`
+
+### Logs
+
+Enable debug logging:
+
+```bash
+export AUTOMATION_LOG_LEVEL="DEBUG"
+```
+
+---
+
+## Security Considerations
+
+- **API Key Security**: Store `AUTOMATION_AGENT_SERVER_API_KEY` securely (not in version control)
+- **Database Access**: SQLite file permissions should be restricted
+- **Network**: In production, use HTTPS and proper firewall rules
+- **Auth**: The service authenticates requests via OpenHands Cloud API or custom middleware
+
+---
+
+## Migration from Cloud Mode
+
+If migrating an existing Cloud-mode deployment to self-hosted:
+
+1. Export your automations via the API
+2. Set up local agent server and database
+3. Configure local mode environment variables
+4. Import automations (update tarball paths if using internal storage)
+5. Update any webhook URLs to point to new service location

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -78,6 +78,7 @@ open http://localhost:8000/automations
 │                                                              │
 │  /workspace ──── user's project files (volume)              │
 │  /data/automations.db ──── SQLite database (volume)         │
+│  /data/storage ──── tarball uploads (local file storage)    │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -172,7 +173,7 @@ export AUTOMATION_AGENT_SERVER_API_KEY="your-agent-server-key"
 export AUTOMATION_DB_URL="sqlite+aiosqlite:///./automation.db"
 
 # Required: Base URL for callbacks
-export AUTOMATION_BASE_URL="http://localhost:8000/api/automation"
+export AUTOMATION_BASE_URL="http://localhost:8000"
 
 # Required: LLM configuration (for preset automations)
 export OPENHANDS_LLM_MODEL="anthropic/claude-sonnet-4-20250514"
@@ -225,7 +226,7 @@ curl http://localhost:8000/api/automation/v1
 | `AUTOMATION_AGENT_SERVER_URL` | Agent server URL | `http://localhost:3000` |
 | `AUTOMATION_AGENT_SERVER_API_KEY` | Agent server API key | `your-secret-key` |
 | `AUTOMATION_DB_URL` | Database URL | `sqlite+aiosqlite:///./automation.db` |
-| `AUTOMATION_BASE_URL` | Service base URL (for callbacks) | `http://localhost:8000/api/automation` |
+| `AUTOMATION_BASE_URL` | Service base URL (for callbacks) | `http://localhost:8000` |
 
 ### Optional Settings
 
@@ -236,6 +237,24 @@ curl http://localhost:8000/api/automation/v1
 | `AUTOMATION_SCHEDULER_INTERVAL` | Scheduler poll interval (seconds) | `10` |
 | `AUTOMATION_DISPATCHER_INTERVAL` | Dispatcher poll interval (seconds) | `5` |
 | `AUTOMATION_WATCHDOG_INTERVAL` | Watchdog poll interval (seconds) | `30` |
+| `AUTOMATION_AUTH_DISABLED` | Disable auth (self-hosted mode) | `false` |
+
+### Storage Options
+
+The Docker image uses local filesystem storage by default. For manual setup:
+
+| Environment Variable | Description | Default |
+|---------------------|-------------|---------|
+| `FILE_STORE` | Storage backend: `gcs`, `s3`, or `local` | `gcs` |
+| `LOCAL_STORAGE_PATH` | Directory for local storage (if `FILE_STORE=local`) | (required) |
+| `GCS_BUCKET_NAME` | GCS bucket (if `FILE_STORE=gcs`) | (required) |
+| `AWS_S3_BUCKET` | S3 bucket (if `FILE_STORE=s3`) | (required) |
+
+For self-hosted mode, set:
+```bash
+FILE_STORE=local
+LOCAL_STORAGE_PATH=/data/storage
+```
 
 ### Database Options
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -97,13 +97,17 @@ class TestLocalAgentServerBackend:
         assert api_key == "local-key"
 
     def test_build_env_vars_basic(self):
-        """build_env_vars() includes AGENT_SERVER_URL."""
+        """build_env_vars() includes AGENT_SERVER_URL and SDK-required vars."""
         backend = LocalAgentServerBackend(
             agent_server_url="http://localhost:3000",
             api_key="local-key",
         )
-        env_vars = backend.build_env_vars("ignored-key")
-        assert env_vars == {"AGENT_SERVER_URL": "http://localhost:3000"}
+        env_vars = backend.build_env_vars("session-key")
+        assert env_vars == {
+            "AGENT_SERVER_URL": "http://localhost:3000",
+            "SANDBOX_ID": "local-mode",
+            "SESSION_API_KEY": "session-key",
+        }
 
     def test_build_env_vars_with_cloud_url(self):
         """build_env_vars() includes OPENHANDS_CLOUD_API_URL if set."""
@@ -112,10 +116,31 @@ class TestLocalAgentServerBackend:
             api_key="local-key",
             cloud_api_url="https://app.all-hands.dev",
         )
-        env_vars = backend.build_env_vars("ignored-key")
+        env_vars = backend.build_env_vars("session-key")
         assert env_vars == {
             "AGENT_SERVER_URL": "http://localhost:3000",
+            "SANDBOX_ID": "local-mode",
+            "SESSION_API_KEY": "session-key",
             "OPENHANDS_CLOUD_API_URL": "https://app.all-hands.dev",
+        }
+
+    def test_build_env_vars_with_llm_config(self):
+        """build_env_vars() includes LLM config when set."""
+        backend = LocalAgentServerBackend(
+            agent_server_url="http://localhost:3000",
+            api_key="local-key",
+            llm_model="anthropic/claude-sonnet-4-20250514",
+            llm_api_key="sk-ant-xxx",
+            llm_base_url="https://custom.api.com",
+        )
+        env_vars = backend.build_env_vars("session-key")
+        assert env_vars == {
+            "AGENT_SERVER_URL": "http://localhost:3000",
+            "SANDBOX_ID": "local-mode",
+            "SESSION_API_KEY": "session-key",
+            "LLM_MODEL": "anthropic/claude-sonnet-4-20250514",
+            "LLM_API_KEY": "sk-ant-xxx",
+            "LLM_BASE_URL": "https://custom.api.com",
         }
 
     @pytest.mark.asyncio

--- a/tests/test_disable_automation.py
+++ b/tests/test_disable_automation.py
@@ -5,7 +5,7 @@ the system should automatically disable it to prevent repeated failed runs.
 """
 
 import uuid
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy import select
@@ -17,6 +17,14 @@ from automation.execution import _is_permanent_http_error
 # Test UUIDs
 TEST_USER_ID = uuid.UUID("12345678-1234-5678-1234-567812345678")
 TEST_ORG_ID = uuid.UUID("87654321-4321-8765-4321-876543218765")
+
+
+def create_mock_backend(is_local_mode: bool = False):
+    """Create a mock backend for testing."""
+    mock_backend = MagicMock()
+    mock_backend.is_local_mode = is_local_mode
+    mock_backend.get_api_key = AsyncMock(return_value="test-api-key")
+    return mock_backend
 
 
 def _docker_available() -> bool:
@@ -207,11 +215,10 @@ class TestDownloadInternalTarball:
 class TestExecuteRunDisablesAutomation:
     """Tests that _execute_run disables automation on permanent errors."""
 
+    @pytest.mark.asyncio
     @patch("automation.dispatcher.dispatch_automation")
-    @patch("automation.dispatcher.get_api_key_for_automation_run")
     async def test_disables_automation_on_internal_tarball_not_found(
         self,
-        mock_get_api_key,
         mock_dispatch,
         async_session_factory,
         mock_settings,
@@ -220,7 +227,7 @@ class TestExecuteRunDisablesAutomation:
         from automation.dispatcher import _execute_run
         from automation.models import Automation, AutomationRun, AutomationRunStatus
 
-        mock_get_api_key.return_value = "test-api-key"
+        mock_backend = create_mock_backend()
 
         # Create an automation with a non-existent internal tarball
         fake_upload_id = uuid.uuid4()
@@ -256,7 +263,8 @@ class TestExecuteRunDisablesAutomation:
             )
             run = result.scalars().first()
 
-            await _execute_run(run, mock_settings, async_session_factory)
+            with patch("automation.dispatcher.get_backend", return_value=mock_backend):
+                await _execute_run(run, mock_settings, async_session_factory)
 
         # Verify automation was disabled
         async with async_session_factory() as session:
@@ -277,11 +285,10 @@ class TestExecuteRunDisablesAutomation:
             assert run.status == AutomationRunStatus.FAILED
             assert "not found" in run.error_detail.lower()
 
+    @pytest.mark.asyncio
     @patch("automation.dispatcher.dispatch_automation")
-    @patch("automation.dispatcher.get_api_key_for_automation_run")
     async def test_does_not_disable_on_transient_error(
         self,
-        mock_get_api_key,
         mock_dispatch,
         async_session_factory,
         mock_settings,
@@ -290,7 +297,7 @@ class TestExecuteRunDisablesAutomation:
         from automation.dispatcher import _execute_run
         from automation.models import Automation, AutomationRun, AutomationRunStatus
 
-        mock_get_api_key.return_value = "test-api-key"
+        mock_backend = create_mock_backend()
         # Simulate a transient dispatch failure (e.g., sandbox creation failed)
         mock_dispatch.return_value = AsyncMock(
             success=False, sandbox_id=None, error="Connection timeout"
@@ -328,7 +335,8 @@ class TestExecuteRunDisablesAutomation:
             )
             run = result.scalars().first()
 
-            await _execute_run(run, mock_settings, async_session_factory)
+            with patch("automation.dispatcher.get_backend", return_value=mock_backend):
+                await _execute_run(run, mock_settings, async_session_factory)
 
         # Verify automation is still enabled (transient error)
         async with async_session_factory() as session:

--- a/tests/test_local_mode.py
+++ b/tests/test_local_mode.py
@@ -110,7 +110,7 @@ class TestGetLastBashCommandResult:
         )
 
         assert result.found is False
-        assert "Not found" in result.error
+        assert result.error is not None and "Not found" in result.error
 
     @pytest.mark.asyncio
     async def test_handles_empty_response(self):

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -6,7 +6,7 @@ with appropriate status based on sandbox verification results.
 
 import uuid
 from datetime import timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -19,6 +19,14 @@ from automation.watchdog import _verify_and_mark_run
 # Test UUIDs
 TEST_USER_ID = uuid.UUID("12345678-1234-5678-1234-567812345678")
 TEST_ORG_ID = uuid.UUID("87654321-4321-8765-4321-876543218765")
+
+
+def create_mock_backend(verification_result: VerificationResult):
+    """Create a mock backend that returns the given verification result."""
+    mock_backend = MagicMock()
+    mock_backend.verify_run = AsyncMock(return_value=verification_result)
+    mock_backend.cleanup_after_verification = AsyncMock()
+    return mock_backend
 
 
 @pytest.fixture
@@ -70,18 +78,9 @@ class TestVerifyAndMarkRunExitCodes:
             stderr="",
         )
 
-        with (
-            patch(
-                "automation.watchdog.verify_run_status",
-                new_callable=AsyncMock,
-                return_value=verification,
-            ),
-            patch(
-                "automation.watchdog.get_api_key_for_automation_run",
-                new_callable=AsyncMock,
-                return_value="test-api-key",
-            ),
-        ):
+        mock_backend = create_mock_backend(verification)
+
+        with patch("automation.watchdog.get_backend", return_value=mock_backend):
             async with async_session_factory() as session:
                 run = await session.get(AutomationRun, run_id)
                 result = await _verify_and_mark_run(session, run, mock_settings)
@@ -111,18 +110,9 @@ class TestVerifyAndMarkRunExitCodes:
             stderr="Command timed out after 60 seconds",
         )
 
-        with (
-            patch(
-                "automation.watchdog.verify_run_status",
-                new_callable=AsyncMock,
-                return_value=verification,
-            ),
-            patch(
-                "automation.watchdog.get_api_key_for_automation_run",
-                new_callable=AsyncMock,
-                return_value="test-api-key",
-            ),
-        ):
+        mock_backend = create_mock_backend(verification)
+
+        with patch("automation.watchdog.get_backend", return_value=mock_backend):
             async with async_session_factory() as session:
                 run = await session.get(AutomationRun, run_id)
                 result = await _verify_and_mark_run(session, run, mock_settings)
@@ -153,18 +143,9 @@ class TestVerifyAndMarkRunExitCodes:
             stderr="",
         )
 
-        with (
-            patch(
-                "automation.watchdog.verify_run_status",
-                new_callable=AsyncMock,
-                return_value=verification,
-            ),
-            patch(
-                "automation.watchdog.get_api_key_for_automation_run",
-                new_callable=AsyncMock,
-                return_value="test-api-key",
-            ),
-        ):
+        mock_backend = create_mock_backend(verification)
+
+        with patch("automation.watchdog.get_backend", return_value=mock_backend):
             async with async_session_factory() as session:
                 run = await session.get(AutomationRun, run_id)
                 result = await _verify_and_mark_run(session, run, mock_settings)
@@ -194,18 +175,9 @@ class TestVerifyAndMarkRunExitCodes:
             stderr="Error: something went wrong",
         )
 
-        with (
-            patch(
-                "automation.watchdog.verify_run_status",
-                new_callable=AsyncMock,
-                return_value=verification,
-            ),
-            patch(
-                "automation.watchdog.get_api_key_for_automation_run",
-                new_callable=AsyncMock,
-                return_value="test-api-key",
-            ),
-        ):
+        mock_backend = create_mock_backend(verification)
+
+        with patch("automation.watchdog.get_backend", return_value=mock_backend):
             async with async_session_factory() as session:
                 run = await session.get(AutomationRun, run_id)
                 result = await _verify_and_mark_run(session, run, mock_settings)
@@ -237,18 +209,9 @@ class TestVerifyAndMarkRunExitCodes:
             stderr="bash: command not found",
         )
 
-        with (
-            patch(
-                "automation.watchdog.verify_run_status",
-                new_callable=AsyncMock,
-                return_value=verification,
-            ),
-            patch(
-                "automation.watchdog.get_api_key_for_automation_run",
-                new_callable=AsyncMock,
-                return_value="test-api-key",
-            ),
-        ):
+        mock_backend = create_mock_backend(verification)
+
+        with patch("automation.watchdog.get_backend", return_value=mock_backend):
             async with async_session_factory() as session:
                 run = await session.get(AutomationRun, run_id)
                 result = await _verify_and_mark_run(session, run, mock_settings)
@@ -279,29 +242,16 @@ class TestVerifyAndMarkRunVerificationFailed:
             error="Sandbox not available",
         )
 
-        with (
-            patch(
-                "automation.watchdog.verify_run_status",
-                new_callable=AsyncMock,
-                return_value=verification,
-            ),
-            patch(
-                "automation.watchdog.get_api_key_for_automation_run",
-                new_callable=AsyncMock,
-                return_value="test-api-key",
-            ),
-            patch(
-                "automation.watchdog.cleanup_sandbox",
-                new_callable=AsyncMock,
-            ) as mock_cleanup,
-        ):
+        mock_backend = create_mock_backend(verification)
+
+        with patch("automation.watchdog.get_backend", return_value=mock_backend):
             async with async_session_factory() as session:
                 run = await session.get(AutomationRun, run_id)
                 result = await _verify_and_mark_run(session, run, mock_settings)
                 await session.commit()
 
         assert result is True
-        mock_cleanup.assert_called_once()
+        mock_backend.cleanup_after_verification.assert_called_once()
 
         # Verify the run was marked as FAILED with timeout message
         async with async_session_factory() as session:
@@ -347,22 +297,9 @@ class TestVerifyAndMarkRunVerificationFailed:
             error="Sandbox not available",
         )
 
-        with (
-            patch(
-                "automation.watchdog.verify_run_status",
-                new_callable=AsyncMock,
-                return_value=verification,
-            ),
-            patch(
-                "automation.watchdog.get_api_key_for_automation_run",
-                new_callable=AsyncMock,
-                return_value="test-api-key",
-            ),
-            patch(
-                "automation.watchdog.cleanup_sandbox",
-                new_callable=AsyncMock,
-            ) as mock_cleanup,
-        ):
+        mock_backend = create_mock_backend(verification)
+
+        with patch("automation.watchdog.get_backend", return_value=mock_backend):
             async with async_session_factory() as session:
                 run = await session.get(AutomationRun, run_id)
                 result = await _verify_and_mark_run(session, run, mock_settings)
@@ -370,4 +307,4 @@ class TestVerifyAndMarkRunVerificationFailed:
 
         assert result is True
         # Cleanup should NOT be called when keep_alive is True
-        mock_cleanup.assert_not_called()
+        mock_backend.cleanup_after_verification.assert_not_called()


### PR DESCRIPTION
## Summary

Adds the combined Docker image and documentation for self-hosted deployments.

**Part of the self-hosted deployment stack** - See PR #82 for overview.

## Changes

### 1. Combined Docker Image (`containers/Dockerfile.local`)

Multi-stage Dockerfile that bundles:
- Automation service (scheduler, dispatcher, watchdog, API)
- Agent server from OpenHands SDK
- Frontend SPA
- Pre-configured environment for self-hosted mode

Environment defaults:
- `AUTOMATION_AUTH_DISABLED=true` - No external auth required
- `FILE_STORE=local` + `LOCAL_STORAGE_PATH=/data/storage` - Local file storage
- `AUTOMATION_DB_URL=sqlite+aiosqlite:////data/automations.db` - SQLite database
- `AUTOMATION_BASE_URL=http://localhost:8000` - Service base URL

### 2. Supervisord Configuration (`containers/supervisord.conf`)

Process manager config to run both automation service and agent server.

### 3. Self-Hosted Documentation (`docs/self-hosted.md`)

Comprehensive guide covering:
- Quick start with Docker
- Building the image locally
- Manual installation without Docker
- Configuration reference (including new storage options)
- Hybrid mode setup
- Troubleshooting

## Testing

Built and tested the Docker image:

```bash
# Build
docker build -f containers/Dockerfile.local -t automation-local:dev .

# Run
docker run -d --name automation -p 8000:8000 \
  -v ./workspace:/workspace -v ./data:/data \
  -e OPENHANDS_LLM_MODEL=anthropic/claude-sonnet-4-20250514 \
  -e OPENHANDS_LLM_API_KEY=test-key \
  automation-local:dev

# Test
curl http://localhost:8000/api/automation/health  # ✅
curl http://localhost:8000/api/automation/v1      # ✅ (list automations)
curl -X POST http://localhost:8000/api/automation/v1/preset/prompt ...  # ✅ (create automation)
```

## Stack Position

```
PR1: local-mode-config (base: main) ✅
PR2: sqlite-support (base: PR1) ✅
PR3: local-execution-backend (base: PR2) ✅
PR4: dispatcher-local-mode (base: PR3) 🔄
PR5: preset-dual-mode (base: PR4) ✅
PR6a: local-storage-backend (base: PR5) ✅ (#90)
PR6b: docs-self-hosted (base: PR6a) ← THIS PR
```