### PR TITLE
feat(storage): add LocalFileStore for self-hosted deployments

### DIFF
--- a/automation/config.py
+++ b/automation/config.py
@@ -95,12 +95,13 @@ class LogSettings(BaseSettings):
 class StorageSettings(BaseSettings):
     """File storage backend configuration.
 
-    The automation service supports two storage backends:
+    The automation service supports three storage backends:
     - GCS (Google Cloud Storage) - default
     - S3 (AWS S3 or S3-compatible like MinIO)
+    - Local (local filesystem for self-hosted deployments)
 
     Environment variables (no prefix, follows SDK conventions):
-        FILE_STORE: Backend type, "gcs" or "s3" (default: "gcs")
+        FILE_STORE: Backend type, "gcs", "s3", or "local" (default: "gcs")
 
         # GCS settings
         GCS_BUCKET_NAME: GCS bucket name (required if FILE_STORE=gcs)
@@ -112,6 +113,9 @@ class StorageSettings(BaseSettings):
         AWS_S3_SECURE: Use HTTPS (default: "true")
         AWS_S3_AUTO_CREATE_BUCKET: Auto-create bucket if missing (default: "false")
 
+        # Local settings
+        LOCAL_STORAGE_PATH: Base directory for local storage (required if local)
+
         # Size limits
         MAX_UPLOAD_SIZE: Max tarball upload size in bytes (default: 1MB)
         MAX_STREAM_SIZE: Max streaming upload size in bytes (default: 100MB)
@@ -121,7 +125,7 @@ class StorageSettings(BaseSettings):
         AWS_SECRET_ACCESS_KEY: AWS secret key
     """
 
-    file_store: Literal["gcs", "s3"] = "gcs"
+    file_store: Literal["gcs", "s3", "local"] = "gcs"
 
     # GCS settings
     gcs_bucket_name: str | None = None
@@ -133,6 +137,9 @@ class StorageSettings(BaseSettings):
     aws_s3_secure: bool = True
     aws_s3_auto_create_bucket: bool = False
 
+    # Local settings
+    local_storage_path: str | None = None
+
     # Size limits
     max_upload_size: int = 1 * 1024 * 1024  # 1 MB
     max_stream_size: int = 100 * 1024 * 1024  # 100 MB
@@ -141,13 +148,15 @@ class StorageSettings(BaseSettings):
 
     @model_validator(mode="after")
     def validate_bucket_for_backend(self) -> "StorageSettings":
-        """Ensure the appropriate bucket is configured for the selected backend."""
+        """Ensure the appropriate bucket/path is configured for the selected backend."""
         if self.file_store == "gcs" and not self.gcs_bucket_name:
             raise ValueError(
                 "GCS_BUCKET_NAME is required when FILE_STORE=gcs (or not set)"
             )
         if self.file_store == "s3" and not self.aws_s3_bucket:
             raise ValueError("AWS_S3_BUCKET is required when FILE_STORE=s3")
+        if self.file_store == "local" and not self.local_storage_path:
+            raise ValueError("LOCAL_STORAGE_PATH is required when FILE_STORE=local")
         return self
 
 

--- a/automation/storage/__init__.py
+++ b/automation/storage/__init__.py
@@ -1,6 +1,7 @@
 from automation.storage.factory import get_file_store
 from automation.storage.file_store import FileStore
 from automation.storage.google_cloud import FileSizeLimitExceeded, GoogleCloudFileStore
+from automation.storage.local import LocalFileStore
 from automation.storage.s3 import S3FileStore
 
 
@@ -8,6 +9,7 @@ __all__ = [
     "FileStore",
     "FileSizeLimitExceeded",
     "GoogleCloudFileStore",
+    "LocalFileStore",
     "S3FileStore",
     "get_file_store",
 ]

--- a/automation/storage/factory.py
+++ b/automation/storage/factory.py
@@ -10,6 +10,7 @@ def get_file_store() -> FileStore:
     The FILE_STORE environment variable determines which backend to use:
     - "gcs" (default): Google Cloud Storage (GoogleCloudFileStore)
     - "s3": S3-compatible storage (S3FileStore) - works with AWS S3, MinIO, etc.
+    - "local": Local filesystem (LocalFileStore) - for self-hosted deployments
 
     Returns:
         A FileStore instance configured for the selected backend.
