### PR TITLE
feat: add regenerate endpoint to refresh stale preset tarballs

### DIFF
--- a/openhands/automation/preset_router.py
+++ b/openhands/automation/preset_router.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from openhands.automation.auth import AuthenticatedUser, authenticate_request
@@ -27,7 +28,10 @@ from openhands.automation.db import get_session
 from openhands.automation.models import Automation, TarballUpload, UploadStatus
 from openhands.automation.schemas import AutomationResponse, Trigger
 from openhands.automation.storage import FileStore, get_file_store
-from openhands.automation.utils.tarball_validation import build_internal_url
+from openhands.automation.utils.tarball_validation import (
+    build_internal_url,
+    parse_internal_upload_id,
+)
 from openhands.sdk.plugin import PluginSource
 from openhands.workspace import RepoSource
 
@@ -529,3 +533,193 @@ async def create_automation_from_plugin(
     )
 
     return AutomationResponse.model_validate(automation)
+
+
+async def _read_tarball_files(
+    tarball_path: str,
+    session: AsyncSession,
+    file_store: FileStore,
+) -> dict[str, bytes]:
+    """Read all files from an internal preset tarball.
+
+    Returns a mapping of ``filename -> bytes`` for every file in the archive.
+    Used by the regenerate endpoint to recover ``prompt.txt`` (and an optional
+    ``repos_config.json``) from a legacy tarball when the DB ``prompt`` field
+    is ``None``.
+
+    Raises:
+        HTTPException 422: ``tarball_path`` is not an internal upload URL.
+        HTTPException 404: The ``TarballUpload`` record no longer exists.
+    """
+    upload_id = parse_internal_upload_id(tarball_path)
+    if upload_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "Cannot regenerate: automation tarball is not an internal upload. "
+                "Only automations created via preset endpoints can be regenerated."
+            ),
+        )
+
+    result = await session.execute(
+        select(TarballUpload).where(TarballUpload.id == upload_id)
+    )
+    upload = result.scalars().first()
+    if upload is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Tarball upload {upload_id} not found; it may have been deleted.",
+        )
+
+    tarball_bytes = file_store.read(upload.storage_path)
+
+    files: dict[str, bytes] = {}
+    with tarfile.open(fileobj=io.BytesIO(tarball_bytes), mode="r:gz") as tar:
+        for member in tar.getmembers():
+            if member.isfile():
+                f = tar.extractfile(member)
+                if f is not None:
+                    files[member.name] = f.read()
+
+    return files
+
+
+@router.post("/{automation_id}/regenerate", status_code=status.HTTP_200_OK)
+async def regenerate_preset_automation(
+    automation_id: uuid.UUID,
+    user: AuthenticatedUser = Depends(authenticate_request),
+    session: AsyncSession = Depends(get_session),
+    file_store: FileStore = Depends(get_file_store),
+) -> AutomationResponse:
+    """Regenerate a preset automation's tarball using the current template.
+
+    Re-packages the automation with the latest ``sdk_main.py`` and
+    ``setup.sh`` while preserving the original prompt and any repository
+    configuration.  This is the fix for automations that break after an SDK
+    update — rather than deleting and recreating the automation, call this
+    endpoint to refresh it in place.
+
+    The prompt is taken from the DB ``prompt`` field when available.  For
+    legacy automations created before that field was added (where ``prompt``
+    is ``None``), the endpoint falls back to extracting ``prompt.txt`` from
+    the existing tarball.  ``repos_config.json`` is also restored from the
+    tarball when present.
+
+    Raises:
+        404: Automation not found (or belongs to a different user).
+        422: No prompt could be recovered (not a preset automation, or tarball
+             has been deleted).
+        500: New tarball upload failed.
+    """
+    result = await session.execute(
+        select(Automation).where(
+            Automation.id == automation_id,
+            Automation.user_id == user.user_id,
+            Automation.org_id == user.org_id,
+            Automation.deleted_at.is_(None),
+        )
+    )
+    auto = result.scalars().first()
+    if auto is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Automation not found",
+        )
+
+    # Determine prompt and repos.  Prefer stored prompt; fall back to tarball.
+    prompt = auto.prompt
+    repos: list[RepoSource] | None = None
+
+    if prompt is None:
+        # Legacy automation: extract prompt (and optional repos config) from tarball.
+        tarball_files = await _read_tarball_files(auto.tarball_path, session, file_store)
+        prompt_bytes = tarball_files.get("prompt.txt")
+        if prompt_bytes is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    "Cannot regenerate: no prompt found. "
+                    "This automation was not created via a preset endpoint, "
+                    "or its tarball has been deleted."
+                ),
+            )
+        prompt = prompt_bytes.decode("utf-8")
+
+        repos_bytes = tarball_files.get("repos_config.json")
+        if repos_bytes:
+            repos_config_list = json.loads(repos_bytes.decode("utf-8"))
+            repos = [RepoSource.model_validate(r) for r in repos_config_list]
+    else:
+        # Even when the prompt is stored, restore repos from the tarball so
+        # that repository configuration added at creation time is preserved.
+        try:
+            tarball_files = await _read_tarball_files(
+                auto.tarball_path, session, file_store
+            )
+            repos_bytes = tarball_files.get("repos_config.json")
+            if repos_bytes:
+                repos_config_list = json.loads(repos_bytes.decode("utf-8"))
+                repos = [RepoSource.model_validate(r) for r in repos_config_list]
+        except HTTPException:
+            # Non-fatal: if tarball is gone, regenerate without repos.
+            pass
+
+    # Re-generate with the current template.
+    tarball_content = _generate_tarball(prompt, repos=repos)
+
+    # Upload the regenerated tarball.
+    upload_id = uuid.uuid4()
+    storage_path = _build_storage_path(user.org_id, user.user_id, upload_id)
+
+    upload = TarballUpload(
+        id=upload_id,
+        user_id=user.user_id,
+        org_id=user.org_id,
+        name=f"prompt-automation-{_safe_truncate(auto.name, 50)}-regen",
+        description=f"Regenerated preset for: {_safe_truncate(auto.name, 100)}",
+        status=UploadStatus.UPLOADING,
+        storage_path=storage_path,
+    )
+    session.add(upload)
+    await session.flush()
+
+    try:
+        size_bytes = await file_store.write_stream(
+            path=storage_path,
+            stream=_bytes_to_async_iter(tarball_content),
+            content_type="application/x-tar",
+        )
+        upload.status = UploadStatus.COMPLETED
+        upload.size_bytes = size_bytes
+    except Exception as e:
+        logger.exception("Failed to upload regenerated tarball: %s", e)
+        upload.status = UploadStatus.FAILED
+        upload.error_message = f"Upload failed: {e!s}"
+        await session.flush()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to upload regenerated tarball: {e!s}",
+        )
+
+    await session.flush()
+
+    old_tarball_path = auto.tarball_path
+    auto.tarball_path = build_internal_url(upload_id)
+    # Backfill the prompt field for legacy automations so future regenerations
+    # don't need to touch the tarball.
+    if auto.prompt is None:
+        auto.prompt = prompt
+
+    await session.flush()
+    await session.refresh(auto)
+
+    logger.info(
+        "Regenerated preset automation tarball",
+        extra={
+            "automation_id": str(automation_id),
+            "old_tarball_path": old_tarball_path,
+            "new_tarball_path": auto.tarball_path,
+        },
+    )
+
+    return AutomationResponse.model_validate(auto)

