### PR TITLE
feat(local-backend): split host-side and sandbox-side agent-server URLs

### DIFF
--- a/openhands/automation/backends/__init__.py
+++ b/openhands/automation/backends/__init__.py
@@ -50,6 +50,7 @@ def get_backend(run: AutomationRun) -> ExecutionBackend:
             run=run,
             workspace_base=settings.workspace_base,
             callback_api_key=settings.local_api_key,
+            sandbox_agent_server_url=settings.sandbox_agent_server_url or None,
         )
     else:
         return CloudSandboxBackend(

--- a/openhands/automation/backends/local.py
+++ b/openhands/automation/backends/local.py
@@ -58,12 +58,14 @@ class LocalAgentServerBackend(ExecutionBackend):
         run: AutomationRun,
         workspace_base: str | None = None,
         callback_api_key: str | None = None,
+        sandbox_agent_server_url: str | None = None,
     ):
         """Initialize the local agent-server backend for a specific run.
 
         Args:
             agent_server_url: URL of the local agent server
-                (e.g., "http://localhost:3000")
+                (e.g., "http://localhost:3000"). Used by the backend itself
+                to upload tarballs and start bash commands.
             api_key: API key for authenticating with the agent server
             run: The automation run this backend will operate on
             workspace_base: Base workspace directory. If None, defaults to
@@ -71,12 +73,22 @@ class LocalAgentServerBackend(ExecutionBackend):
             callback_api_key: API key for authenticating completion callbacks
                 to the automation service (local_api_key from config). If None,
                 callbacks will be sent without authentication.
+            sandbox_agent_server_url: Optional override for the
+                AGENT_SERVER_URL env var exported into the in-sandbox bash
+                chain. Defaults to ``agent_server_url`` when None. Useful in
+                container-split setups (e.g. ``dev:docker``) where the
+                backend reaches the agent-server at one URL but the bash
+                chain runs inside the agent-server container and needs a
+                different one (e.g. ``http://127.0.0.1:8000``).
         """
         self.agent_server_url = agent_server_url.rstrip("/")
         self.api_key = api_key
         self._run = run
         self.workspace_base = workspace_base
         self.callback_api_key = callback_api_key
+        self.sandbox_agent_server_url = (
+            sandbox_agent_server_url.rstrip("/") if sandbox_agent_server_url else None
+        )
 
     @property
     def is_local_mode(self) -> bool:
@@ -116,7 +128,10 @@ class LocalAgentServerBackend(ExecutionBackend):
         """Build local mode environment variables.
 
         Provides the env vars needed for local mode:
-        - AGENT_SERVER_URL: URL of the local agent server
+        - AGENT_SERVER_URL: URL of the local agent server — from the
+          *sandbox's* point of view. Defaults to ``agent_server_url`` (the
+          URL the backend uses) but can be overridden via
+          ``sandbox_agent_server_url`` for container-split setups.
         - SESSION_API_KEY: API key for authenticating with the agent server
         - WORKSPACE_BASE: Run-isolated workspace directory for SDK operations
         - AUTOMATION_CALLBACK_API_KEY: API key for callback auth to automation service
@@ -130,7 +145,7 @@ class LocalAgentServerBackend(ExecutionBackend):
         # Use run-specific workspace directory for isolation
         run_workspace = self.get_work_dir(str(self._run.id))
         env_vars = {
-            "AGENT_SERVER_URL": self.agent_server_url,
+            "AGENT_SERVER_URL": self.sandbox_agent_server_url or self.agent_server_url,
             "SESSION_API_KEY": self.api_key,
             "WORKSPACE_BASE": run_workspace,
         }

--- a/openhands/automation/config.py
+++ b/openhands/automation/config.py
@@ -252,6 +252,13 @@ class ServiceSettings(BaseSettings):
         # Local agent-server mode (self-hosted deployments)
         AUTOMATION_AGENT_SERVER_URL: Local agent server URL (e.g., localhost:3000)
         AUTOMATION_AGENT_SERVER_API_KEY: Session API key for local agent server
+        AUTOMATION_SANDBOX_AGENT_SERVER_URL: Optional override for the
+            AGENT_SERVER_URL exported into the in-sandbox bash chain. Defaults
+            to AUTOMATION_AGENT_SERVER_URL when empty. Use this when the
+            backend reaches the agent-server at a different URL than the bash
+            chain does (e.g. agent-canvas `dev:docker`, where the backend
+            runs on the host and the bash chain runs inside the agent-server
+            container).
         AUTOMATION_WORKSPACE_BASE: Base workspace directory (local mode default)
 
         # Background workers
@@ -308,6 +315,15 @@ class ServiceSettings(BaseSettings):
     # - Authenticates using local_api_key instead of OpenHands SaaS API
     agent_server_url: str = ""
     agent_server_api_key: str = ""
+    # Optional override for the AGENT_SERVER_URL env var exported into the
+    # in-sandbox bash chain by LocalAgentServerBackend.build_env_vars.
+    # When empty, defaults to agent_server_url (the URL the backend itself
+    # uses). Needed in container-split dev setups (e.g. agent-canvas
+    # `dev:docker`) where the host-side backend reaches the agent-server at
+    # `localhost:<hostPort>` but the bash chain runs *inside* the
+    # agent-server container and needs `127.0.0.1:8000` or
+    # `host.docker.internal:<hostPort>` instead.
+    sandbox_agent_server_url: str = ""
     workspace_base: str = "/workspace"
 
     # Local API key for authentication in local mode (self-hosted deployments)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -163,6 +163,34 @@ class TestLocalAgentServerBackend:
         # No callback key when callback_api_key is not set
         assert "AUTOMATION_CALLBACK_API_KEY" not in env_vars
 
+    def test_build_env_vars_sandbox_url_override(self, mock_run):
+        """sandbox_agent_server_url overrides AGENT_SERVER_URL only in the
+        sandbox export — the backend itself still uses agent_server_url."""
+        backend = LocalAgentServerBackend(
+            agent_server_url="http://localhost:18000",
+            api_key="agent-key",
+            run=mock_run,
+            sandbox_agent_server_url="http://127.0.0.1:8000",
+        )
+        env_vars = backend.build_env_vars()
+        # In-sandbox bash chain sees the override
+        assert env_vars["AGENT_SERVER_URL"] == "http://127.0.0.1:8000"
+        # But the backend still uses the original URL for its own HTTP calls
+        assert backend.agent_server_url == "http://localhost:18000"
+
+    def test_build_env_vars_sandbox_url_falls_back(self, mock_run):
+        """When sandbox_agent_server_url is None or empty, the in-sandbox
+        AGENT_SERVER_URL falls back to agent_server_url (current behaviour)."""
+        backend = LocalAgentServerBackend(
+            agent_server_url="http://localhost:3000",
+            api_key="agent-key",
+            run=mock_run,
+            sandbox_agent_server_url=None,
+        )
+        assert backend.sandbox_agent_server_url is None
+        env_vars = backend.build_env_vars()
+        assert env_vars["AGENT_SERVER_URL"] == "http://localhost:3000"
+
     def test_get_work_dir_default_workspace(self, mock_run):
         """get_work_dir() returns isolated directory with ~ expanded."""
         backend = LocalAgentServerBackend(


### PR DESCRIPTION
## Summary

Add a new optional config knob — `AUTOMATION_SANDBOX_AGENT_SERVER_URL` (Settings field `sandbox_agent_server_url`) — that decouples the agent-server URL the dispatcher uses on the host from the one that gets exported into the in-sandbox bash chain as `AGENT_SERVER_URL`. When unset, behaviour is unchanged.

## Why

Today `LocalAgentServerBackend.build_env_vars` hard-wires the in-sandbox `AGENT_SERVER_URL` to `self.agent_server_url` — the same URL the host-side dispatcher uses to upload tarballs and call `/api/bash/start_bash_command`. That single value has to be reachable from **both** sides:

- The dispatcher (host-side process)
- The bash chain (which in `dev:docker` runs **inside** the agent-server container)

In native local mode they're trivially the same. In container-split dev setups they aren't:

| Reachable from… | URL that works |
|-----------------|----------------|
| Host (dispatcher) | `http://localhost:<hostPort>` (the published port) |
| Inside the agent-server container (bash chain) | `http://127.0.0.1:8000` (loopback) — or `http://host.docker.internal:<hostPort>` (bounce out and back) |

agent-canvas#603 tried to make `host.docker.internal:<hostPort>` serve both, on the theory that the host's `/etc/hosts` would alias it back to loopback. That holds on Docker Desktop macOS but **not** on OrbStack / colima / Linux hosts — there `host.docker.internal` isn't in the host's `/etc/hosts`. The dispatcher's very first call (the tarball `_upload`) then fails with `[Errno 8] nodename nor servname provided`, dispatch never reaches `_start_bash`, and `bash_command_id` is never populated.

You can see this directly in the run table — all runs after the offending change have:

```
error_detail: [Errno 8] nodename nor servname provided, or not known
bash_command_id: NULL
```

…while every preceding run that successfully reached `_start_bash` has a populated `bash_command_id`.

## Changes

- **`config.py`** — new optional `sandbox_agent_server_url: str = ""` field (env var `AUTOMATION_SANDBOX_AGENT_SERVER_URL`), with doc-string in the env-var help block.
- **`backends/__init__.py`** — pass it through to `LocalAgentServerBackend`.
- **`backends/local.py`** — accept it in `__init__`, store it (rstripped), and use it in `build_env_vars` to populate the exported `AGENT_SERVER_URL`. Falls back to `agent_server_url` when unset, so existing deployments are unaffected.
- **`tests/test_backends.py`** — two new unit tests:
  - `test_build_env_vars_sandbox_url_override` — when set, the sandbox sees the override while the backend still uses `agent_server_url` for its own HTTP calls.
  - `test_build_env_vars_sandbox_url_falls_back` — when unset/`None`, current behaviour is preserved.

## How agent-canvas will use this

Paired change in `agent-canvas/scripts/dev-with-automation.mjs` (separate PR) restores the host-side URL to `localhost:<hostPort>` (works on every Docker host implementation) and uses the container's own loopback for the sandbox-side URL (no `/etc/hosts` lookup needed at all).

## Test plan

- `uv run pytest tests/test_backends.py` — 30 passed (full suite; pre-existing Docker-dependent tests skipped/errored independently of this change).
- `uv run ruff format --check` & `uv run ruff check` — clean.
- Default behaviour (no env var set) is identical to before, verified by `test_build_env_vars_sandbox_url_falls_back` and the unchanged pre-existing `test_build_env_vars*` tests.

---

_This PR was opened by an AI agent (OpenHands) on behalf of the user._
