### PR TITLE
Add MIT License and beta notice to README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 OpenHands contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenHands Automation Service
 
+> ⚠️ **Beta**: This project is currently in beta. APIs and features may change without notice.
+
 Scheduled and event-driven automation execution for OpenHands Cloud. This service allows users to create automations that run on a schedule (cron) or in response to events (webhooks).
 
 ## Features


### PR DESCRIPTION
## Summary

This PR adds two housekeeping items to align the automation repository with other OpenHands public projects:

1. **MIT License** - Added a `LICENSE` file with the MIT License, matching the license used by most other OpenHands projects (e.g., `software-agent-sdk`, `openhands-aci`, `OpenHands-CLI`, `extensions`, etc.)

2. **Beta Notice** - Added a warning banner at the top of the README to indicate this project is currently in beta and APIs/features may change without notice.

## Changes

- `LICENSE` - New file with MIT License (copyright: OpenHands contributors)
- `README.md` - Added beta warning notice at the top

## Notes

- The `pyproject.toml` already had `license = "MIT"` defined, but was missing the actual LICENSE file
- The license text follows the same format used in other OpenHands repos

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ccc5dbd3-8d26-4117-9460-caf36db4fdcb)