### PR TITLE
fix: register conversation ID with workspace for completion callback

### DIFF
--- a/openhands/automation/presets/plugin/sdk_main.py
+++ b/openhands/automation/presets/plugin/sdk_main.py
@@ -299,6 +299,10 @@ This automation was triggered by a webhook event:
         delete_on_close=False,  # Keep conversation history after completion
     )
     assert isinstance(conversation, RemoteConversation)
+
+    # Register conversation ID with workspace for completion callback
+    workspace.register_conversation(str(conversation.id))
+
     print(f"  conversation created: {type(conversation).__name__}")
     print(f"  plugins loaded: {len(plugin_sources)}")
 

--- a/openhands/automation/presets/prompt/sdk_main.py
+++ b/openhands/automation/presets/prompt/sdk_main.py
@@ -287,6 +287,10 @@ This automation was triggered by a webhook event:
         delete_on_close=False,  # Keep conversation history after completion
     )
     assert isinstance(conversation, RemoteConversation)
+
+    # Register conversation ID with workspace for completion callback
+    workspace.register_conversation(str(conversation.id))
+
     print(f"  conversation created: {type(conversation).__name__}")
 
     # Inject secrets into the conversation (as LookupSecret references)


### PR DESCRIPTION
## Summary

Fixes #113 - UI shows "Conversation not created" when conversations actually started successfully.

## Problem

The preset scripts (`sdk_main.py` for both prompt and plugin presets) create conversations but never call `workspace.register_conversation()` to tell the workspace what conversation ID to include in the completion callback.

When the workspace context manager exits, it sends a completion callback to the automation service, but `conversation_id` is always `None` because it was never registered.

## Solution

After creating the conversation, call `workspace.register_conversation(str(conversation.id))` so the conversation ID is included in the callback payload.

## Changes

- `openhands/automation/presets/prompt/sdk_main.py`: Add `workspace.register_conversation()` call after conversation creation
- `openhands/automation/presets/plugin/sdk_main.py`: Add `workspace.register_conversation()` call after conversation creation

## Testing

New automations created after this fix will include the `conversation_id` in their completion callbacks, allowing the UI to link directly to the conversation.

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/49ad0311-8529-4e47-970c-f72d748ad73e)