### PR TITLE
test: SDK PR #3054 MCP config fix testing

### DIFF
--- a/automation/presets/plugin/setup.sh
+++ b/automation/presets/plugin/setup.sh
@@ -1,17 +1,26 @@
 #!/bin/bash
-# Install the OpenHands SDK from PyPI.
+# Install the OpenHands SDK from PR branch for testing.
+#
+# TESTING: SDK PR #3054 - MCP config fix
+# https://github.com/OpenHands/software-agent-sdk/pull/3054
+#
+# This installs from the fix/mcp-config-format-passthrough branch
+# to test the MCP config changes before PyPI release.
 #
 # Note: Repository cloning is handled by the SDK's
 # OpenHandsCloudWorkspace.clone_repos() method inside main.py.
 set -e
 
-SDK_VERSION="1.19.1"
+SDK_BRANCH="fix/mcp-config-format-passthrough"
+SDK_REPO="https://github.com/OpenHands/software-agent-sdk.git"
 
-echo "[setup] Installing OpenHands SDK (version: $SDK_VERSION)"
-# Package order doesn't matter - pip resolves all dependencies together
+echo "[setup] Installing OpenHands SDK from PR branch: $SDK_BRANCH"
+echo "[setup] This is a TEST build for SDK PR #3054"
+
+# Install all three packages from the PR branch
 pip install -q --no-cache-dir \
-  "openhands-sdk==${SDK_VERSION}" \
-  "openhands-tools==${SDK_VERSION}" \
-  "openhands-workspace==${SDK_VERSION}"
+  "openhands-sdk @ git+${SDK_REPO}@${SDK_BRANCH}#subdirectory=openhands-sdk" \
+  "openhands-tools @ git+${SDK_REPO}@${SDK_BRANCH}#subdirectory=openhands-tools" \
+  "openhands-workspace @ git+${SDK_REPO}@${SDK_BRANCH}#subdirectory=openhands-workspace"
 
-echo "[setup] Done"
+echo "[setup] Done - SDK installed from branch: $SDK_BRANCH"

--- a/automation/presets/prompt/setup.sh
+++ b/automation/presets/prompt/setup.sh
@@ -1,17 +1,26 @@
 #!/bin/bash
-# Install the OpenHands SDK from PyPI.
+# Install the OpenHands SDK from PR branch for testing.
+#
+# TESTING: SDK PR #3054 - MCP config fix
+# https://github.com/OpenHands/software-agent-sdk/pull/3054
+#
+# This installs from the fix/mcp-config-format-passthrough branch
+# to test the MCP config changes before PyPI release.
 #
 # Note: Repository cloning is handled by the SDK's
 # OpenHandsCloudWorkspace.clone_repos() method inside main.py.
 set -e
 
-SDK_VERSION="1.19.1"
+SDK_BRANCH="fix/mcp-config-format-passthrough"
+SDK_REPO="https://github.com/OpenHands/software-agent-sdk.git"
 
-echo "[setup] Installing OpenHands SDK (version: $SDK_VERSION)"
-# Package order doesn't matter - pip resolves all dependencies together
+echo "[setup] Installing OpenHands SDK from PR branch: $SDK_BRANCH"
+echo "[setup] This is a TEST build for SDK PR #3054"
+
+# Install all three packages from the PR branch
 pip install -q --no-cache-dir \
-  "openhands-sdk==${SDK_VERSION}" \
-  "openhands-tools==${SDK_VERSION}" \
-  "openhands-workspace==${SDK_VERSION}"
+  "openhands-sdk @ git+${SDK_REPO}@${SDK_BRANCH}#subdirectory=openhands-sdk" \
+  "openhands-tools @ git+${SDK_REPO}@${SDK_BRANCH}#subdirectory=openhands-tools" \
+  "openhands-workspace @ git+${SDK_REPO}@${SDK_BRANCH}#subdirectory=openhands-workspace"
 
-echo "[setup] Done"
+echo "[setup] Done - SDK installed from branch: $SDK_BRANCH"


### PR DESCRIPTION
## Purpose

This PR temporarily patches `setup.sh` to install the SDK from the PR branch instead of PyPI, enabling us to test the MCP config fix before it's released.

## Testing SDK PR

**SDK PR**: https://github.com/OpenHands/software-agent-sdk/pull/3054
**Related Issue**: https://github.com/OpenHands/automation/issues/93

### The Problem

MCP servers configured in user's SaaS workspace settings work in regular conversations but **do not work in automation-triggered conversations**.

### The Fix (in SDK PR #3054)

The PR modifies `openhands-workspace/openhands/workspace/cloud/workspace.py`:
1. Adds `expose_secrets=true` parameter to the `/api/v1/users/me` API call
2. Passes through `mcpServers` format directly when returned by API (instead of expecting legacy `sse_servers`/`shttp_servers` arrays)

## Changes in This PR

Modified `automation/presets/prompt/setup.sh` and `automation/presets/plugin/setup.sh` to install SDK from:
```
git+https://github.com/OpenHands/software-agent-sdk.git@fix/mcp-config-format-passthrough
```

## Testing Plan

1. ✅ This PR triggers the automation CI to build a Docker image
2. ✅ `trigger-deploy-preview.yml` will auto-create a PR in OpenHands/deploy
3. 🔄 Wait for feature environment deployment
4. 🧪 Test MCP servers work in automations at the feature environment
5. ✅ If tests pass, merge SDK PR #3054 and publish to PyPI
6. 🔄 Revert this PR (or close without merging) after testing

## ⚠️ Do Not Merge

This is a **test PR only**. After testing is complete:
- If SDK fix works → merge SDK PR #3054, publish to PyPI, then close this PR
- Update automation's setup.sh with the new PyPI version in a separate PR

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3459dbb4-d93a-4506-ae15-72f17581d101)