--- a/tests/test_preset_router.py
+++ b/tests/test_preset_router.py
@@ -1149,3 +1149,322 @@ class TestCreateAutomationFromPlugin:
             assert config[0]["source"] == "github:owner/minimal-plugin"
             # No ref or repo_path since they were None
             assert "ref" not in config[0]
+
+
+@requires_docker
+class TestRegeneratePresetAutomation:
+    """Tests for POST /v1/preset/{automation_id}/regenerate endpoint."""
+
+    @pytest.fixture
+    def mock_file_store(self):
+        """Create a stateful mock file store that supports read and write."""
+        from collections.abc import AsyncIterator
+        from unittest.mock import AsyncMock
+
+        store = MagicMock()
+        store._storage: dict[str, bytes] = {}
+
+        async def mock_write_stream(
+            path: str,
+            stream: AsyncIterator[bytes],
+            max_size: int | None = None,
+            content_type: str = "application/octet-stream",
+        ) -> int:
+            content = b""
+            async for chunk in stream:
+                content += chunk
+            store._storage[path] = content
+            return len(content)
+
+        def mock_read(path: str) -> bytes:
+            if path not in store._storage:
+                raise FileNotFoundError(f"File not found: {path}")
+            return store._storage[path]
+
+        store.write_stream = AsyncMock(side_effect=mock_write_stream)
+        store.read = MagicMock(side_effect=mock_read)
+        store.delete = MagicMock()
+        return store
+
+    @pytest.fixture(autouse=True)
+    def setup_file_store_override(self, mock_file_store):
+        """Override file_store for all tests in this class."""
+        from openhands.automation.app import app
+        from openhands.automation.storage import get_file_store
+
+        app.dependency_overrides[get_file_store] = lambda: mock_file_store
+        yield
+        app.dependency_overrides.pop(get_file_store, None)
+
+    def _make_legacy_tarball(
+        self,
+        prompt: str,
+        repos_config: list | None = None,
+    ) -> bytes:
+        """Build a minimal legacy tarball with old template code."""
+        buf = io.BytesIO()
+        old_main = (
+            "from openhands.tools import get_default_agent\n"
+            "print('hello')\n"
+        )
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            for name, content in [
+                ("main.py", old_main.encode()),
+                ("prompt.txt", prompt.encode()),
+                ("setup.sh", b"#!/bin/bash\npip install openhands-sdk\n"),
+            ]:
+                info = tarfile.TarInfo(name=name)
+                info.size = len(content)
+                tar.addfile(info, io.BytesIO(content))
+
+            if repos_config is not None:
+                rc = json.dumps(repos_config).encode()
+                info = tarfile.TarInfo(name="repos_config.json")
+                info.size = len(rc)
+                tar.addfile(info, io.BytesIO(rc))
+
+        buf.seek(0)
+        return buf.read()
+
+    async def test_regenerate_with_stored_prompt(
+        self, async_client, async_session, mock_file_store
+    ):
+        """Regeneration uses the stored DB prompt and replaces the tarball."""
+        # 1. Create an automation via the preset endpoint (stores prompt in DB).
+        create_resp = await async_client.post(
+            "/api/automation/v1/preset/prompt",
+            json={
+                "name": "Echo Bot",
+                "prompt": "Reply hello echo world to every GitHub issue",
+                "trigger": {
+                    "type": "event",
+                    "source": "github",
+                    "on": "issues.labeled",
+                    "filter": "label.name == 'openhands-test'",
+                },
+            },
+        )
+        assert create_resp.status_code == 201
+        automation_id = create_resp.json()["id"]
+        original_tarball_path = create_resp.json()["tarball_path"]
+
+        # 2. Regenerate.
+        regen_resp = await async_client.post(
+            f"/api/automation/v1/preset/{automation_id}/regenerate"
+        )
+        assert regen_resp.status_code == 200
+        data = regen_resp.json()
+
+        # tarball_path must have changed.
+        assert data["tarball_path"] != original_tarball_path
+        assert data["tarball_path"].startswith("oh-internal://uploads/")
+
+        # 3. The new tarball must contain the current template (not the old import).
+        new_tarball_path = data["tarball_path"]
+        new_upload_id = new_tarball_path.removeprefix("oh-internal://uploads/")
+        storage_path = f"uploads/{TEST_ORG_ID}/{TEST_USER_ID}/{new_upload_id}.tar"
+        new_tarball_bytes = mock_file_store._storage[storage_path]
+
+        with tarfile.open(fileobj=io.BytesIO(new_tarball_bytes), mode="r:gz") as tar:
+            main_file = tar.extractfile("main.py")
+            assert main_file is not None
+            main_content = main_file.read().decode()
+            # New template uses the scoped import, not the old bare import.
+            assert "from openhands.tools.preset.default import get_default_agent" in main_content
+            assert "from openhands.tools import get_default_agent" not in main_content
+
+            prompt_file = tar.extractfile("prompt.txt")
+            assert prompt_file is not None
+            assert prompt_file.read().decode() == "Reply hello echo world to every GitHub issue"
+
+    async def test_regenerate_legacy_automation_null_prompt(
+        self, async_client, async_session, mock_file_store
+    ):
+        """Legacy automation (prompt=None in DB) is regenerated from tarball."""
+        # Build a legacy tarball and store it directly in the mock file store.
+        legacy_prompt = "Reply hello echo world to every GitHub issue"
+        legacy_tarball = self._make_legacy_tarball(legacy_prompt)
+
+        legacy_upload_id = uuid.uuid4()
+        legacy_storage_path = (
+            f"uploads/{TEST_ORG_ID}/{TEST_USER_ID}/{legacy_upload_id}.tar"
+        )
+        mock_file_store._storage[legacy_storage_path] = legacy_tarball
+
+        # Insert matching TarballUpload and Automation records directly.
+        from openhands.automation.models import TarballUpload, UploadStatus, Automation
+
+        upload = TarballUpload(
+            id=legacy_upload_id,
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            name="legacy-upload",
+            status=UploadStatus.COMPLETED,
+            storage_path=legacy_storage_path,
+            size_bytes=len(legacy_tarball),
+        )
+        async_session.add(upload)
+
+        legacy_automation_id = uuid.uuid4()
+        automation = Automation(
+            id=legacy_automation_id,
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            name="Legacy Echo Bot",
+            prompt=None,  # Simulates pre-prompt-field automation.
+            trigger={"type": "event", "source": "github", "on": "issues.labeled"},
+            tarball_path=f"oh-internal://uploads/{legacy_upload_id}",
+            setup_script_path="setup.sh",
+            entrypoint="python main.py",
+        )
+        async_session.add(automation)
+        await async_session.flush()
+
+        # Regenerate.
+        regen_resp = await async_client.post(
+            f"/api/automation/v1/preset/{legacy_automation_id}/regenerate"
+        )
+        assert regen_resp.status_code == 200
+        data = regen_resp.json()
+
+        # tarball_path must have changed to the new upload.
+        assert data["tarball_path"] != f"oh-internal://uploads/{legacy_upload_id}"
+        assert data["tarball_path"].startswith("oh-internal://uploads/")
+
+        # Prompt must be backfilled in the response.
+        assert data["prompt"] == legacy_prompt
+
+        # New tarball contains current template.
+        new_tarball_path = data["tarball_path"]
+        new_upload_id = new_tarball_path.removeprefix("oh-internal://uploads/")
+        storage_path = f"uploads/{TEST_ORG_ID}/{TEST_USER_ID}/{new_upload_id}.tar"
+        new_tarball_bytes = mock_file_store._storage[storage_path]
+
+        with tarfile.open(fileobj=io.BytesIO(new_tarball_bytes), mode="r:gz") as tar:
+            main_file = tar.extractfile("main.py")
+            assert main_file is not None
+            main_content = main_file.read().decode()
+            assert "from openhands.tools.preset.default import get_default_agent" in main_content
+
+            prompt_file = tar.extractfile("prompt.txt")
+            assert prompt_file is not None
+            assert prompt_file.read().decode() == legacy_prompt
+
+    async def test_regenerate_preserves_repos(
+        self, async_client, async_session, mock_file_store
+    ):
+        """Repos config in the original tarball is preserved after regeneration."""
+        repos_config = [{"url": "owner/my-repo", "provider": "github", "ref": "main"}]
+        legacy_prompt = "Analyze the repo"
+        legacy_tarball = self._make_legacy_tarball(legacy_prompt, repos_config=repos_config)
+
+        legacy_upload_id = uuid.uuid4()
+        legacy_storage_path = (
+            f"uploads/{TEST_ORG_ID}/{TEST_USER_ID}/{legacy_upload_id}.tar"
+        )
+        mock_file_store._storage[legacy_storage_path] = legacy_tarball
+
+        from openhands.automation.models import TarballUpload, UploadStatus, Automation
+
+        upload = TarballUpload(
+            id=legacy_upload_id,
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            name="legacy-repos-upload",
+            status=UploadStatus.COMPLETED,
+            storage_path=legacy_storage_path,
+            size_bytes=len(legacy_tarball),
+        )
+        async_session.add(upload)
+
+        legacy_automation_id = uuid.uuid4()
+        automation = Automation(
+            id=legacy_automation_id,
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            name="Repo Analyzer",
+            prompt=None,
+            trigger={"type": "cron", "schedule": "0 9 * * 1"},
+            tarball_path=f"oh-internal://uploads/{legacy_upload_id}",
+            setup_script_path="setup.sh",
+            entrypoint="python main.py",
+        )
+        async_session.add(automation)
+        await async_session.flush()
+
+        regen_resp = await async_client.post(
+            f"/api/automation/v1/preset/{legacy_automation_id}/regenerate"
+        )
+        assert regen_resp.status_code == 200
+
+        new_tarball_path = regen_resp.json()["tarball_path"]
+        new_upload_id = new_tarball_path.removeprefix("oh-internal://uploads/")
+        storage_path = f"uploads/{TEST_ORG_ID}/{TEST_USER_ID}/{new_upload_id}.tar"
+        new_tarball_bytes = mock_file_store._storage[storage_path]
+
+        with tarfile.open(fileobj=io.BytesIO(new_tarball_bytes), mode="r:gz") as tar:
+            rc_file = tar.extractfile("repos_config.json")
+            assert rc_file is not None
+            restored = json.loads(rc_file.read().decode())
+            assert restored == repos_config
+
+    async def test_regenerate_automation_not_found(self, async_client):
+        """Returns 404 for an unknown automation ID."""
+        missing_id = uuid.uuid4()
+        response = await async_client.post(
+            f"/api/automation/v1/preset/{missing_id}/regenerate"
+        )
+        assert response.status_code == 404
+
+    async def test_regenerate_no_prompt_no_tarball_prompt(
+        self, async_client, async_session, mock_file_store
+    ):
+        """Returns 422 when automation has no stored prompt and no prompt.txt."""
+        # Build a tarball without prompt.txt.
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            content = b"#!/bin/bash\necho hi\n"
+            info = tarfile.TarInfo(name="setup.sh")
+            info.size = len(content)
+            tar.addfile(info, io.BytesIO(content))
+        buf.seek(0)
+        no_prompt_tarball = buf.read()
+
+        upload_id = uuid.uuid4()
+        storage_path = f"uploads/{TEST_ORG_ID}/{TEST_USER_ID}/{upload_id}.tar"
+        mock_file_store._storage[storage_path] = no_prompt_tarball
+
+        from openhands.automation.models import TarballUpload, UploadStatus, Automation
+
+        upload = TarballUpload(
+            id=upload_id,
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            name="no-prompt-upload",
+            status=UploadStatus.COMPLETED,
+            storage_path=storage_path,
+            size_bytes=len(no_prompt_tarball),
+        )
+        async_session.add(upload)
+
+        automation_id = uuid.uuid4()
+        automation = Automation(
+            id=automation_id,
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            name="Non-Preset Automation",
+            prompt=None,
+            trigger={"type": "cron", "schedule": "0 0 * * *"},
+            tarball_path=f"oh-internal://uploads/{upload_id}",
+            setup_script_path="setup.sh",
+            entrypoint="python main.py",
+        )
+        async_session.add(automation)
+        await async_session.flush()
+
+        response = await async_client.post(
+            f"/api/automation/v1/preset/{automation_id}/regenerate"
+        )
+        assert response.status_code == 422
+        assert "no prompt found" in response.json()["detail"]
+