@@ -24,6 +25,11 @@ def get_file_store() -> FileStore:
         from automation.storage.s3 import S3FileStore
 
         return S3FileStore(storage)
+    elif storage.file_store == "local":
+        from automation.storage.local import LocalFileStore
+
+        # local_storage_path is validated to be non-None by StorageSettings
+        return LocalFileStore(storage.local_storage_path)  # type: ignore[arg-type]
     else:
         # Unreachable due to Pydantic Literal validation, but explicit for safety
         raise ValueError(f"Unsupported file_store: {storage.file_store}")

--- a/automation/storage/factory.py
+++ b/automation/storage/factory.py
@@ -29,7 +29,8 @@ def get_file_store() -> FileStore:
         from automation.storage.local import LocalFileStore
 
         # local_storage_path is validated to be non-None by StorageSettings
-        return LocalFileStore(storage.local_storage_path)  # type: ignore[arg-type]
+        assert storage.local_storage_path is not None
+        return LocalFileStore(storage.local_storage_path)
     else:
         # Unreachable due to Pydantic Literal validation, but explicit for safety
         raise ValueError(f"Unsupported file_store: {storage.file_store}")

--- a/automation/storage/local.py
+++ b/automation/storage/local.py
@@ -30,9 +30,21 @@ class LocalFileStore(FileStore):
         logger.info("LocalFileStore initialized at %s", self.base_path)
 
     def _full_path(self, path: str) -> Path:
-        """Get the full filesystem path for a storage path."""
+        """Get the full filesystem path for a storage path.
+
+        Raises:
+            ValueError: If the path attempts to escape the base directory.
+        """
         prefixed = self._prefixed_path(path)
-        return self.base_path / prefixed
+        full_path = (self.base_path / prefixed).resolve()
+
+        # Prevent path traversal - ensure resolved path is under base_path
+        try:
+            full_path.relative_to(self.base_path.resolve())
+        except ValueError as e:
+            raise ValueError(f"Path traversal attempt blocked: {path}") from e
+
+        return full_path
 
     def write(self, path: str, contents: str | bytes) -> None:
         """Write contents to a file at the given path."""
@@ -64,15 +76,13 @@ class LocalFileStore(FileStore):
 
         # If it's a directory, list all files recursively
         result = []
-        prefix_len = len(str(self.base_path)) + 1  # +1 for trailing slash
         for file_path in full_path.rglob("*"):
             if file_path.is_file():
-                # Return path relative to base_path, without the automation/ prefix
-                rel_path = str(file_path)[prefix_len:]
-                # Remove the BUCKET_PREFIX from the start
-                if rel_path.startswith("automation/"):
-                    rel_path = rel_path[len("automation/") :]
-                result.append(rel_path)
+                # Get path relative to base_path, then remove automation prefix
+                rel_path = file_path.relative_to(self.base_path)
+                if rel_path.parts and rel_path.parts[0] == "automation":
+                    rel_path = Path(*rel_path.parts[1:])
+                result.append(str(rel_path).replace("\\", "/"))
         return result
 
     def delete(self, path: str) -> None:

--- a/automation/storage/local.py
+++ b/automation/storage/local.py
@@ -1,0 +1,115 @@
+"""Local filesystem storage backend for self-hosted deployments."""
+
+import logging
+import shutil
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+from automation.storage.file_store import FileStore
+from automation.storage.google_cloud import FileSizeLimitExceeded
+
+
+logger = logging.getLogger("automation.storage.local")
+
+
+class LocalFileStore(FileStore):
+    """File storage backed by the local filesystem.
+
+    Used for self-hosted/local deployments where cloud storage isn't available.
+    Stores files under a configurable base directory.
+    """
+
+    def __init__(self, base_path: str | Path):
+        """Initialize local file store.
+
+        Args:
+            base_path: Base directory for storing files.
+        """
+        self.base_path = Path(base_path)
+        self.base_path.mkdir(parents=True, exist_ok=True)
+        logger.info("LocalFileStore initialized at %s", self.base_path)
+
+    def _full_path(self, path: str) -> Path:
+        """Get the full filesystem path for a storage path."""
+        prefixed = self._prefixed_path(path)
+        return self.base_path / prefixed
+
+    def write(self, path: str, contents: str | bytes) -> None:
+        """Write contents to a file at the given path."""
+        full_path = self._full_path(path)
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if isinstance(contents, str):
+            contents = contents.encode("utf-8")
+
+        full_path.write_bytes(contents)
+        logger.debug("Wrote %d bytes to %s", len(contents), path)
+
+    def read(self, path: str) -> bytes:
+        """Read and return the contents of the file at the given path."""
+        full_path = self._full_path(path)
+        if not full_path.exists():
+            raise FileNotFoundError(f"File not found: {path}")
+        return full_path.read_bytes()
+
+    def list(self, path: str) -> list[str]:
+        """List all files under the given path prefix."""
+        full_path = self._full_path(path)
+        if not full_path.exists():
+            return []
+
+        # If it's a file, return just that file
+        if full_path.is_file():
+            return [path]
+
+        # If it's a directory, list all files recursively
+        result = []
+        prefix_len = len(str(self.base_path)) + 1  # +1 for trailing slash
+        for file_path in full_path.rglob("*"):
+            if file_path.is_file():
+                # Return path relative to base_path, without the automation/ prefix
+                rel_path = str(file_path)[prefix_len:]
+                # Remove the BUCKET_PREFIX from the start
+                if rel_path.startswith("automation/"):
+                    rel_path = rel_path[len("automation/") :]
+                result.append(rel_path)
+        return result
+
+    def delete(self, path: str) -> None:
+        """Delete the file at the given path."""
+        full_path = self._full_path(path)
+        if full_path.exists():
+            if full_path.is_file():
+                full_path.unlink()
+                logger.debug("Deleted file %s", path)
+            else:
+                # Delete directory and all contents
+                shutil.rmtree(full_path)
+                logger.debug("Deleted directory %s", path)
+
+    async def write_stream(
+        self,
+        path: str,
+        stream: AsyncIterator[bytes],
+        max_size: int | None = None,
+        content_type: str = "application/octet-stream",  # noqa: ARG002
+    ) -> int:
+        """Stream content to a file, enforcing an optional size limit."""
+        full_path = self._full_path(path)
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+
+        total_bytes = 0
+        with full_path.open("wb") as f:
+            async for chunk in stream:
+                if max_size is not None and total_bytes + len(chunk) > max_size:
+                    # Clean up partial file
+                    f.close()
+                    full_path.unlink(missing_ok=True)
+                    raise FileSizeLimitExceeded(
+                        max_size=max_size, actual_size=total_bytes + len(chunk)
+                    )
+                f.write(chunk)
+                total_bytes += len(chunk)
+
+        logger.debug("Streamed %d bytes to %s", total_bytes, path)
+        return total_bytes

--- a/tests/test_storage_local.py
+++ b/tests/test_storage_local.py
@@ -173,6 +173,75 @@ class TestLocalFileStore:
         assert BUCKET_PREFIX == "automation"
 
 
+class TestLocalFileStorePathTraversal:
+    """Security tests for path traversal prevention."""
+
+    def test_path_traversal_blocked_write(self, tmp_path: Path):
+        """Path traversal attempts should be blocked for write operations."""
+        store = LocalFileStore(tmp_path)
+
+        # These paths escape the base directory when combined with automation/ prefix
+        malicious_paths = [
+            "../../../etc/passwd",  # escapes via automation/../../../etc/passwd
+            "../../secret",  # escapes via automation/../../secret
+            "automation/../../../secret",  # escapes via double automation prefix
+        ]
+
+        for bad_path in malicious_paths:
+            with pytest.raises(ValueError, match="Path traversal"):
+                store.write(bad_path, "malicious")
+
+    def test_path_traversal_blocked_read(self, tmp_path: Path):
+        """Path traversal attempts should be blocked for read operations."""
+        store = LocalFileStore(tmp_path)
+
+        malicious_paths = [
+            "../../../etc/passwd",
+            "../../secret",
+        ]
+
+        for bad_path in malicious_paths:
+            with pytest.raises(ValueError, match="Path traversal"):
+                store.read(bad_path)
+
+    def test_path_traversal_blocked_delete(self, tmp_path: Path):
+        """Path traversal attempts should be blocked for delete operations."""
+        store = LocalFileStore(tmp_path)
+
+        with pytest.raises(ValueError, match="Path traversal"):
+            store.delete("../../../important_file")
+
+    def test_path_traversal_blocked_list(self, tmp_path: Path):
+        """Path traversal attempts should be blocked for list operations."""
+        store = LocalFileStore(tmp_path)
+
+        with pytest.raises(ValueError, match="Path traversal"):
+            store.list("../../../etc")
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_blocked_write_stream(self, tmp_path: Path):
+        """Path traversal attempts should be blocked for streaming writes."""
+        store = LocalFileStore(tmp_path)
+
+        async def mock_stream():
+            yield b"malicious"
+
+        with pytest.raises(ValueError, match="Path traversal"):
+            await store.write_stream("../../../etc/passwd", mock_stream())
+
+    def test_valid_paths_still_work(self, tmp_path: Path):
+        """Ensure valid paths with dots in names still work."""
+        store = LocalFileStore(tmp_path)
+
+        # Paths with dots but no traversal should work
+        store.write("file.txt", "content")
+        store.write("dir.name/file.ext", "content")
+        store.write("..hidden/file", "content")  # double dot at start of name
+
+        assert store.read("file.txt") == b"content"
+        assert store.read("dir.name/file.ext") == b"content"
+
+
 class TestLocalFileStoreWriteStream:
     """Tests for the async write_stream method."""
 

