### PR TITLE
chore: bump version to 1.0.0a1 for alpha release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-automation"
-version = "0.1.0"
+version = "1.0.0a1"
 description = "OpenHands automation service"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -2158,7 +2158,7 @@ wheels = [
 
 [[package]]
 name = "openhands-automation"
-version = "0.1.0"
+version = "1.0.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Bumps the package version from `0.1.0` to `1.0.0a1` in preparation for the first alpha release to PyPI.

## Changes

- Updated `version` in `pyproject.toml` from `"0.1.0"` to `"1.0.0a1"`

## Release Checklist

Before tagging `1.0.0a1`, ensure the following PRs are merged in order:

1. [x] #104 — Restructure package to use `openhands.automation` namespace
2. [x] #100 — Add tag-based release workflows for Docker and PyPI  
3. [ ] This PR — Version bump to `1.0.0a1`

After all PRs are merged, push the tag:
```bash
git tag 1.0.0a1
git push origin 1.0.0a1
```

This will trigger:
- **PyPI**: Publish `openhands-automation==1.0.0a1` (alpha release)
- **Docker**: Tag `ghcr.io/openhands/automation:1.0.0a1`

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b33b5123-22ea-492c-8d60-d7e3bfd980fd)