### PR TITLE
feat: add prepare-release workflow for version bumps

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,117 @@
+---
+# Workflow that prepares a release by bumping the version and opening a PR.
+# Triggered manually via workflow_dispatch with a version input.
+# After the PR is merged, create and push a tag to trigger the actual release.
+name: Prepare Release
+
+on:
+    workflow_dispatch:
+        inputs:
+            version:
+                description: 'Version to release (e.g., 1.0.0, 1.0.0a3, 1.0.0b1)'
+                required: true
+                type: string
+
+jobs:
+    prepare-release:
+        name: Prepare Release PR
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            - name: Validate version format
+              run: |
+                  VERSION="${{ inputs.version }}"
+                  # Basic PEP 440 validation (allows: X.Y.Z, X.Y.ZaN, X.Y.ZbN, X.Y.ZrcN)
+                  if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(a[0-9]+|b[0-9]+|rc[0-9]+)?$'; then
+                    echo "::error::Invalid version format: $VERSION"
+                    echo "Expected format: X.Y.Z, X.Y.ZaN (alpha), X.Y.ZbN (beta), or X.Y.ZrcN (release candidate)"
+                    exit 1
+                  fi
+
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  fetch-depth: 0
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v7
+              with:
+                  version: latest
+
+            - name: Set up Python
+              run: uv python install 3.12
+
+            - name: Get current version
+              id: current
+              run: |
+                  CURRENT=$(grep -oP '^version = "\K[^"]+' pyproject.toml)
+                  echo "version=$CURRENT" >> $GITHUB_OUTPUT
+                  echo "Current version: $CURRENT"
+
+            - name: Bump version
+              run: |
+                  VERSION="${{ inputs.version }}"
+                  sed -i "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
+                  echo "Updated pyproject.toml to version $VERSION"
+                  grep '^version = ' pyproject.toml
+
+            - name: Update lockfile
+              run: uv lock
+
+            - name: Configure git
+              run: |
+                  git config user.name "all-hands-bot"
+                  git config user.email "all-hands-bot@all-hands.dev"
+
+            - name: Create branch and commit
+              id: commit
+              run: |
+                  VERSION="${{ inputs.version }}"
+                  BRANCH_NAME="release/v$VERSION"
+                  
+                  git checkout -b "$BRANCH_NAME"
+                  git add pyproject.toml uv.lock
+                  git commit -m "chore: bump version to $VERSION"
+                  git push -u origin "$BRANCH_NAME"
+                  
+                  echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+            - name: Create Pull Request
+              env:
+                  GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+              run: |
+                  VERSION="${{ inputs.version }}"
+                  CURRENT="${{ steps.current.outputs.version }}"
+                  
+                  gh pr create \
+                    --title "chore: release v$VERSION" \
+                    --body "## Release v$VERSION
+                  
+                  This PR bumps the version from \`$CURRENT\` to \`$VERSION\`.
+                  
+                  ### Changes
+                  - Updated \`pyproject.toml\` version to \`$VERSION\`
+                  - Regenerated \`uv.lock\`
+                  
+                  ### After Merging
+                  
+                  Once this PR is merged, create and push the release tag:
+                  
+                  \`\`\`bash
+                  git checkout main
+                  git pull origin main
+                  git tag $VERSION
+                  git push origin $VERSION
+                  \`\`\`
+                  
+                  This will trigger:
+                  - \`pypi-release.yml\` — publishes \`openhands-automation\` to PyPI
+                  - \`tag-image.yml\` — tags the Docker image with \`$VERSION\`
+                  
+                  ---
+                  *This PR was automatically created by the Prepare Release workflow.*" \
+                    --base main \
+                    --head "${{ steps.commit.outputs.branch }}"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -54,6 +54,11 @@ jobs:
             - name: Bump version
               run: |
                   VERSION="${{ inputs.version }}"
+                  CURRENT="${{ steps.current.outputs.version }}"
+                  if [ "$CURRENT" = "$VERSION" ]; then
+                    echo "::error::Version $VERSION is already set in pyproject.toml"
+                    exit 1
+                  fi
                   sed -i "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
                   if ! grep -q "^version = \"$VERSION\"" pyproject.toml; then
                     echo "::error::Failed to update version in pyproject.toml"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -55,11 +55,21 @@ jobs:
               run: |
                   VERSION="${{ inputs.version }}"
                   sed -i "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
+                  if ! grep -q "^version = \"$VERSION\"" pyproject.toml; then
+                    echo "::error::Failed to update version in pyproject.toml"
+                    exit 1
+                  fi
                   echo "Updated pyproject.toml to version $VERSION"
                   grep '^version = ' pyproject.toml
 
             - name: Update lockfile
-              run: uv lock
+              run: |
+                  uv lock
+                  if ! git diff --quiet uv.lock; then
+                    echo "Lock file updated successfully"
+                  else
+                    echo "::warning::Lock file unchanged - verify dependencies are correct"
+                  fi
 
             - name: Configure git
               run: |
@@ -72,7 +82,10 @@ jobs:
                   VERSION="${{ inputs.version }}"
                   BRANCH_NAME="release/v$VERSION"
                   
-                  git checkout -b "$BRANCH_NAME"
+                  git checkout -b "$BRANCH_NAME" 2>/dev/null || {
+                    echo "::error::Branch $BRANCH_NAME already exists. Delete it or use a different version."
+                    exit 1
+                  }
                   git add pyproject.toml uv.lock
                   git commit -m "chore: bump version to $VERSION"
                   git push -u origin "$BRANCH_NAME"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -8,7 +8,7 @@ on:
     workflow_dispatch:
         inputs:
             version:
-                description: 'Version to release (e.g., 1.0.0, 1.0.0a3, 1.0.0b1)'
+                description: Version to release (e.g., 1.0.0, 1.0.0a3, 1.0.0b1)
                 required: true
                 type: string
 
@@ -81,7 +81,7 @@ jobs:
               run: |
                   VERSION="${{ inputs.version }}"
                   BRANCH_NAME="release/v$VERSION"
-                  
+
                   git checkout -b "$BRANCH_NAME" 2>/dev/null || {
                     echo "::error::Branch $BRANCH_NAME already exists. Delete it or use a different version."
                     exit 1
@@ -89,7 +89,7 @@ jobs:
                   git add pyproject.toml uv.lock
                   git commit -m "chore: bump version to $VERSION"
                   git push -u origin "$BRANCH_NAME"
-                  
+
                   echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
             - name: Create Pull Request
@@ -98,32 +98,32 @@ jobs:
               run: |
                   VERSION="${{ inputs.version }}"
                   CURRENT="${{ steps.current.outputs.version }}"
-                  
+
                   gh pr create \
                     --title "chore: release v$VERSION" \
                     --body "## Release v$VERSION
-                  
+
                   This PR bumps the version from \`$CURRENT\` to \`$VERSION\`.
-                  
+
                   ### Changes
                   - Updated \`pyproject.toml\` version to \`$VERSION\`
                   - Regenerated \`uv.lock\`
-                  
+
                   ### After Merging
-                  
+
                   Once this PR is merged, create and push the release tag:
-                  
+
                   \`\`\`bash
                   git checkout main
                   git pull origin main
                   git tag $VERSION
                   git push origin $VERSION
                   \`\`\`
-                  
+
                   This will trigger:
                   - \`pypi-release.yml\` — publishes \`openhands-automation\` to PyPI
                   - \`tag-image.yml\` — tags the Docker image with \`$VERSION\`
-                  
+
                   ---
                   *This PR was automatically created by the Prepare Release workflow.*" \
                     --base main \


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` workflow that automates the release preparation process, preventing the issue where a tag is created before the version is bumped in `pyproject.toml` (which caused the `1.0.0a2` PyPI publish to fail).