--- a/tests/test_storage_local.py
+++ b/tests/test_storage_local.py
@@ -1,0 +1,290 @@
+"""Unit tests for LocalFileStore.
+
+These tests verify the local filesystem storage backend works correctly.
+Unlike GCS/S3 tests, these don't require mocks since they use real filesystem
+operations via temporary directories.
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from automation.config import StorageSettings, clear_config_cache
+from automation.storage import LocalFileStore, get_file_store
+from automation.storage.google_cloud import BUCKET_PREFIX, FileSizeLimitExceeded
+
+
+def make_local_settings(base_path: str, **kwargs) -> StorageSettings:
+    """Create StorageSettings for local backend."""
+    return StorageSettings(
+        file_store="local",
+        local_storage_path=base_path,
+        **kwargs,
+    )
+
+
+class TestLocalFileStore:
+    """Unit tests for LocalFileStore using real filesystem operations."""
+
+    def test_init_creates_base_directory(self, tmp_path: Path):
+        """Initialize creates the base directory if it doesn't exist."""
+        base_path = tmp_path / "storage"
+        assert not base_path.exists()
+
+        store = LocalFileStore(base_path)
+
+        assert store.base_path == base_path
+        assert base_path.exists()
+        assert base_path.is_dir()
+
+    def test_init_with_existing_directory(self, tmp_path: Path):
+        """Initialize works with an existing directory."""
+        store = LocalFileStore(tmp_path)
+        assert store.base_path == tmp_path
+
+    def test_init_accepts_string_path(self, tmp_path: Path):
+        """Initialize accepts string path and converts to Path."""
+        store = LocalFileStore(str(tmp_path))
+        assert isinstance(store.base_path, Path)
+        assert store.base_path == tmp_path
+
+    def test_prefixed_path(self, tmp_path: Path):
+        """Paths are prefixed with automation/."""
+        store = LocalFileStore(tmp_path)
+        assert store._prefixed_path("test/path.txt") == "automation/test/path.txt"
+        assert store._prefixed_path("/test/path.txt") == "automation/test/path.txt"
+
+    def test_write_string(self, tmp_path: Path):
+        """Write string content to storage with automation prefix."""
+        store = LocalFileStore(tmp_path)
+        store.write("test/path.txt", "hello world")
+
+        # Verify file was created with correct content
+        full_path = tmp_path / "automation" / "test" / "path.txt"
+        assert full_path.exists()
+        assert full_path.read_text() == "hello world"
+
+    def test_write_bytes(self, tmp_path: Path):
+        """Write bytes content to storage with automation prefix."""
+        store = LocalFileStore(tmp_path)
+        store.write("test/path.bin", b"binary data")
+
+        full_path = tmp_path / "automation" / "test" / "path.bin"
+        assert full_path.exists()
+        assert full_path.read_bytes() == b"binary data"
+
+    def test_write_creates_parent_directories(self, tmp_path: Path):
+        """Write creates parent directories as needed."""
+        store = LocalFileStore(tmp_path)
+        store.write("deeply/nested/path/file.txt", "content")
+
+        full_path = tmp_path / "automation" / "deeply" / "nested" / "path" / "file.txt"
+        assert full_path.exists()
+
+    def test_read_returns_bytes(self, tmp_path: Path):
+        """Read returns bytes content."""
+        store = LocalFileStore(tmp_path)
+        store.write("test/file.txt", "hello")
+
+        result = store.read("test/file.txt")
+
+        assert result == b"hello"
+        assert isinstance(result, bytes)
+
+    def test_read_not_found(self, tmp_path: Path):
+        """Read raises FileNotFoundError when file doesn't exist."""
+        store = LocalFileStore(tmp_path)
+
+        with pytest.raises(FileNotFoundError, match="File not found"):
+            store.read("nonexistent.txt")
+
+    def test_list_files(self, tmp_path: Path):
+        """List files under a prefix."""
+        store = LocalFileStore(tmp_path)
+        store.write("users/file1.txt", "content1")
+        store.write("users/file2.txt", "content2")
+        store.write("other/file3.txt", "content3")
+
+        result = store.list("users/")
+
+        assert sorted(result) == ["users/file1.txt", "users/file2.txt"]
+
+    def test_list_nested_files(self, tmp_path: Path):
+        """List includes nested files."""
+        store = LocalFileStore(tmp_path)
+        store.write("data/a.txt", "a")
+        store.write("data/sub/b.txt", "b")
+        store.write("data/sub/deep/c.txt", "c")
+
+        result = store.list("data/")
+
+        assert sorted(result) == ["data/a.txt", "data/sub/b.txt", "data/sub/deep/c.txt"]
+
+    def test_list_empty_path(self, tmp_path: Path):
+        """List returns empty list when path doesn't exist."""
+        store = LocalFileStore(tmp_path)
+
+        result = store.list("nonexistent/")
+
+        assert result == []
+
+    def test_list_single_file(self, tmp_path: Path):
+        """List returns single file when path points to a file."""
+        store = LocalFileStore(tmp_path)
+        store.write("single.txt", "content")
+
+        result = store.list("single.txt")
+
+        assert result == ["single.txt"]
+
+    def test_delete_file(self, tmp_path: Path):
+        """Delete removes a file."""
+        store = LocalFileStore(tmp_path)
+        store.write("test/file.txt", "content")
+        full_path = tmp_path / "automation" / "test" / "file.txt"
+        assert full_path.exists()
+
+        store.delete("test/file.txt")
+
+        assert not full_path.exists()
+
+    def test_delete_directory(self, tmp_path: Path):
+        """Delete removes a directory and all contents."""
+        store = LocalFileStore(tmp_path)
+        store.write("dir/file1.txt", "content1")
+        store.write("dir/sub/file2.txt", "content2")
+        dir_path = tmp_path / "automation" / "dir"
+        assert dir_path.exists()
+
+        store.delete("dir")
+
+        assert not dir_path.exists()
+
+    def test_delete_nonexistent(self, tmp_path: Path):
+        """Delete does nothing when path doesn't exist."""
+        store = LocalFileStore(tmp_path)
+        # Should not raise
+        store.delete("nonexistent.txt")
+
+    def test_bucket_prefix_matches_other_stores(self, tmp_path: Path):
+        """Verify the bucket prefix matches GCS/S3 implementations."""
+        assert BUCKET_PREFIX == "automation"
+
+
+class TestLocalFileStoreWriteStream:
+    """Tests for the async write_stream method."""
+
+    @pytest.mark.asyncio
+    async def test_write_stream_success(self, tmp_path: Path):
+        """Stream upload completes successfully."""
+        store = LocalFileStore(tmp_path)
+
+        async def mock_stream():
+            yield b"chunk1"
+            yield b"chunk2"
+            yield b"chunk3"
+
+        size = await store.write_stream(
+            path="test/streamed.tar",
+            stream=mock_stream(),
+            max_size=1000,
+            content_type="application/x-tar",
+        )
+
+        assert size == 18  # len("chunk1") + len("chunk2") + len("chunk3")
+
+        full_path = tmp_path / "automation" / "test" / "streamed.tar"
+        assert full_path.exists()
+        assert full_path.read_bytes() == b"chunk1chunk2chunk3"
+
+    @pytest.mark.asyncio
+    async def test_write_stream_exceeds_limit(self, tmp_path: Path):
+        """Stream upload raises FileSizeLimitExceeded when limit exceeded."""
+        store = LocalFileStore(tmp_path)
+
+        async def large_stream():
+            yield b"a" * 500
+            yield b"b" * 500
+            yield b"c" * 500  # This exceeds the 1000 byte limit
+
+        with pytest.raises(FileSizeLimitExceeded) as exc_info:
+            await store.write_stream(
+                path="test/oversized.tar",
+                stream=large_stream(),
+                max_size=1000,
+            )
+
+        assert exc_info.value.max_size == 1000
+        assert exc_info.value.actual_size == 1500
+
+        # Partial file should be cleaned up
+        full_path = tmp_path / "automation" / "test" / "oversized.tar"
+        assert not full_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_write_stream_no_limit(self, tmp_path: Path):
+        """Stream upload works without size limit."""
+        store = LocalFileStore(tmp_path)
+
+        async def mock_stream():
+            for i in range(10):
+                yield f"chunk{i}_".encode()
+
+        # max_size=None means no limit
+        size = await store.write_stream(
+            path="test/no_limit.tar",
+            stream=mock_stream(),
+            max_size=None,
+        )
+
+        assert size > 0
+        full_path = tmp_path / "automation" / "test" / "no_limit.tar"
+        assert full_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_write_stream_creates_directories(self, tmp_path: Path):
+        """Stream upload creates parent directories."""
+        store = LocalFileStore(tmp_path)
+
+        async def mock_stream():
+            yield b"content"
+
+        await store.write_stream(
+            path="deeply/nested/file.tar",
+            stream=mock_stream(),
+        )
+
+        full_path = tmp_path / "automation" / "deeply" / "nested" / "file.tar"
+        assert full_path.exists()
+
+
+class TestGetFileStoreFactory:
+    """Test the get_file_store factory function with local backend."""
+
+    def test_local_returns_localfilestore(self, tmp_path: Path):
+        """FILE_STORE=local returns LocalFileStore."""
+        with patch.dict(
+            os.environ,
+            {"FILE_STORE": "local", "LOCAL_STORAGE_PATH": str(tmp_path)},
+        ):
+            clear_config_cache()
+            store = get_file_store()
+            assert isinstance(store, LocalFileStore)
+            assert store.base_path == tmp_path
+
+
+class TestStorageSettingsValidation:
+    """Test StorageSettings validation for local backend."""
+
+    def test_local_requires_storage_path(self):
+        """LOCAL_STORAGE_PATH is required when FILE_STORE=local."""
+        with pytest.raises(ValueError, match="LOCAL_STORAGE_PATH is required"):
+            StorageSettings(file_store="local", local_storage_path=None)
+
+    def test_local_with_storage_path_succeeds(self, tmp_path: Path):
+        """StorageSettings validates successfully with LOCAL_STORAGE_PATH."""
+        settings = make_local_settings(str(tmp_path))
+        assert settings.file_store == "local"
+        assert settings.local_storage_path == str(tmp_path)


