### PR TITLE
fix(verifier): scope BashOutput lookups by command_id to avoid cross-run contamination

### DIFF
--- a/migrations/versions/005_add_bash_command_id.py
+++ b/migrations/versions/005_add_bash_command_id.py
@@ -1,0 +1,37 @@
+"""Add bash_command_id column to automation_runs table.
+
+Records the agent-server BashCommand id assigned when an automation's bash
+chain is dispatched. The verifier (watchdog) uses it to filter BashOutput
+events by ``command_id__eq=<hex>`` so it picks up *this run's* output rather
+than whatever BashOutput happened to land on the agent-server most recently
+— a real cross-contamination hazard in local mode where a single agent-
+server is shared across runs (and the agent's own TerminalTool).
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-05-18
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "005"
+down_revision: str = "004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # 32-char UUID hex is the only thing we ever store here; 64 leaves room
+    # if the agent-server's command id representation ever widens.
+    op.add_column(
+        "automation_runs",
+        sa.Column("bash_command_id", sa.String(length=64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("automation_runs", "bash_command_id")

--- a/openhands/automation/backends/cloud.py
+++ b/openhands/automation/backends/cloud.py
@@ -196,6 +196,7 @@ class CloudSandboxBackend(ExecutionBackend):
                 sandbox_id=sandbox_id,
                 keep_alive=self._run.keep_alive,
                 run_id=run_id,
+                bash_command_id=self._run.bash_command_id,
             )
 
         return await self._with_auth_retry(_do_verify)

--- a/openhands/automation/backends/local.py
+++ b/openhands/automation/backends/local.py
@@ -148,11 +148,22 @@ class LocalAgentServerBackend(ExecutionBackend):
         return env_vars
 
     async def verify_run(self, run_id: str) -> VerificationResult:
-        """Verify run status by querying agent server directly."""
+        """Verify run status by querying agent server directly.
+
+        The stored ``bash_command_id`` (recorded right after dispatch) is
+        forwarded so the verifier reads BashOutput from *this run's* bash
+        chain only. Without it, the verifier samples the most recent
+        BashOutput on the agent server — which on a shared dev/local
+        server can easily belong to another run or to the agent's own
+        TerminalTool, producing misleading error_detail values like
+        "fatal: not a git repository" attributed to a run that never
+        ran a git command.
+        """
         return await verify_run_on_agent_server(
             agent_url=self.agent_server_url,
             session_key=self.api_key,
             run_id=run_id,
+            bash_command_id=self._run.bash_command_id,
         )
 
     async def cleanup_after_verification(

--- a/openhands/automation/dispatcher.py
+++ b/openhands/automation/dispatcher.py
@@ -42,6 +42,7 @@ from openhands.automation.utils.run import (
     disable_automation,
     mark_run_status,
     mark_run_terminal,
+    update_bash_command_id,
     update_sandbox_id,
 )
 from openhands.automation.utils.tarball_validation import (
@@ -268,6 +269,13 @@ async def _execute_run(
     if result.success:
         if ctx.sandbox_id:
             await update_sandbox_id(session_factory, run.id, ctx.sandbox_id)
+        if result.bash_command_id:
+            # Persist the BashCommand id so the verifier can filter
+            # BashOutput events by exactly this command (avoids
+            # cross-command contamination on a shared agent server).
+            await update_bash_command_id(
+                session_factory, run.id, result.bash_command_id
+            )
         logger.info(
             "Automation dispatched successfully, waiting for callback",
             extra=_log_ctx(sandbox_id=ctx.sandbox_id),

--- a/openhands/automation/execution.py
+++ b/openhands/automation/execution.py
@@ -320,6 +320,12 @@ class DispatchResult:
     success: bool
     sandbox_id: str | None = None
     error: str | None = None
+    # Agent-server BashCommand id assigned to this dispatch. Surfaced so the
+    # caller can persist it on the AutomationRun and the verifier can later
+    # filter BashOutput by exactly this command (see watchdog → backend.
+    # verify_run → get_last_bash_command_result(command_id=...)). Only set
+    # when dispatch reached `_start_bash`; remains None on earlier failures.
+    bash_command_id: str | None = None
 
 
 async def execute_in_context(
@@ -400,7 +406,11 @@ async def execute_in_context(
             extra=_log_ctx(),
         )
 
-        return DispatchResult(success=True, sandbox_id=sandbox_id)
+        return DispatchResult(
+            success=True,
+            sandbox_id=sandbox_id,
+            bash_command_id=command_id,
+        )
 
     except PermanentDispatchError:
         # Re-raise so caller can handle (e.g., disable automation)

--- a/openhands/automation/models.py
+++ b/openhands/automation/models.py
@@ -148,6 +148,13 @@ class AutomationRun(Base):
     # The sandbox ID used for execution (for status verification)
     sandbox_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
+    # The agent-server BashCommand id for this run's dispatched bash chain.
+    # Stored so the verifier can filter BashOutput events by this specific
+    # command and avoid sampling output from concurrent bash activity on a
+    # shared agent server (e.g., the agent's TerminalTool or other runs in
+    # local mode). Set immediately after `_start_bash` returns.
+    bash_command_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
     # Event payload for event-triggered runs (JSON)
     # Contains the webhook payload that triggered this run.
     # For GitHub events: model_dump() of the parsed Pydantic event

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -599,6 +599,7 @@ class AutomationRunResponse(BaseModel):
     timeout_at: datetime | None
     keep_alive: bool
     sandbox_id: str | None
+    bash_command_id: str | None = None
     created_at: datetime
     started_at: datetime | None
     completed_at: datetime | None

--- a/openhands/automation/utils/agent_server.py
+++ b/openhands/automation/utils/agent_server.py
@@ -31,29 +31,45 @@ async def get_last_bash_command_result(
     client: httpx.AsyncClient,
     agent_url: str,
     session_key: str,
+    command_id: str | None = None,
 ) -> BashCommandResult:
-    """Query the agent server for the last bash command's result.
+    """Query the agent server for a bash command's result.
 
-    Returns the exit code and output of the most recent bash command.
-    Works with both Cloud sandboxes and local agent servers.
+    When *command_id* is supplied, returns the latest BashOutput for that
+    specific command. This is the correct path on shared agent servers
+    (local mode), where multiple bash commands from different runs — and
+    from the agent's own TerminalTool — can be in flight concurrently;
+    without the filter, "the latest BashOutput" can easily belong to
+    something else and produce nonsensical error_detail values on the
+    run record.
+
+    When *command_id* is None, falls back to the (legacy) most-recent-
+    output behavior. Callers that have a command id should always pass it.
 
     Args:
         client: HTTP client
         agent_url: Agent server URL
         session_key: API key for the agent server
+        command_id: Optional BashCommand id (hex) to filter by
 
     Returns:
         BashCommandResult with found=True if command result was retrieved
     """
     try:
-        # Search for the most recent BashOutput event
+        # Search for the most recent BashOutput event, scoped to this run's
+        # bash command whenever we know which one it is. The agent-server's
+        # search endpoint accepts ``command_id__eq`` and only matches
+        # BashOutput files whose embedded command_id matches.
+        params: dict[str, str | int] = {
+            "kind__eq": "BashOutput",
+            "sort_order": "TIMESTAMP_DESC",
+            "limit": 1,
+        }
+        if command_id:
+            params["command_id__eq"] = command_id
         resp = await client.get(
             f"{agent_url}/api/bash/bash_events/search",
-            params={
-                "kind__eq": "BashOutput",
-                "sort_order": "TIMESTAMP_DESC",
-                "limit": 1,
-            },
+            params=params,
             headers={"X-Session-API-Key": session_key},
             timeout=30.0,
         )
@@ -102,6 +118,7 @@ async def verify_run_on_agent_server(
     agent_url: str,
     session_key: str,
     run_id: str | None = None,
+    bash_command_id: str | None = None,
 ) -> VerificationResult:
     """Verify an automation run's status by querying an agent server directly.
 
@@ -115,6 +132,10 @@ async def verify_run_on_agent_server(
         agent_url: Agent server URL
         session_key: API key for the agent server
         run_id: Optional run ID for logging
+        bash_command_id: Optional BashCommand id (hex) recorded for this
+            run; when present, BashOutput lookups are scoped to it so the
+            verifier doesn't sample an unrelated command's output from a
+            shared agent server.
 
     Returns:
         VerificationResult with the verification outcome
@@ -123,8 +144,10 @@ async def verify_run_on_agent_server(
     extra = log_extra(run_id=run_id)
 
     async with httpx.AsyncClient(timeout=60.0) as client:
-        # Get last bash command result
-        bash_result = await get_last_bash_command_result(client, agent_url, session_key)
+        # Get last bash command result, scoped to this run's command if known
+        bash_result = await get_last_bash_command_result(
+            client, agent_url, session_key, command_id=bash_command_id
+        )
 
         if not bash_result.found:
             logger.warning(

--- a/openhands/automation/utils/run.py
+++ b/openhands/automation/utils/run.py
@@ -184,6 +184,33 @@ async def update_sandbox_id(
         logger.exception("Failed to update sandbox_id for run %s", run_id)
 
 
+async def update_bash_command_id(
+    session_factory: async_sessionmaker[AsyncSession],
+    run_id: uuid.UUID,
+    bash_command_id: str,
+) -> None:
+    """Store the agent-server BashCommand id on the automation run.
+
+    The verifier reads this back later to filter BashOutput events by exactly
+    this command, so it doesn't pick up output from concurrent bash activity
+    on a shared agent server. Failure to record this is non-fatal — the run
+    will still execute — but verification may fall back to the (buggy)
+    most-recent-output behavior, which is what we're trying to avoid.
+    """
+    try:
+        async with session_factory() as session:
+            await session.execute(
+                update(AutomationRun)
+                .where(AutomationRun.id == run_id)
+                .values(bash_command_id=bash_command_id)
+            )
+            await session.commit()
+    except Exception:
+        logger.exception(
+            "Failed to update bash_command_id for run %s", run_id
+        )
+
+
 async def mark_run_terminal(
     session_factory: async_sessionmaker[AsyncSession],
     run: AutomationRun,

--- a/openhands/automation/utils/run.py
+++ b/openhands/automation/utils/run.py
@@ -206,9 +206,7 @@ async def update_bash_command_id(
             )
             await session.commit()
     except Exception:
-        logger.exception(
-            "Failed to update bash_command_id for run %s", run_id
-        )
+        logger.exception("Failed to update bash_command_id for run %s", run_id)
 
 
 async def mark_run_terminal(

--- a/openhands/automation/utils/sandbox.py
+++ b/openhands/automation/utils/sandbox.py
@@ -134,6 +134,7 @@ async def verify_run_status(
     sandbox_id: str,
     keep_alive: bool = False,
     run_id: str | None = None,
+    bash_command_id: str | None = None,
 ) -> VerificationResult:
     """Verify an automation run's status by querying its sandbox.
 
