### PR TITLE
Fix SQLite source-tree migration discovery

### DIFF
--- a/openhands/automation/app.py
+++ b/openhands/automation/app.py
@@ -34,6 +34,24 @@ from openhands.automation.webhook_router import router as webhook_router
 logger = logging.getLogger("automation.app")
 
 
+def _resolve_migrations_path(package_dir: Path | None = None) -> Path:
+    """Find Alembic migrations for packaged installs and source checkouts."""
+    package_dir = package_dir or Path(__file__).parent
+    candidates = [
+        package_dir / "migrations",  # Packaged wheel path
+        package_dir.parent.parent / "migrations",  # Source checkout repo root
+        package_dir.parent / "migrations",  # Legacy source fallback
+    ]
+
+    for migrations_path in candidates:
+        if migrations_path.is_dir():
+            return migrations_path
+
+    checked = ", ".join(str(path) for path in candidates)
+    msg = f"Migrations directory not found. Checked: {checked}"
+    raise RuntimeError(msg)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application startup/shutdown lifecycle."""
@@ -75,23 +93,7 @@ async def lifespan(app: FastAPI):
 
         from openhands.automation.db import normalize_sqlite_url_for_alembic
 
-        # Find migrations folder relative to this package.
-        # When installed via pip/uvx, migrations are bundled inside
-        # automation/migrations.
-        package_dir = Path(__file__).parent
-        migrations_path = package_dir / "migrations"
-
-        if not migrations_path.is_dir():
-            # Fallback: check if running from source (migrations at repo root)
-            repo_root_migrations = package_dir.parent / "migrations"
-            if repo_root_migrations.is_dir():
-                migrations_path = repo_root_migrations
-            else:
-                msg = (
-                    f"Migrations directory not found. "
-                    f"Checked: {migrations_path}, {repo_root_migrations}"
-                )
-                raise RuntimeError(msg)
+        migrations_path = _resolve_migrations_path()
 
         alembic_cfg = Config()
         alembic_cfg.set_main_option("script_location", str(migrations_path))

--- a/tests/test_app_migrations.py
+++ b/tests/test_app_migrations.py
@@ -1,0 +1,50 @@
+"""Tests for application migration discovery."""
+
+import pytest
+
+from openhands.automation.app import _resolve_migrations_path
+
+
+def test_resolve_migrations_path_prefers_packaged_migrations(tmp_path):
+    """Packaged migrations are used when bundled inside the package."""
+    package_dir = tmp_path / "openhands" / "automation"
+    packaged_migrations = package_dir / "migrations"
+    source_migrations = tmp_path / "migrations"
+    packaged_migrations.mkdir(parents=True)
+    source_migrations.mkdir()
+
+    assert _resolve_migrations_path(package_dir) == packaged_migrations
+
+
+def test_resolve_migrations_path_finds_source_checkout_repo_root(tmp_path):
+    """Source checkouts use the repo-root migrations directory."""
+    package_dir = tmp_path / "openhands" / "automation"
+    package_dir.mkdir(parents=True)
+    repo_root_migrations = tmp_path / "migrations"
+    repo_root_migrations.mkdir()
+
+    assert _resolve_migrations_path(package_dir) == repo_root_migrations
+
+
+def test_resolve_migrations_path_keeps_legacy_parent_fallback(tmp_path):
+    """The old parent fallback is retained for non-standard layouts."""
+    package_dir = tmp_path / "openhands" / "automation"
+    package_dir.mkdir(parents=True)
+    legacy_migrations = tmp_path / "openhands" / "migrations"
+    legacy_migrations.mkdir()
+
+    assert _resolve_migrations_path(package_dir) == legacy_migrations
+
+
+def test_resolve_migrations_path_error_lists_checked_paths(tmp_path):
+    """Missing migrations raise an error with every checked location."""
+    package_dir = tmp_path / "openhands" / "automation"
+    package_dir.mkdir(parents=True)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _resolve_migrations_path(package_dir)
+
+    message = str(exc_info.value)
+    assert str(package_dir / "migrations") in message
+    assert str(tmp_path / "migrations") in message
+    assert str(tmp_path / "openhands" / "migrations") in message


### PR DESCRIPTION
## Summary
- Extract SQLite migration path discovery into a helper.
- Preserve packaged migration discovery while checking the source checkout repo-root `migrations/` path via `package_dir.parent.parent / "migrations"`.
- Retain the previous `package_dir.parent / "migrations"` path as a legacy fallback.
- Add tests covering packaged, source checkout, legacy fallback, and missing-path behavior.

Fixes #128.

## Tests
- `uv run pytest tests/test_app_migrations.py -v`
- `uv run ruff check openhands/automation/app.py tests/test_app_migrations.py`
- `uv run ruff format --check openhands/automation/app.py tests/test_app_migrations.py`
- `uv run pre-commit run --files openhands/automation/app.py tests/test_app_migrations.py --show-diff-on-failure`
- Attempted `uv run pytest tests/ -v --ignore=tests/integration`, but the full suite could not complete because this environment does not have a Docker daemon available for testcontainers.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2538b6c5-ee0a-4f12-b834-9eb649b3698c)