### PR TITLE
feat: inject OPENHANDS_SDK_VERSION from installed package into sandbox

### DIFF
--- a/openhands/automation/app.py
+++ b/openhands/automation/app.py
@@ -1,6 +1,7 @@
 """FastAPI application entrypoint."""
 
 import asyncio
+import importlib.metadata
 import logging
 import os
 from contextlib import asynccontextmanager
@@ -252,6 +253,26 @@ async def readiness():
             status_code=503,
             content={"status": "not_ready", "error": "database unavailable"},
         )
+
+
+@app.get("/sdk-version")
+@app.get(f"{_base_path}/sdk-version")
+async def sdk_version():
+    """Return the SDK version this service is running.
+
+    Called by setup.sh inside every automation sandbox to determine which
+    openhands-sdk version to install.  No authentication required — the
+    version string is not sensitive and must be readable before credentials
+    are available in the sandbox.
+    """
+    try:
+        version = importlib.metadata.version("openhands-sdk")
+    except importlib.metadata.PackageNotFoundError:
+        return JSONResponse(
+            status_code=503,
+            content={"error": "openhands-sdk package not found"},
+        )
+    return {"version": version}
 
 
 # ---------------------------------------------------------------------------

--- a/openhands/automation/dispatcher.py
+++ b/openhands/automation/dispatcher.py
@@ -15,7 +15,6 @@ in the ExecutionBackend (see automation/backends/).
 """
 
 import asyncio
-import importlib.metadata
 import json
 import logging
 import uuid
@@ -52,14 +51,6 @@ from openhands.automation.utils.tarball_validation import (
 
 
 logger = logging.getLogger("automation.dispatcher")
-
-try:
-    _SDK_VERSION = importlib.metadata.version("openhands-sdk")
-except importlib.metadata.PackageNotFoundError:
-    _SDK_VERSION = ""
-    logger.warning(
-        "openhands-sdk package not found; OPENHANDS_SDK_VERSION will be empty"
-    )
 
 
 async def _download_internal_tarball(
@@ -186,7 +177,7 @@ async def _execute_run(
     env_vars = backend.build_env_vars()
     env_vars["AUTOMATION_CALLBACK_URL"] = callback_url
     env_vars["AUTOMATION_RUN_ID"] = run_id
-    env_vars["OPENHANDS_SDK_VERSION"] = _SDK_VERSION
+    env_vars["AUTOMATION_API_URL"] = settings.resolved_base_url
     env_vars["AUTOMATION_EVENT_PAYLOAD"] = json.dumps(
         {
             "trigger": automation.trigger,

--- a/openhands/automation/dispatcher.py
+++ b/openhands/automation/dispatcher.py
@@ -15,6 +15,7 @@ in the ExecutionBackend (see automation/backends/).
 """
 
 import asyncio
+import importlib.metadata
 import json
 import logging
 import uuid