@@ -146,6 +147,11 @@ async def verify_run_status(
         sandbox_id: The sandbox to query
         keep_alive: If True, don't delete the sandbox after verification
         run_id: Optional run ID for logging
+        bash_command_id: Optional BashCommand id (hex) recorded for this
+            run; scopes the BashOutput lookup to this specific command.
+            In cloud mode each run owns its sandbox so contamination is
+            unlikely, but scoping is still safer when the agent inside
+            the sandbox runs other bash commands during the run.
 
     Returns:
         VerificationResult with the verification outcome
@@ -166,8 +172,10 @@ async def verify_run_status(
         agent_url, session_key = result
         logger.info("Connected to sandbox for verification", extra=extra)
 
-        # Get last bash command result
-        bash_result = await get_last_bash_command_result(client, agent_url, session_key)
+        # Get last bash command result, scoped to this run's command if known
+        bash_result = await get_last_bash_command_result(
+            client, agent_url, session_key, command_id=bash_command_id
+        )
 
         if not bash_result.found:
             logger.warning(

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -49,6 +49,8 @@ class TestLocalAgentServerBackend:
         run.id = "test-run-123"
         run.sandbox_id = None
         run.keep_alive = False
+        # Default to None — individual tests override when needed
+        run.bash_command_id = None
         return run
 
     def test_is_local_mode(self, mock_run):
@@ -186,7 +188,12 @@ class TestLocalAgentServerBackend:
 
     @pytest.mark.asyncio
     async def test_verify_run_calls_agent_server(self, mock_run):
-        """verify_run() delegates to verify_run_on_agent_server."""
+        """verify_run() delegates to verify_run_on_agent_server and
+        forwards the stored bash_command_id so the verifier filters
+        BashOutput events by *this run's* command instead of sampling
+        the most recent BashOutput on a shared agent server.
+        """
+        mock_run.bash_command_id = "abc123def456"
         backend = LocalAgentServerBackend(
             agent_server_url="http://localhost:3000",
             api_key="local-key",
@@ -205,6 +212,7 @@ class TestLocalAgentServerBackend:
                 agent_url="http://localhost:3000",
                 session_key="local-key",
                 run_id="run-123",
+                bash_command_id="abc123def456",
             )
 
     @pytest.mark.asyncio
@@ -228,6 +236,8 @@ class TestCloudSandboxBackend:
         run = MagicMock()
         run.sandbox_id = "sandbox-123"
         run.keep_alive = False
+        # Default to None — individual tests override when needed
+        run.bash_command_id = None
         return run
 
     def test_is_local_mode(self, mock_run):
@@ -321,7 +331,11 @@ class TestCloudSandboxBackend:
 
     @pytest.mark.asyncio
     async def test_verify_run_calls_verify_run_status(self, mock_run):
-        """verify_run() delegates to verify_run_status."""
+        """verify_run() delegates to verify_run_status and forwards the
+        stored bash_command_id so BashOutput lookups are scoped to this
+        run's specific command.
+        """
+        mock_run.bash_command_id = "deadbeefcafebabe"
         backend = CloudSandboxBackend(api_url="https://app.all-hands.dev", run=mock_run)
         mock_result = MagicMock(verified=True, exit_code=0)
 
@@ -345,6 +359,7 @@ class TestCloudSandboxBackend:
                 sandbox_id="sandbox-123",
                 keep_alive=False,
                 run_id="run-123",
+                bash_command_id="deadbeefcafebabe",
             )
 
     @pytest.mark.asyncio

--- a/tests/test_local_mode.py
+++ b/tests/test_local_mode.py
@@ -178,6 +178,58 @@ class TestGetLastBashCommandResult:
         assert result.exit_code == 0
         assert result.stdout == "Hello"
 
+    @pytest.mark.asyncio
+    async def test_adds_command_id_filter_when_provided(self):
+        """When command_id is provided, params include command_id__eq."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        import httpx
+
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"items": []}
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        await get_last_bash_command_result(
+            mock_client,
+            "http://localhost:3000",
+            "test-key",
+            command_id="abc123",
+        )
+
+        # Verify the request was made with command_id__eq in params
+        mock_client.get.assert_called_once()
+        _, kwargs = mock_client.get.call_args
+        assert kwargs["params"]["command_id__eq"] == "abc123"
+        assert kwargs["params"]["kind__eq"] == "BashOutput"
+        assert kwargs["params"]["sort_order"] == "TIMESTAMP_DESC"
+        assert kwargs["params"]["limit"] == 1
+
+    @pytest.mark.asyncio
+    async def test_omits_command_id_filter_when_none(self):
+        """When command_id is None, params do NOT include command_id__eq."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        import httpx
+
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"items": []}
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        await get_last_bash_command_result(
+            mock_client,
+            "http://localhost:3000",
+            "test-key",
+        )
+
+        mock_client.get.assert_called_once()
+        _, kwargs = mock_client.get.call_args
+        assert "command_id__eq" not in kwargs["params"]
+        assert kwargs["params"]["kind__eq"] == "BashOutput"
+
 
 class TestVerifyRunOnAgentServer:
     """Tests for verify_run_on_agent_server function."""


### PR DESCRIPTION
_This PR was opened by an AI agent (OpenHands) on behalf of @tofarr. Please verify the empirical findings before merging._

See commit message for full investigation trace. Two-sentence summary:

* `verify_run` reads the most recent `BashOutput` on the agent server with no command-id filter, so on a shared agent server (local mode / `dev:docker`) it consistently misattributes another command's stderr to the run being verified — visible as nonsensical `error_detail` values like `fatal: not a git repository` on runs that never invoked git.
* This PR records the dispatched `BashCommand` id on the run row at dispatch time and forwards it to every later `BashOutput` lookup via `command_id__eq=<hex>` (a filter the agent-server already supports), so verification only sees this run's output.

**Files changed** (11):

- `migrations/versions/005_add_bash_command_id.py` (new) — additive, nullable `VARCHAR(64)` column.
- `openhands/automation/models.py` — model field.
- `openhands/automation/schemas.py` — surfaced on `AutomationRunResponse` for debugging.
- `openhands/automation/execution.py` — `DispatchResult.bash_command_id` returned from `_start_bash`.
- `openhands/automation/utils/run.py` — new `update_bash_command_id` helper (mirrors `update_sandbox_id`).
- `openhands/automation/dispatcher.py` — persists the id after a successful dispatch.
- `openhands/automation/utils/agent_server.py` — `get_last_bash_command_result(..., command_id=)`; `verify_run_on_agent_server` forwards it.
- `openhands/automation/utils/sandbox.py` — same in cloud `verify_run_status`.
- `openhands/automation/backends/local.py` + `backends/cloud.py` — `verify_run` passes `self._run.bash_command_id`.
- `tests/test_backends.py` — updated delegation tests.

**Fallback.** When `bash_command_id` is `NULL` (legacy rows, or `_start_bash` failed before returning) we fall back to the existing latest-BashOutput lookup — no change for those.

**Test status.** 477 passed, 0 failed. (120 errors at collection time are pre-existing testcontainers / Docker-socket env failures, unrelated.)

**Companion PR (independent).** The `setup.sh "Failed to fetch SDK version"` failure that revealed this verifier bug has its own root cause in `agent-canvas` — `AUTOMATION_BASE_URL` was hardcoded to `localhost:<ingressPort>` in `dev:docker` mode where the bash chain runs inside the agent-server container. Fixed in a separate `agent-canvas` PR (`fix/automation-base-url-dev-docker`).

**Risk.** Low. Migration is additive; writes are best-effort with logged-and-swallowed failures; `command_id=None` callers keep current behavior.