### PR TITLE
feat: add local_api_key for self-hosted authentication

### DIFF
--- a/automation/auth.py
+++ b/automation/auth.py
@@ -168,6 +168,20 @@ def _get_local_user() -> AuthenticatedUser:
 
     Used when authenticating with local_api_key in self-hosted deployments.
     Provides deterministic user/org IDs for consistent data ownership.
+
+    Security notes:
+    - Uses deterministic UUID5 based on DNS namespace, meaning every self-hosted
+      installation gets identical user/org IDs. This ensures consistent data
+      ownership tracking across service restarts.
+    - If logs or database exports containing these IDs are shared between
+      separate installations, data attribution could be ambiguous. For isolated
+      deployments (the typical self-hosted case), this is acceptable.
+
+    Access model:
+    - Grants admin role with manage_automations permission, giving full access.
+    - Self-hosted deployments typically have full trust in their environment,
+      so permissive defaults are appropriate. Read-only or restricted access
+      modes could be added later if needed via additional config options.
     """
     # Use deterministic UUIDs based on namespace (consistent across restarts)
     local_user_id = uuid.uuid5(uuid.NAMESPACE_DNS, "openhands-local-user")

--- a/automation/auth.py
+++ b/automation/auth.py
@@ -10,6 +10,7 @@ to get the user and organization identity.
 
 import hashlib
 import logging
+import secrets
 import uuid
 from enum import StrEnum
 
@@ -230,17 +231,19 @@ async def authenticate_request(
 ) -> AuthenticatedUser:
     """Authenticate the request using API key or keycloak_auth cookie.
 
-    Supports three authentication methods (checked in priority order):
-    1. Local API key (in local mode only): Bearer token matching local_api_key
-    2. API key via Authorization: Bearer <api_key> header (validated via SaaS)
-    3. Cookie via keycloak_auth cookie (validated via SaaS)
+    Authentication modes:
 
-    In local mode with local_api_key configured, matching Bearer tokens are
-    authenticated as a default local user without calling OpenHands API.
+    **Local mode with local_api_key configured:**
+    Only the configured local API key is accepted. SaaS authentication is
+    disabled. Matching Bearer tokens are authenticated as a default local
+    user without calling the OpenHands API. Non-matching keys are rejected
+    immediately.
 
-    For SaaS authentication, calls the OpenHands API GET /api/v1/users/me to
-    verify credentials and get user/org identity. Implements retry with
-    exponential backoff for rate limiting. Results are cached in-memory.
+    **SaaS mode (local_api_key not configured):**
+    Supports API key via Authorization: Bearer header or keycloak_auth cookie.
+    Calls the OpenHands API GET /api/v1/users/me to verify credentials and
+    get user/org identity. Implements retry with exponential backoff for
+    rate limiting. Results are cached in-memory.
     """
     settings = get_config().service
 
@@ -255,8 +258,10 @@ async def authenticate_request(
             )
 
         # In local mode with local_api_key configured, only accept that key
+        # (SaaS authentication is disabled when local_api_key is set)
         if settings.is_local_mode and settings.local_api_key:
-            if api_key == settings.local_api_key:
+            # Use constant-time comparison to prevent timing attacks
+            if secrets.compare_digest(api_key, settings.local_api_key):
                 logger.debug("Authenticated via local API key")
                 return _get_local_user()
             # Key doesn't match - reject immediately in local mode

--- a/automation/auth.py
+++ b/automation/auth.py
@@ -62,6 +62,7 @@ class AuthMethod(StrEnum):
 
     API_KEY = "api_key"
     COOKIE = "cookie"
+    LOCAL_API_KEY = "local_api_key"
 
 
 def create_http_client() -> httpx.AsyncClient:
@@ -162,6 +163,27 @@ async def _make_auth_request_with_retry(
     return await client.get(url, headers=headers)
 
 
+def _get_local_user() -> AuthenticatedUser:
+    """Return a default user for local mode authentication.
+
+    Used when authenticating with local_api_key in self-hosted deployments.
+    Provides deterministic user/org IDs for consistent data ownership.
+    """
+    # Use deterministic UUIDs based on namespace (consistent across restarts)
+    local_user_id = uuid.uuid5(uuid.NAMESPACE_DNS, "openhands-local-user")
+    local_org_id = uuid.uuid5(uuid.NAMESPACE_DNS, "openhands-local-org")
+
+    return AuthenticatedUser(
+        user_id=local_user_id,
+        org_id=local_org_id,
+        email="local@localhost",
+        role="admin",
+        permissions=["manage_automations"],
+        auth_method=AuthMethod.LOCAL_API_KEY,
+        api_key=None,
+    )
+
+
 def require_permission(permission: str):
     """Factory that returns a FastAPI dependency enforcing a permission.
 
