### PR TITLE
PR6a: Local Filesystem Storage Backend + Auth Bypass

### DIFF
--- a/automation/auth.py
+++ b/automation/auth.py
@@ -201,7 +201,23 @@ async def authenticate_request(
     Calls the OpenHands API GET /api/v1/users/me to verify credentials and get
     user/org identity. Implements retry with exponential backoff for rate limiting.
     Results are cached in-memory for 20 seconds to reduce API calls.
+
+    If AUTOMATION_AUTH_DISABLED=true, returns a local user for self-hosted mode.
     """
+    # Check if auth is disabled (self-hosted local mode)
+    config = get_config()
+    if config.http.auth_disabled:
+        # Use fixed UUIDs for local mode (deterministic for testing)
+        # Grant all automation-related permissions for local admin
+        return AuthenticatedUser(
+            user_id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+            org_id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+            email="local@localhost",
+            role="admin",
+            permissions=["manage_automations", "automations:read", "automations:write"],
+            auth_method=AuthMethod.API_KEY,
+        )
+
     # Determine authentication method (API key takes priority)
     auth_header = request.headers.get("Authorization", "")
     if auth_header.startswith("Bearer "):

--- a/automation/config.py
+++ b/automation/config.py
@@ -95,12 +95,13 @@ class LogSettings(BaseSettings):
 class StorageSettings(BaseSettings):
     """File storage backend configuration.
 
-    The automation service supports two storage backends:
+    The automation service supports three storage backends:
     - GCS (Google Cloud Storage) - default
     - S3 (AWS S3 or S3-compatible like MinIO)
+    - Local (local filesystem for self-hosted deployments)
 
     Environment variables (no prefix, follows SDK conventions):
-        FILE_STORE: Backend type, "gcs" or "s3" (default: "gcs")
+        FILE_STORE: Backend type, "gcs", "s3", or "local" (default: "gcs")
 
         # GCS settings
         GCS_BUCKET_NAME: GCS bucket name (required if FILE_STORE=gcs)
@@ -112,6 +113,9 @@ class StorageSettings(BaseSettings):
         AWS_S3_SECURE: Use HTTPS (default: "true")
         AWS_S3_AUTO_CREATE_BUCKET: Auto-create bucket if missing (default: "false")
 
+        # Local storage settings
+        LOCAL_STORAGE_PATH: Directory for local storage (required if FILE_STORE=local)
+
         # Size limits
         MAX_UPLOAD_SIZE: Max tarball upload size in bytes (default: 1MB)
         MAX_STREAM_SIZE: Max streaming upload size in bytes (default: 100MB)
@@ -121,7 +125,7 @@ class StorageSettings(BaseSettings):
         AWS_SECRET_ACCESS_KEY: AWS secret key
     """
 
-    file_store: Literal["gcs", "s3"] = "gcs"
+    file_store: Literal["gcs", "s3", "local"] = "gcs"
 
     # GCS settings
     gcs_bucket_name: str | None = None
@@ -133,6 +137,9 @@ class StorageSettings(BaseSettings):
     aws_s3_secure: bool = True
     aws_s3_auto_create_bucket: bool = False
 
+    # Local storage settings
+    local_storage_path: str | None = None
+
     # Size limits
     max_upload_size: int = 1 * 1024 * 1024  # 1 MB
     max_stream_size: int = 100 * 1024 * 1024  # 100 MB
@@ -141,13 +148,15 @@ class StorageSettings(BaseSettings):
 
     @model_validator(mode="after")
     def validate_bucket_for_backend(self) -> "StorageSettings":
-        """Ensure the appropriate bucket is configured for the selected backend."""
+        """Ensure the appropriate bucket/path is configured for the selected backend."""
         if self.file_store == "gcs" and not self.gcs_bucket_name:
             raise ValueError(
                 "GCS_BUCKET_NAME is required when FILE_STORE=gcs (or not set)"
             )
         if self.file_store == "s3" and not self.aws_s3_bucket:
             raise ValueError("AWS_S3_BUCKET is required when FILE_STORE=s3")
+        if self.file_store == "local" and not self.local_storage_path:
+            raise ValueError("LOCAL_STORAGE_PATH is required when FILE_STORE=local")
         return self
 
 
@@ -167,6 +176,7 @@ class HttpSettings(BaseSettings):
         AUTOMATION_AUTH_MAX_RETRIES: Max auth retry attempts (default: 3)
         AUTOMATION_AUTH_INITIAL_BACKOFF: Initial backoff in seconds (default: 1.0)
         AUTOMATION_AUTH_MAX_BACKOFF: Max backoff for retries in seconds (default: 10.0)
+        AUTOMATION_AUTH_DISABLED: Disable auth for local/dev mode (default: false)
     """
 
     http_timeout: float = 10.0
@@ -176,6 +186,7 @@ class HttpSettings(BaseSettings):
     auth_max_retries: int = 3
     auth_initial_backoff: float = 1.0
     auth_max_backoff: float = 10.0
+    auth_disabled: bool = False
 
     model_config = {"env_prefix": "AUTOMATION_"}
 

--- a/automation/dispatcher.py
+++ b/automation/dispatcher.py
@@ -202,6 +202,7 @@ async def _execute_run(
             timeout=effective_timeout,
             callback_url=callback_url,
             run_id=run_id,
+            local_mode=backend.is_local_mode,
         )
 
         sandbox_extra = _log_ctx(sandbox_id=result.sandbox_id)

--- a/automation/execution.py
+++ b/automation/execution.py
@@ -328,24 +328,32 @@ async def dispatch_automation(
     timeout: int | None = None,
     callback_url: str | None = None,
     run_id: str | None = None,
+    local_mode: bool = False,
 ) -> DispatchResult:
-    """Dispatch an automation to a sandbox (fire-and-forget).
+    """Dispatch an automation to a sandbox or local agent server (fire-and-forget).
 
+    Cloud mode (local_mode=False):
     1. Create sandbox and wait until RUNNING.
     2. Get tarball into sandbox (upload bytes OR download from URL).
     3. Extract it, run ``setup.sh`` (if present), then start *entrypoint*.
     4. Return immediately without waiting for the entrypoint to complete.
 
-    The SDK inside the sandbox will POST to callback_url when finished.
-    The caller should store sandbox_id to verify status later if needed.
+    Local mode (local_mode=True):
+    1. Use api_url directly as the agent server (no sandbox creation).
+    2. Get tarball into agent server (upload bytes OR download from URL).
+    3. Extract it, run ``setup.sh`` (if present), then start *entrypoint*.
+    4. Return immediately without waiting for the entrypoint to complete.
+
+    The SDK inside the execution environment will POST to callback_url when finished.
+    The caller should store sandbox_id to verify status later if needed (Cloud mode only).
 
     *tarball_source*: Either raw bytes (uploaded to sandbox) or a URL string
     (downloaded directly inside sandbox via curl). URLs avoid downloading
     untrusted/large files on the automation service.
 
-    *env_vars* are exported before the entrypoint runs.  The sandbox
-    identity env vars (``SANDBOX_ID``, ``SESSION_API_KEY``) are
-    **always** injected so the SDK's ``local_agent_server_mode`` works.
+    *env_vars* are exported before the entrypoint runs.  In Cloud mode, the
+    sandbox identity env vars (``SANDBOX_ID``, ``SESSION_API_KEY``) are
+    injected so the SDK's ``local_agent_server_mode`` works.
     If *callback_url* / *run_id* are set they are injected as
     ``AUTOMATION_CALLBACK_URL`` / ``AUTOMATION_RUN_ID`` so the SDK's
     ``OpenHandsCloudWorkspace`` can POST completion status on exit.
@@ -366,38 +374,49 @@ async def dispatch_automation(
     def _log_ctx() -> dict[str, Any]:
         return log_extra(run_id=run_id, sandbox_id=sandbox_id)
 
-    logger.info("Dispatching automation to sandbox", extra=_log_ctx())
+    if local_mode:
+        logger.info("Dispatching automation to local agent server", extra=_log_ctx())
+    else:
+        logger.info("Dispatching automation to sandbox", extra=_log_ctx())
 
     async with httpx.AsyncClient(timeout=http_timeout) as client:
-        try:
-            sandbox_id, session_key, agent_url = await _create_and_wait(
-                client, api_url, api_key
-            )
-            logger.info(
-                "Sandbox ready: %s at %s", sandbox_id, agent_url, extra=_log_ctx()
-            )
-        except Exception as e:
-            # If sandbox creation started but failed to reach RUNNING,
-            # still attempt cleanup.
-            logger.exception("Sandbox creation failed", extra=_log_ctx())
-            if sandbox_id:
-                await delete_sandbox(client, api_url, api_key, sandbox_id)
-            return DispatchResult(success=False, sandbox_id=sandbox_id, error=str(e))
+        # In local mode, skip sandbox creation - use agent server directly
+        if local_mode:
+            agent_url = api_url
+            session_key = api_key
+            logger.info("Using local agent server at %s", agent_url, extra=_log_ctx())
+        else:
+            try:
+                sandbox_id, session_key, agent_url = await _create_and_wait(
+                    client, api_url, api_key
+                )
+                logger.info(
+                    "Sandbox ready: %s at %s", sandbox_id, agent_url, extra=_log_ctx()
+                )
+            except Exception as e:
+                # If sandbox creation started but failed to reach RUNNING,
+                # still attempt cleanup.
+                logger.exception("Sandbox creation failed", extra=_log_ctx())
+                if sandbox_id:
+                    await delete_sandbox(client, api_url, api_key, sandbox_id)
+                return DispatchResult(success=False, sandbox_id=sandbox_id, error=str(e))
 
         try:
-            # Always inject sandbox identity so the SDK can call
+            # In Cloud mode, inject sandbox identity so the SDK can call
             # get_llm() / get_secrets() inside the sandbox.
-            env_vars.setdefault("SANDBOX_ID", sandbox_id)
-            env_vars.setdefault("SESSION_API_KEY", session_key)
+            # In local mode, these are not needed (SDK uses different auth).
+            if not local_mode and sandbox_id:
+                env_vars.setdefault("SANDBOX_ID", sandbox_id)
+                env_vars.setdefault("SESSION_API_KEY", session_key)
 
-            # Get tarball into sandbox: upload bytes or download from URL
+            # Get tarball into execution environment: upload bytes or download from URL
             if isinstance(tarball_source, bytes):
-                logger.info("Uploading tarball to sandbox", extra=_log_ctx())
+                logger.info("Uploading tarball to agent server", extra=_log_ctx())
                 await _upload(
                     client, agent_url, session_key, tarball_source, TARBALL_PATH
                 )
             else:
-                logger.info("Downloading tarball in sandbox from URL", extra=_log_ctx())
+                logger.info("Downloading tarball from URL", extra=_log_ctx())
                 await _download_in_sandbox(
                     client, agent_url, session_key, tarball_source, TARBALL_PATH
                 )
@@ -429,7 +448,8 @@ async def dispatch_automation(
 
         except PermanentDispatchError:
             # Clean up sandbox before re-raising so dispatcher can disable automation
-            if sandbox_id:
+            # (only in Cloud mode - local mode has no sandbox to clean up)
+            if sandbox_id and not local_mode:
                 try:
                     await delete_sandbox(client, api_url, api_key, sandbox_id)
                 except Exception:
@@ -438,7 +458,8 @@ async def dispatch_automation(
         except Exception as e:
             logger.exception("Automation dispatch failed", extra=_log_ctx())
             # Delete sandbox on dispatch failure to avoid orphaned sandboxes
-            if sandbox_id:
+            # (only in Cloud mode - local mode has no sandbox to clean up)
+            if sandbox_id and not local_mode:
                 await delete_sandbox(client, api_url, api_key, sandbox_id)
             return DispatchResult(success=False, sandbox_id=sandbox_id, error=str(e))
 

--- a/automation/storage/factory.py
+++ b/automation/storage/factory.py
@@ -10,6 +10,7 @@ def get_file_store() -> FileStore:
     The FILE_STORE environment variable determines which backend to use:
     - "gcs" (default): Google Cloud Storage (GoogleCloudFileStore)
     - "s3": S3-compatible storage (S3FileStore) - works with AWS S3, MinIO, etc.
+    - "local": Local filesystem (LocalFileStore) - for self-hosted deployments
 
     Returns:
         A FileStore instance configured for the selected backend.
@@ -24,6 +25,11 @@ def get_file_store() -> FileStore:
         from automation.storage.s3 import S3FileStore
 
         return S3FileStore(storage)
+    elif storage.file_store == "local":
+        from automation.storage.local import LocalFileStore
+
+        # local_storage_path is validated to be non-None by StorageSettings
+        return LocalFileStore(storage.local_storage_path)  # type: ignore[arg-type]
     else:
         # Unreachable due to Pydantic Literal validation, but explicit for safety
         raise ValueError(f"Unsupported file_store: {storage.file_store}")

--- a/automation/storage/local.py
+++ b/automation/storage/local.py
@@ -1,0 +1,117 @@
+"""Local filesystem storage backend for self-hosted deployments."""
+
+import logging
+import os
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+from automation.storage.file_store import FileStore
+from automation.storage.google_cloud import FileSizeLimitExceeded
+
+logger = logging.getLogger("automation.storage.local")
+
+
+class LocalFileStore(FileStore):
+    """File storage backed by the local filesystem.
+
+    Used for self-hosted/local deployments where cloud storage isn't available.
+    Stores files under a configurable base directory.
+    """
+
+    def __init__(self, base_path: str | Path):
+        """Initialize local file store.
+
+        Args:
+            base_path: Base directory for storing files.
+        """
+        self.base_path = Path(base_path)
+        self.base_path.mkdir(parents=True, exist_ok=True)
+        logger.info("LocalFileStore initialized at %s", self.base_path)
+
+    def _full_path(self, path: str) -> Path:
+        """Get the full filesystem path for a storage path."""
+        prefixed = self._prefixed_path(path)
+        return self.base_path / prefixed
+
+    def write(self, path: str, contents: str | bytes) -> None:
+        """Write contents to a file at the given path."""
+        full_path = self._full_path(path)
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if isinstance(contents, str):
+            contents = contents.encode("utf-8")
+
+        full_path.write_bytes(contents)
+        logger.debug("Wrote %d bytes to %s", len(contents), path)
+
+    def read(self, path: str) -> bytes:
+        """Read and return the contents of the file at the given path."""
+        full_path = self._full_path(path)
+        if not full_path.exists():
+            raise FileNotFoundError(f"File not found: {path}")
+        return full_path.read_bytes()
+
+    def list(self, path: str) -> list[str]:
+        """List all files under the given path prefix."""
+        full_path = self._full_path(path)
+        if not full_path.exists():
+            return []
+
+        # If it's a file, return just that file
+        if full_path.is_file():
+            return [path]
+
+        # If it's a directory, list all files recursively
+        result = []
+        prefix_len = len(str(self.base_path)) + 1  # +1 for trailing slash
+        for root, _, files in os.walk(full_path):
+            for f in files:
+                file_path = os.path.join(root, f)
+                # Return path relative to base_path, without the automation/ prefix
+                rel_path = file_path[prefix_len:]
+                # Remove the BUCKET_PREFIX from the start
+                if rel_path.startswith("automation/"):
+                    rel_path = rel_path[len("automation/") :]
+                result.append(rel_path)
+        return result
+
+    def delete(self, path: str) -> None:
+        """Delete the file at the given path."""
+        full_path = self._full_path(path)
+        if full_path.exists():
+            if full_path.is_file():
+                full_path.unlink()
+                logger.debug("Deleted file %s", path)
+            else:
+                # Delete directory and all contents
+                import shutil
+
+                shutil.rmtree(full_path)
+                logger.debug("Deleted directory %s", path)
+
+    async def write_stream(
+        self,
+        path: str,
+        stream: AsyncIterator[bytes],
+        max_size: int | None = None,
+        content_type: str = "application/octet-stream",
+    ) -> int:
+        """Stream content to a file, enforcing an optional size limit."""
+        full_path = self._full_path(path)
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+
+        total_bytes = 0
+        with full_path.open("wb") as f:
+            async for chunk in stream:
+                if max_size is not None and total_bytes + len(chunk) > max_size:
+                    # Clean up partial file
+                    f.close()
+                    full_path.unlink(missing_ok=True)
+                    raise FileSizeLimitExceeded(
+                        f"File exceeds maximum size of {max_size} bytes"
+                    )
+                f.write(chunk)
+                total_bytes += len(chunk)
+
+        logger.debug("Streamed %d bytes to %s", total_bytes, path)
+        return total_bytes


### PR DESCRIPTION
## Summary

Adds local filesystem storage backend and auth bypass to support self-hosted deployments.

**Part of the self-hosted deployment stack** - See PR #82 for overview.

## Changes

### 1. Local Filesystem Storage Backend (`automation/storage/local.py`)

New storage backend for self-hosted deployments that stores files on the local filesystem instead of cloud storage (GCS/S3).

- Implements full `FileStore` interface
- Stores files under configurable `LOCAL_STORAGE_PATH`
- Supports all operations: `read`, `write`, `list`, `delete`, `write_stream`
- Enforces size limits on streaming uploads

### 2. Auth Bypass for Local Mode (`automation/auth.py`)

Allows API access without OpenHands Cloud authentication for self-hosted mode.

- New `AUTOMATION_AUTH_DISABLED` config option
- When enabled, returns a fixed local user with full admin permissions
- Enables `/api/automation/v1/*` endpoints to work without external auth

### 3. Config Updates (`automation/config.py`)

- Added `"local"` to `FILE_STORE` options (`gcs`, `s3`, `local`)
- Added `LOCAL_STORAGE_PATH` setting for local storage directory
- Added `AUTOMATION_AUTH_DISABLED` setting for self-hosted mode

### 4. Factory Updates (`automation/storage/factory.py`)

- Added support for `FILE_STORE=local` backend selection

## Usage

```bash
# Enable local storage
export FILE_STORE=local
export LOCAL_STORAGE_PATH=/data/storage

# Disable auth for self-hosted mode
export AUTOMATION_AUTH_DISABLED=true
```

## Testing

- Tested with Docker image build and API calls
- All endpoints working with local storage and auth bypass

## Stack Position

```
PR1: local-mode-config (base: main) ✅
PR2: sqlite-support (base: PR1) ✅
PR3: local-execution-backend (base: PR2) ✅
PR4: dispatcher-local-mode (base: PR3) 🔄
PR5: preset-dual-mode (base: PR4) ✅
PR6a: local-storage-backend (base: PR5) ← THIS PR
PR6b: docs-self-hosted (base: PR6a)
```

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/aa2a79aa-40d1-44c8-ab95-e69e42bc37f7)