### PR TITLE
chore: bump version to 1.0.0a2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-automation"
-version = "1.0.0a1"
+version = "1.0.0a2"
 description = "OpenHands automation service"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -2158,7 +2158,7 @@ wheels = [
 
 [[package]]
 name = "openhands-automation"
-version = "1.0.0a1"
+version = "1.0.0a2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

The release workflow for tag `1.0.0a2` failed because `pyproject.toml` still had version `1.0.0a1`. PyPI rejected the upload since `openhands_automation-1.0.0a1` already exists.

This PR updates the version in `pyproject.toml` to `1.0.0a2` to match the intended release tag.

## Changes

- Bumped `version` in `pyproject.toml` from `1.0.0a1` to `1.0.0a2`
- Updated `uv.lock` accordingly

## Re-publishing Steps

After merging this PR, the following steps are required to properly publish `1.0.0a2`:

1. **Delete the old tag** (it points to the wrong commit):
   ```bash
   git push origin --delete 1.0.0a2
   git tag -d 1.0.0a2
   ```

2. **Pull the merged changes** and create a new tag:
   ```bash
   git checkout main
   git pull origin main
   git tag 1.0.0a2
   git push origin 1.0.0a2
   ```

3. The release workflow will automatically trigger and publish `1.0.0a2` to PyPI.

---

*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3159ccbc-e5c7-4484-9dca-160200e051f4)