@@ -194,14 +216,20 @@ async def authenticate_request(
 ) -> AuthenticatedUser:
     """Authenticate the request using API key or keycloak_auth cookie.
 
-    Supports two authentication methods (checked in priority order):
-    1. API key via Authorization: Bearer <api_key> header
-    2. Cookie via keycloak_auth cookie
+    Supports three authentication methods (checked in priority order):
+    1. Local API key (in local mode only): Bearer token matching local_api_key
+    2. API key via Authorization: Bearer <api_key> header (validated via SaaS)
+    3. Cookie via keycloak_auth cookie (validated via SaaS)
 
-    Calls the OpenHands API GET /api/v1/users/me to verify credentials and get
-    user/org identity. Implements retry with exponential backoff for rate limiting.
-    Results are cached in-memory for 20 seconds to reduce API calls.
+    In local mode with local_api_key configured, matching Bearer tokens are
+    authenticated as a default local user without calling OpenHands API.
+
+    For SaaS authentication, calls the OpenHands API GET /api/v1/users/me to
+    verify credentials and get user/org identity. Implements retry with
+    exponential backoff for rate limiting. Results are cached in-memory.
     """
+    settings = get_config().service
+
     # Determine authentication method (API key takes priority)
     auth_header = request.headers.get("Authorization", "")
     if auth_header.startswith("Bearer "):
@@ -211,6 +239,18 @@ async def authenticate_request(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Empty API key",
             )
+
+        # In local mode with local_api_key configured, only accept that key
+        if settings.is_local_mode and settings.local_api_key:
+            if api_key == settings.local_api_key:
+                logger.debug("Authenticated via local API key")
+                return _get_local_user()
+            # Key doesn't match - reject immediately in local mode
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid API key",
+            )
+
         auth_method = AuthMethod.API_KEY
         credential = api_key
     else:
@@ -236,7 +276,6 @@ async def authenticate_request(
     logger.debug("Auth cache miss, validating with OpenHands API")
 
     # Build outbound headers based on auth method
-    settings = get_config().service
     if auth_method == AuthMethod.API_KEY:
         outbound_headers = {"Authorization": f"Bearer {credential}"}
     else:

--- a/automation/config.py
+++ b/automation/config.py
@@ -303,9 +303,16 @@ class ServiceSettings(BaseSettings):
     # - Uses a persistent local agent server instead of cloud sandboxes
     # - Skips per-user API key minting (uses agent_server_api_key instead)
     # - Supports SQLite database via db_url
+    # - Authenticates using local_api_key instead of OpenHands SaaS API
     agent_server_url: str = ""
     agent_server_api_key: str = ""
     workspace_base: str = "/workspace"
+
+    # Local API key for authentication in local mode (self-hosted deployments)
+    # When set and is_local_mode is True, requests with this Bearer token
+    # are authenticated as a default local user without calling OpenHands API.
+    # Generate a secure random key for production self-hosted deployments.
+    local_api_key: str = ""
 
     # OpenHands SaaS API
     openhands_api_base_url: str = "https://app.all-hands.dev"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -725,3 +725,160 @@ class TestRequirePermission:
             await checker(user=user)
 
         assert exc_info.value.status_code == 403
+
+
+class TestLocalApiKeyAuthentication:
+    """Tests for local API key authentication in self-hosted mode."""
+
+    @pytest.fixture
+    def local_mode_settings(self):
+        """Create mock settings for local mode with local_api_key configured."""
+        settings = MagicMock()
+        settings.is_local_mode = True
+        settings.local_api_key = "test-local-api-key"
+        settings.openhands_api_base_url = "https://app.openhands.ai"
+        return settings
+
+    @pytest.fixture
+    def non_local_mode_settings(self):
+        """Create mock settings for non-local (SaaS) mode."""
+        settings = MagicMock()
+        settings.is_local_mode = False
+        settings.local_api_key = ""
+        settings.openhands_api_base_url = "https://app.openhands.ai"
+        return settings
+
+    @pytest.fixture
+    def local_mode_no_key_settings(self):
+        """Create mock settings for local mode without local_api_key configured."""
+        settings = MagicMock()
+        settings.is_local_mode = True
+        settings.local_api_key = ""
+        settings.openhands_api_base_url = "https://app.openhands.ai"
+        return settings
+
+    async def test_local_api_key_matches_returns_local_user(
+        self, mock_request, mock_http_client, local_mode_settings
+    ):
+        """When local API key matches, should return local user without SaaS call."""
+        mock_request.headers.get.return_value = "Bearer test-local-api-key"
+
+        with patch("automation.auth.get_config") as mock_get_config:
+            mock_config = MagicMock()
+            mock_config.service = local_mode_settings
+            mock_get_config.return_value = mock_config
+
+            user = await authenticate_request(mock_request, client=mock_http_client)
+
+            # Should NOT have called SaaS API
+            mock_http_client.get.assert_not_called()
+
+            assert user.email == "local@localhost"
+            assert user.role == "admin"
+            assert "manage_automations" in user.permissions
+            assert user.auth_method == AuthMethod.LOCAL_API_KEY
+            # Verify deterministic UUIDs
+            expected_user_id = uuid.uuid5(uuid.NAMESPACE_DNS, "openhands-local-user")
+            expected_org_id = uuid.uuid5(uuid.NAMESPACE_DNS, "openhands-local-org")
+            assert user.user_id == expected_user_id
+            assert user.org_id == expected_org_id
+
+    async def test_local_api_key_mismatch_raises_401(
+        self, mock_request, mock_http_client, local_mode_settings
+    ):
+        """When local API key doesn't match, should raise 401 immediately."""
+        mock_request.headers.get.return_value = "Bearer wrong-key"
+
+        with patch("automation.auth.get_config") as mock_get_config:
+            mock_config = MagicMock()
+            mock_config.service = local_mode_settings
+            mock_get_config.return_value = mock_config
+
+            with pytest.raises(HTTPException) as exc_info:
+                await authenticate_request(mock_request, client=mock_http_client)
+
+            assert exc_info.value.status_code == 401
+            assert "Invalid API key" in exc_info.value.detail
+            # Should NOT have called SaaS API
+            mock_http_client.get.assert_not_called()
+
+    async def test_local_mode_without_key_falls_through_to_saas(
+        self, mock_request, mock_http_client, local_mode_no_key_settings
+    ):
+        """When local mode is enabled but no local_api_key, should use SaaS auth."""
+        mock_request.headers.get.return_value = "Bearer saas-api-key"
+
+        # Mock successful SaaS auth response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = MOCK_USERS_ME_RESPONSE
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        with patch("automation.auth.get_config") as mock_get_config:
+            mock_config = MagicMock()
+            mock_config.service = local_mode_no_key_settings
+            mock_get_config.return_value = mock_config
+
+            user = await authenticate_request(mock_request, client=mock_http_client)
+
+            # Should have called SaaS API
+            mock_http_client.get.assert_called_once()
+            assert user.email == "test@example.com"
+            assert user.auth_method == AuthMethod.API_KEY
+
+    async def test_non_local_mode_uses_saas_auth(
+        self, mock_request, mock_http_client, non_local_mode_settings
+    ):
+        """When not in local mode, should always use SaaS auth."""
+        mock_request.headers.get.return_value = "Bearer any-key"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = MOCK_USERS_ME_RESPONSE
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        with patch("automation.auth.get_config") as mock_get_config:
+            mock_config = MagicMock()
+            mock_config.service = non_local_mode_settings
+            mock_get_config.return_value = mock_config
+
+            user = await authenticate_request(mock_request, client=mock_http_client)
+
+            mock_http_client.get.assert_called_once()
+            assert user.auth_method == AuthMethod.API_KEY
+
+    def test_get_local_user_returns_expected_structure(self):
+        """_get_local_user should return consistent, valid AuthenticatedUser."""
+        from automation.auth import _get_local_user
+
+        user = _get_local_user()
+
+        # Check basic structure
+        assert isinstance(user, AuthenticatedUser)
+        assert user.email == "local@localhost"
+        assert user.role == "admin"
+        assert user.permissions == ["manage_automations"]
+        assert user.auth_method == AuthMethod.LOCAL_API_KEY
+        assert user.api_key is None
+
+        # Check deterministic UUIDs are valid and consistent
+        assert isinstance(user.user_id, uuid.UUID)
+        assert isinstance(user.org_id, uuid.UUID)
+
+        # Call again to verify determinism
+        user2 = _get_local_user()
+        assert user.user_id == user2.user_id
+        assert user.org_id == user2.org_id
+
+    def test_get_local_user_uuid_determinism(self):
+        """Local user UUIDs should be deterministic across calls."""
+        from automation.auth import _get_local_user
+
+        # Expected values based on uuid5(NAMESPACE_DNS, "openhands-local-*")
+        expected_user_id = uuid.uuid5(uuid.NAMESPACE_DNS, "openhands-local-user")
+        expected_org_id = uuid.uuid5(uuid.NAMESPACE_DNS, "openhands-local-org")
+
+        user = _get_local_user()
+
+        assert user.user_id == expected_user_id
+        assert user.org_id == expected_org_id


### PR DESCRIPTION
## Summary

Adds `AUTOMATION_LOCAL_API_KEY` configuration for self-hosted deployments.

## Changes

In local mode (when `AUTOMATION_AGENT_SERVER_URL` is configured), requests with a Bearer token matching `AUTOMATION_LOCAL_API_KEY` are authenticated as a default local user without calling the OpenHands SaaS API.

**Important:** When `local_api_key` is configured, only that key is accepted. SaaS authentication is disabled in this mode.

This enables:
- Self-hosted deployments to use a simple API key for authentication
- Local development without requiring cloud credentials

## Configuration

```bash
# Enable local mode
AUTOMATION_AGENT_SERVER_URL=http://localhost:18000

# Set local API key (generate a secure random key for production)
AUTOMATION_LOCAL_API_KEY=my-local-dev-key
```

## Testing

Requests with `Authorization: Bearer my-local-dev-key` will be authenticated as the local user with `manage_automations` permission.

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*