### PR TITLE
chore: bump version to 1.0.0a4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-automation"
-version = "1.0.0a3"
+version = "1.0.0a4"
 description = "OpenHands automation service"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -2158,7 +2158,7 @@ wheels = [
 
 [[package]]
 name = "openhands-automation"
-version = "1.0.0a3"
+version = "1.0.0a4"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Bumps the pre-release version from `1.0.0a3` to `1.0.0a4`.

### Changes
- Updated `version` in `pyproject.toml` from `1.0.0a3` to `1.0.0a4`
- Regenerated `uv.lock`

### Commits since 1.0.0a3
- `e585779` fix(verifier): scope BashOutput lookups by command_id to avoid cross-run contamination (#122)
- `df19433` fix: use bounded trigger type in AUTOMATION_EVENT_PAYLOAD to avoid tag overflow (#115)

After merging, tag and push to trigger the PyPI + Docker release:
```bash
git checkout main && git pull origin main
git tag 1.0.0a4
git push origin 1.0.0a4
```

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ee1eecb0-6695-4e70-b09b-c269011d92d8)