### PR DESCRIPTION
## Problem

Preset automations created with old template versions break when the SDK is updated. The specific failure observed in automation `Reply hello world on openhands-test label` (created April 10, 2026, before the `prompt` DB field was added in #49):

```
ModuleNotFoundError: No module named 'openhands.sdk.utils.path'

Traceback:
  main.py line 63: from openhands.tools import get_default_agent
  → openhands/tools/__init__.py: from openhands.tools.file_editor import FileEditorTool
  → openhands/tools/file_editor/editor.py: from openhands.sdk.utils.path import ...
```

The old template used `from openhands.tools import get_default_agent`, which cascades through `openhands.tools.__init__` and eventually tries to import `openhands.sdk.utils.path` — a module that no longer exists in current SDK releases. The current template already uses the correct scoped import (`from openhands.tools.preset.default import get_default_agent`), but old automations have their tarball frozen at creation time with no way to refresh it.

## Solution

Add `POST /v1/preset/{automation_id}/regenerate` to `preset_router.py`. This endpoint re-packages a preset automation in-place using the latest `sdk_main.py` and `setup.sh` templates while preserving the original prompt and any repository configuration.

**Prompt resolution order:**
1. DB `prompt` field (populated for automations created after #49)
2. `prompt.txt` extracted from the existing tarball (legacy fallback for automations where `prompt` is `NULL`)

`repos_config.json` is always restored from the tarball when present. After regeneration the DB `prompt` field is backfilled, so subsequent calls don't need to read the tarball.

**Returns** `422` if no prompt can be recovered (non-preset automation or deleted tarball), `404` if the automation doesn't exist.

## Changes

- **`openhands/automation/preset_router.py`**
  - New imports: `select` from SQLAlchemy, `parse_internal_upload_id`
  - New helper `_read_tarball_files(tarball_path, session, file_store)` — reads all files from an internal tarball by resolving the upload record
  - New endpoint `POST /v1/preset/{automation_id}/regenerate`

- **`tests/test_preset_router.py`**
  - New `TestRegeneratePresetAutomation` class with 5 tests covering: regeneration with stored prompt, legacy null-prompt case (extraction from tarball + DB backfill), repos preservation, 404, and 422

## How to fix the failing automation

```bash
curl -X POST "https://staging.all-hands.dev/api/automation/v1/preset/1bd23c57-956e-4482-9727-ffafe2b784e7/regenerate" \
  -H "Authorization: Bearer ${OPENHANDS_API_KEY}"
```

> _This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://staging.all-hands.dev/conversations/118b2895-734a-4a7f-9fe8-cfc3411cf3a9)