### PR DESCRIPTION
## Summary

Add support for local filesystem storage backend as an alternative to cloud storage (GCS/S3) for self-hosted deployments where cloud storage isn't available.

## Changes

### New Files
- `automation/storage/local.py` - LocalFileStore implementation
- `tests/test_storage_local.py` - Comprehensive unit tests

### Modified Files
- `automation/config.py` - Added `local` option to `FILE_STORE` and `LOCAL_STORAGE_PATH` env var
- `automation/storage/factory.py` - Updated factory to return LocalFileStore when configured
- `automation/storage/__init__.py` - Export LocalFileStore

## Features

The `LocalFileStore` class implements the full `FileStore` interface:
- `write()` - Write string or bytes content
- `read()` - Read file contents as bytes
- `list()` - List files under a prefix (recursive)
- `delete()` - Delete files or directories
- `write_stream()` - Async streaming upload with size limits

## Configuration

To use local file storage:

```bash
FILE_STORE=local
LOCAL_STORAGE_PATH=/path/to/storage
```

Files are stored under the `automation/` prefix within the configured base path (matching the behavior of GCS/S3 backends).

## Testing

- 24 unit tests added covering all operations
- All 63 storage-related tests pass (excluding Docker-dependent integration tests)
- Pre-commit checks pass (ruff format, ruff lint, pycodestyle, pyright)

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c44a9242-8d8f-4b99-9e44-8d7c7935e9c7)