@@ -51,6 +52,12 @@ from openhands.automation.utils.tarball_validation import (
 
 
 logger = logging.getLogger("automation.dispatcher")
+
+try:
+    _SDK_VERSION = importlib.metadata.version("openhands-sdk")
+except importlib.metadata.PackageNotFoundError:
+    _SDK_VERSION = ""
+    logger.warning("openhands-sdk package not found; OPENHANDS_SDK_VERSION will be empty")
 
 
 async def _download_internal_tarball(
@@ -177,6 +184,7 @@ async def _execute_run(
     env_vars = backend.build_env_vars()
     env_vars["AUTOMATION_CALLBACK_URL"] = callback_url
     env_vars["AUTOMATION_RUN_ID"] = run_id
+    env_vars["OPENHANDS_SDK_VERSION"] = _SDK_VERSION
     env_vars["AUTOMATION_EVENT_PAYLOAD"] = json.dumps(
         {
             "trigger": automation.trigger,

--- a/openhands/automation/dispatcher.py
+++ b/openhands/automation/dispatcher.py
@@ -57,7 +57,9 @@ try:
     _SDK_VERSION = importlib.metadata.version("openhands-sdk")
 except importlib.metadata.PackageNotFoundError:
     _SDK_VERSION = ""
-    logger.warning("openhands-sdk package not found; OPENHANDS_SDK_VERSION will be empty")
+    logger.warning(
+        "openhands-sdk package not found; OPENHANDS_SDK_VERSION will be empty"
+    )
 
 
 async def _download_internal_tarball(

--- a/openhands/automation/execution.py
+++ b/openhands/automation/execution.py
@@ -386,8 +386,8 @@ async def execute_in_context(
             f"mkdir -p {work_dir}"
             f" && tar xzf {TARBALL_PATH} -C {work_dir}"
             f" && cd {work_dir}"
-            f" && ([ ! -f setup.sh ] || bash setup.sh)"
-            f" && {exports}{entrypoint}"
+            f" && {exports}([ ! -f setup.sh ] || bash setup.sh)"
+            f" && {entrypoint}"
         )
 
         logger.info("Starting entrypoint: %s", entrypoint, extra=_log_ctx())
@@ -449,8 +449,9 @@ async def run_automation(
     (downloaded directly inside sandbox via curl). URLs avoid downloading
     untrusted/large files on the automation service.
 
-    *env_vars* are exported before the entrypoint runs.  The sandbox
-    identity env vars (``SANDBOX_ID``, ``SESSION_API_KEY``) are
+    *env_vars* are exported before setup.sh and the entrypoint run,
+    so setup.sh can consume injected values such as ``OPENHANDS_SDK_VERSION``.
+    The sandbox identity env vars (``SANDBOX_ID``, ``SESSION_API_KEY``) are
     **always** injected so the SDK's ``local_agent_server_mode`` works.
     If *callback_url* / *run_id* are set they are injected as
     ``AUTOMATION_CALLBACK_URL`` / ``AUTOMATION_RUN_ID`` so the SDK's
@@ -520,8 +521,8 @@ async def run_automation(
                 f"mkdir -p {work_dir}"
                 f" && tar xzf {TARBALL_PATH} -C {work_dir}"
                 f" && cd {work_dir}"
-                f" && ([ ! -f setup.sh ] || bash setup.sh)"
-                f" && {exports}{entrypoint}"
+                f" && {exports}([ ! -f setup.sh ] || bash setup.sh)"
+                f" && {entrypoint}"
             )
 
             logger.info("Executing entrypoint: %s", entrypoint, extra=_log_ctx())

--- a/openhands/automation/execution.py
+++ b/openhands/automation/execution.py
@@ -450,7 +450,7 @@ async def run_automation(
     untrusted/large files on the automation service.
 
     *env_vars* are exported before setup.sh and the entrypoint run,
-    so setup.sh can consume injected values such as ``OPENHANDS_SDK_VERSION``.
+    so setup.sh can consume injected values such as ``AUTOMATION_API_URL``.
     The sandbox identity env vars (``SANDBOX_ID``, ``SESSION_API_KEY``) are
     **always** injected so the SDK's ``local_agent_server_mode`` works.
     If *callback_url* / *run_id* are set they are injected as

--- a/openhands/automation/presets/plugin/setup.sh
+++ b/openhands/automation/presets/plugin/setup.sh
@@ -8,12 +8,18 @@
 #
 # Note: Repository cloning is handled by the SDK's workspace methods inside main.py.
 #
-# OPENHANDS_SDK_VERSION is injected by the automation dispatcher and matches
-# the SDK version the service is currently running, so the sandbox always
-# installs a compatible SDK without any hardcoded version pins here.
+# The SDK version is fetched from the automation service API on every run so
+# that deploying a new service version is the only step required to roll out a
+# new SDK — no tarball re-generation or hardcoded version pins needed.
 set -e
 
-SDK_VERSION="${OPENHANDS_SDK_VERSION}"
+echo "[setup] Fetching SDK version from automation service"
+SDK_VERSION=$(curl -sf "${AUTOMATION_API_URL}/sdk-version" \
+  | python3 -c "import sys, json; print(json.load(sys.stdin)['version'])")
+if [ -z "$SDK_VERSION" ]; then
+    echo "[setup] ERROR: Failed to fetch SDK version from ${AUTOMATION_API_URL}/sdk-version" >&2
+    exit 1
+fi
 
 echo "[setup] Creating isolated virtual environment"
 uv venv .venv --quiet

--- a/openhands/automation/presets/plugin/setup.sh
+++ b/openhands/automation/presets/plugin/setup.sh
@@ -7,9 +7,13 @@
 # - No pollution of the system Python environment
 #
 # Note: Repository cloning is handled by the SDK's workspace methods inside main.py.
+#
+# OPENHANDS_SDK_VERSION is injected by the automation dispatcher and matches
+# the SDK version the service is currently running, so the sandbox always
+# installs a compatible SDK without any hardcoded version pins here.
 set -e
 
-SDK_VERSION="1.22.0"
+SDK_VERSION="${OPENHANDS_SDK_VERSION}"
 
 echo "[setup] Creating isolated virtual environment"
 uv venv .venv --quiet

--- a/openhands/automation/presets/plugin/setup.sh
+++ b/openhands/automation/presets/plugin/setup.sh
@@ -14,8 +14,10 @@
 set -e
 
 echo "[setup] Fetching SDK version from automation service"
+set +e
 SDK_VERSION=$(curl -sf "${AUTOMATION_API_URL}/sdk-version" \
-  | python3 -c "import sys, json; print(json.load(sys.stdin)['version'])")
+  | python3 -c "import sys, json; print(json.load(sys.stdin)['version'])" 2>/dev/null)
+set -e
 if [ -z "$SDK_VERSION" ]; then
     echo "[setup] ERROR: Failed to fetch SDK version from ${AUTOMATION_API_URL}/sdk-version" >&2
     exit 1

--- a/openhands/automation/presets/prompt/setup.sh
+++ b/openhands/automation/presets/prompt/setup.sh
@@ -8,12 +8,18 @@
 #
 # Note: Repository cloning is handled by the SDK's workspace methods inside main.py.
 #
-# OPENHANDS_SDK_VERSION is injected by the automation dispatcher and matches
-# the SDK version the service is currently running, so the sandbox always
-# installs a compatible SDK without any hardcoded version pins here.
+# The SDK version is fetched from the automation service API on every run so
+# that deploying a new service version is the only step required to roll out a
+# new SDK — no tarball re-generation or hardcoded version pins needed.
 set -e
 
-SDK_VERSION="${OPENHANDS_SDK_VERSION}"
+echo "[setup] Fetching SDK version from automation service"
+SDK_VERSION=$(curl -sf "${AUTOMATION_API_URL}/sdk-version" \
+  | python3 -c "import sys, json; print(json.load(sys.stdin)['version'])")
+if [ -z "$SDK_VERSION" ]; then
+    echo "[setup] ERROR: Failed to fetch SDK version from ${AUTOMATION_API_URL}/sdk-version" >&2
+    exit 1
+fi
 
 echo "[setup] Creating isolated virtual environment"
 uv venv .venv --quiet

--- a/openhands/automation/presets/prompt/setup.sh
+++ b/openhands/automation/presets/prompt/setup.sh
@@ -7,9 +7,13 @@
 # - No pollution of the system Python environment
 #
 # Note: Repository cloning is handled by the SDK's workspace methods inside main.py.
+#
+# OPENHANDS_SDK_VERSION is injected by the automation dispatcher and matches
+# the SDK version the service is currently running, so the sandbox always
+# installs a compatible SDK without any hardcoded version pins here.
 set -e
 
-SDK_VERSION="1.22.0"
+SDK_VERSION="${OPENHANDS_SDK_VERSION}"
 
 echo "[setup] Creating isolated virtual environment"
 uv venv .venv --quiet

--- a/openhands/automation/presets/prompt/setup.sh
+++ b/openhands/automation/presets/prompt/setup.sh
@@ -14,8 +14,10 @@
 set -e
 
 echo "[setup] Fetching SDK version from automation service"
+set +e
 SDK_VERSION=$(curl -sf "${AUTOMATION_API_URL}/sdk-version" \
-  | python3 -c "import sys, json; print(json.load(sys.stdin)['version'])")
+  | python3 -c "import sys, json; print(json.load(sys.stdin)['version'])" 2>/dev/null)
+set -e
 if [ -z "$SDK_VERSION" ]; then
     echo "[setup] ERROR: Failed to fetch SDK version from ${AUTOMATION_API_URL}/sdk-version" >&2
     exit 1

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -4,7 +4,6 @@ The dispatcher polls for PENDING automation runs and marks them as RUNNING.
 """
 
 import asyncio
-import importlib.metadata
 import uuid
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -13,7 +12,6 @@ import pytest
 from sqlalchemy import select
 
 from openhands.automation.dispatcher import (
-    _SDK_VERSION,
     dispatch_pending_runs,
     dispatcher_loop,
 )
@@ -32,22 +30,6 @@ TEST_ORG_ID = uuid.UUID("87654321-4321-8765-4321-876543218765")
 def mock_client():
     """Mock httpx.AsyncClient for tests."""
     return MagicMock()
-
-
-class TestSDKVersion:
-    """Tests for OPENHANDS_SDK_VERSION injection into the sandbox environment."""
-
-    def test_sdk_version_resolved_from_installed_package(self):
-        """_SDK_VERSION matches the installed openhands-sdk package version."""
-        expected = importlib.metadata.version("openhands-sdk")
-        assert _SDK_VERSION == expected
-
-    def test_sdk_version_is_non_empty(self):
-        """_SDK_VERSION must be a non-empty string so setup.sh can pin a version."""
-        assert isinstance(_SDK_VERSION, str)
-        assert _SDK_VERSION != "", (
-            "_SDK_VERSION is empty; openhands-sdk may not be installed"
-        )
 
 
 class TestIsHttpUrl:

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -4,6 +4,7 @@ The dispatcher polls for PENDING automation runs and marks them as RUNNING.
 """
 
 import asyncio
+import importlib.metadata
 import uuid
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -12,6 +13,7 @@ import pytest
 from sqlalchemy import select
 
 from openhands.automation.dispatcher import (
+    _SDK_VERSION,
     dispatch_pending_runs,
     dispatcher_loop,
 )
@@ -30,6 +32,20 @@ TEST_ORG_ID = uuid.UUID("87654321-4321-8765-4321-876543218765")
 def mock_client():
     """Mock httpx.AsyncClient for tests."""
     return MagicMock()
+
+
+class TestSDKVersion:
+    """Tests for OPENHANDS_SDK_VERSION injection into the sandbox environment."""
+
+    def test_sdk_version_resolved_from_installed_package(self):
+        """_SDK_VERSION matches the installed openhands-sdk package version."""
+        expected = importlib.metadata.version("openhands-sdk")
+        assert _SDK_VERSION == expected
+
+    def test_sdk_version_is_non_empty(self):
+        """_SDK_VERSION must be a non-empty string so setup.sh can pin a version."""
+        assert isinstance(_SDK_VERSION, str)
+        assert _SDK_VERSION != "", "_SDK_VERSION is empty; openhands-sdk may not be installed"
 
 
 class TestIsHttpUrl:

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -45,7 +45,9 @@ class TestSDKVersion:
     def test_sdk_version_is_non_empty(self):
         """_SDK_VERSION must be a non-empty string so setup.sh can pin a version."""
         assert isinstance(_SDK_VERSION, str)
-        assert _SDK_VERSION != "", "_SDK_VERSION is empty; openhands-sdk may not be installed"
+        assert _SDK_VERSION != "", (
+            "_SDK_VERSION is empty; openhands-sdk may not be installed"
+        )
 
 
 class TestIsHttpUrl:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,6 +1,7 @@
 """Tests for health check endpoints."""
 
-from unittest.mock import AsyncMock
+import importlib.metadata
+from unittest.mock import AsyncMock, patch
 
 from openhands.automation.app import app
 
@@ -40,3 +41,37 @@ class TestHealthEndpoints:
             assert "error" in data
         finally:
             app.state.engine = original_engine
+
+
+class TestSdkVersionEndpoint:
+    """Tests for GET /sdk-version — called by setup.sh on every automation run."""
+
+    async def test_returns_installed_sdk_version(self, async_client):
+        """GET /sdk-version returns the currently installed openhands-sdk version."""
+        response = await async_client.get("/api/automation/sdk-version")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "version" in data
+        assert data["version"] == importlib.metadata.version("openhands-sdk")
+
+    async def test_no_auth_required(self, async_client):
+        """GET /sdk-version is accessible without any authentication token."""
+        # Use a raw client without the auth headers the fixture normally adds
+        response = await async_client.get(
+            "/api/automation/sdk-version",
+            headers={},
+        )
+        assert response.status_code == 200
+
+    async def test_returns_503_when_package_not_found(self, async_client):
+        """GET /sdk-version returns 503 when openhands-sdk is not installed."""
+        with patch(
+            "openhands.automation.app.importlib.metadata.version",
+            side_effect=importlib.metadata.PackageNotFoundError("openhands-sdk"),
+        ):
+            response = await async_client.get("/api/automation/sdk-version")
+
+        assert response.status_code == 503
+        data = response.json()
+        assert "error" in data

--- a/tests/test_preset_router.py
+++ b/tests/test_preset_router.py
@@ -92,6 +92,22 @@ class TestPresetFileSyntax:
             "setup.sh doesn't look like a valid shell script"
         )
 
+    def test_prompt_setup_sh_uses_sdk_version_env_var(self):
+        """Prompt setup.sh reads SDK version from OPENHANDS_SDK_VERSION env var."""
+        setup_sh_path = PRESETS_DIR / "prompt" / "setup.sh"
+        content = setup_sh_path.read_text()
+        assert "${OPENHANDS_SDK_VERSION}" in content, (
+            "setup.sh must use ${OPENHANDS_SDK_VERSION} — do not hardcode the version"
+        )
+
+    def test_plugin_setup_sh_uses_sdk_version_env_var(self):
+        """Plugin setup.sh reads SDK version from OPENHANDS_SDK_VERSION env var."""
+        setup_sh_path = PRESETS_DIR / "plugin" / "setup.sh"
+        content = setup_sh_path.read_text()
+        assert "${OPENHANDS_SDK_VERSION}" in content, (
+            "setup.sh must use ${OPENHANDS_SDK_VERSION} — do not hardcode the version"
+        )
+
 
 class TestGenerateTarball:
     """Tests for the tarball generation function."""

--- a/tests/test_preset_router.py
+++ b/tests/test_preset_router.py
@@ -92,20 +92,22 @@ class TestPresetFileSyntax:
             "setup.sh doesn't look like a valid shell script"
         )
 
-    def test_prompt_setup_sh_uses_sdk_version_env_var(self):
-        """Prompt setup.sh reads SDK version from OPENHANDS_SDK_VERSION env var."""
+    def test_prompt_setup_sh_fetches_sdk_version_from_api(self):
+        """Prompt setup.sh fetches SDK version from the automation service API."""
         setup_sh_path = PRESETS_DIR / "prompt" / "setup.sh"
         content = setup_sh_path.read_text()
-        assert "${OPENHANDS_SDK_VERSION}" in content, (
-            "setup.sh must use ${OPENHANDS_SDK_VERSION} — do not hardcode the version"
+        assert "${AUTOMATION_API_URL}/sdk-version" in content, (
+            "setup.sh must call ${AUTOMATION_API_URL}/sdk-version "
+            "— do not hardcode the version"
         )
 
-    def test_plugin_setup_sh_uses_sdk_version_env_var(self):
-        """Plugin setup.sh reads SDK version from OPENHANDS_SDK_VERSION env var."""
+    def test_plugin_setup_sh_fetches_sdk_version_from_api(self):
+        """Plugin setup.sh fetches SDK version from the automation service API."""
         setup_sh_path = PRESETS_DIR / "plugin" / "setup.sh"
         content = setup_sh_path.read_text()
-        assert "${OPENHANDS_SDK_VERSION}" in content, (
-            "setup.sh must use ${OPENHANDS_SDK_VERSION} — do not hardcode the version"
+        assert "${AUTOMATION_API_URL}/sdk-version" in content, (
+            "setup.sh must call ${AUTOMATION_API_URL}/sdk-version "
+            "— do not hardcode the version"
         )
 
 


### PR DESCRIPTION
## Summary

Remove all hardcoded SDK version strings from the automation service. Instead of baking a version into tarballs or env vars at dispatch time, `setup.sh` now calls the automation service's `/sdk-version` endpoint at the start of every sandbox run to determine which SDK to install. A service redeploy is the only step required to roll out a new SDK version — no tarball re-generation, no env var coordination.

## Problem with previous approaches

| Approach | Problem |
|---|---|
| Hardcoded `SDK_VERSION="1.22.0"` in `setup.sh` | Version baked into every tarball at creation time — requires manual edits on every SDK upgrade |
| Inject `OPENHANDS_SDK_VERSION` env var at dispatch time | Still freezes the version at job-dispatch time; existing tarballs can't benefit |

## Solution

The sandbox calls `GET ${AUTOMATION_API_URL}/sdk-version` from inside `setup.sh` **on every automation run**. The endpoint reads the service's currently installed `openhands-sdk` package version via `importlib.metadata` at request time. No version string is ever frozen in a tarball or at dispatch time.

## Changes

### `app.py` — new `/sdk-version` endpoint
```
GET /sdk-version
GET {base_path}/sdk-version   (e.g. /api/automation/sdk-version)
```
- No authentication required — version info is not sensitive and must be readable before SDK credentials are available in the sandbox
- Returns `{"version": "1.22.0"}` from `importlib.metadata` at request time
- Returns 503 if `openhands-sdk` is not installed

### `dispatcher.py`
- Inject `AUTOMATION_API_URL = settings.resolved_base_url` into every sandbox env — this is the base URL `setup.sh` uses to call the endpoint
- Remove the old `OPENHANDS_SDK_VERSION` env var and `_SDK_VERSION` constant

### `execution.py`
- Move env var `export` statements **before** `bash setup.sh` (they were after, so `AUTOMATION_API_URL` would have been invisible to the setup script)
- Update docstring to reflect the new ordering

### `presets/{prompt,plugin}/setup.sh`
```diff
-SDK_VERSION="1.22.0"
+echo "[setup] Fetching SDK version from automation service"
+SDK_VERSION=$(curl -sf "${AUTOMATION_API_URL}/sdk-version" \
+  | python3 -c "import sys, json; print(json.load(sys.stdin)['version'])")
+if [ -z "$SDK_VERSION" ]; then
+    echo "[setup] ERROR: Failed to fetch SDK version" >&2
+    exit 1
+fi
```

### Tests
- `test_health.py`: `TestSdkVersionEndpoint` — covers happy path (returns installed version), no-auth access, and 503 when package not found
- `test_preset_router.py`: updated assertions verify `${AUTOMATION_API_URL}/sdk-version` is present in both `setup.sh` templates (regression guard against re-hardcoding)
- `test_dispatcher.py`: removed `TestSDKVersion` (no longer applicable)

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Service deployed with new SDK version | Must edit `setup.sh` in two places + recreate tarballs | Redeploy service — all future runs install the new version automatically |
| Automations created before the upgrade | Continue using old hardcoded version | Also install the service's current version on every run |
| `/sdk-version` unreachable | N/A | `setup.sh` exits with a clear error — run fails fast rather than silently installing a wrong version |

## Testing

All unit tests pass (Docker-dependent tests skipped — pre-existing):

```
tests/test_preset_router.py::TestPresetFileSyntax::test_prompt_setup_sh_fetches_sdk_version_from_api PASSED
tests/test_preset_router.py::TestPresetFileSyntax::test_plugin_setup_sh_fetches_sdk_version_from_api PASSED
```

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._