## How It Works

1. Go to **Actions → Prepare Release → Run workflow**
2. Enter the version to release (e.g., `1.0.0a3`, `1.0.0`, `1.1.0b1`)
3. The workflow will:
   - Validate the version format (PEP 440 compliant)
   - Bump the version in `pyproject.toml`
   - Regenerate `uv.lock`
   - Create a branch `release/vX.Y.Z`
   - Open a PR with merge instructions

4. After merging the PR, create and push the tag:
   ```bash
   git checkout main && git pull
   git tag X.Y.Z
   git push origin X.Y.Z
   ```

## Secrets Used

- **`ALLHANDS_BOT_GITHUB_PAT`** — Used to create the branch and PR (already exists, used by other workflows)

## Version Format

Supports PEP 440 versions:
- Stable: `1.0.0`, `1.2.3`
- Alpha: `1.0.0a1`, `1.0.0a2`
- Beta: `1.0.0b1`, `1.0.0b2`
- Release candidate: `1.0.0rc1`, `1.0.0rc2`

## Example PR Created

When triggered with version `1.0.0a3`, the workflow creates a PR like:

> **chore: release v1.0.0a3**
> 
> This PR bumps the version from `1.0.0a2` to `1.0.0a3`.
> 
> ### After Merging
> Once this PR is merged, create and push the release tag:
> ```bash
> git tag 1.0.0a3
> git push origin 1.0.0a3
> ```

---

*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3159ccbc-e5c7-4484-9dca-160200e051f4)