### PR TITLE
feat(auth): accept X-Session-API-Key header as auth fallback

### DIFF
--- a/openhands/automation/auth.py
+++ b/openhands/automation/auth.py
@@ -301,7 +301,9 @@ def _extract_credential(request: Request) -> tuple[str, AuthMethod]:
     )
 
 
-def _parse_users_me(data: dict, auth_method: AuthMethod, credential: str) -> AuthenticatedUser:  # type: ignore[type-arg]
+def _parse_users_me(
+    data: dict, auth_method: AuthMethod, credential: str
+) -> AuthenticatedUser:  # type: ignore[type-arg]
     """Build an AuthenticatedUser from the OpenHands /api/v1/users/me response."""
     user_id_raw = data.get("id")
     org_id_raw = data.get("org_id")

--- a/openhands/automation/auth.py
+++ b/openhands/automation/auth.py
@@ -1,10 +1,12 @@
 """Authentication for the automations service API.
 
-Supports two authentication methods:
-1. API key: Bearer token in the Authorization header
-2. Cookie: keycloak_auth cookie from the OpenHands web UI
+Supports three authentication methods (checked in order):
+1. API key via Authorization: Bearer header
+2. API key via X-Session-API-Key header (matches agent-server convention,
+   useful behind reverse proxies that overwrite the Authorization header)
+3. Cookie: keycloak_auth cookie from the OpenHands web UI
 
-Both methods validate against the OpenHands API GET /api/v1/users/me endpoint
+All methods validate against the OpenHands API GET /api/v1/users/me endpoint
 to get the user and organization identity.
 """
 
@@ -257,119 +259,50 @@ def require_permission(permission: str):
     return _check
 
 
-async def authenticate_request(
-    request: Request,
-    client: httpx.AsyncClient = Depends(get_http_client),
-) -> AuthenticatedUser:
-    """Authenticate the request using API key or keycloak_auth cookie.
+def _extract_api_key(request: Request) -> str | None:
+    """Extract an API key from the request headers.
 
-    Authentication modes:
-
-    **Local mode with local_api_key configured:**
-    Only the configured local API key is accepted. SaaS authentication is
-    disabled. Matching Bearer tokens are authenticated as a default local
-    user without calling the OpenHands API. Non-matching keys are rejected
-    immediately.
-
-    **SaaS mode (local_api_key not configured):**
-    Supports API key via Authorization: Bearer header or keycloak_auth cookie.
-    Calls the OpenHands API GET /api/v1/users/me to verify credentials and
-    get user/org identity. Implements retry with exponential backoff for
-    rate limiting. Results are cached in-memory.
+    Checks Authorization: Bearer first, then X-Session-API-Key as a fallback
+    (useful behind reverse proxies that overwrite the Authorization header).
+    Returns None when neither header carries a key.
     """
-    settings = get_config().service
-
-    # Determine authentication method (API key takes priority)
     auth_header = request.headers.get("Authorization", "")
     if auth_header.startswith("Bearer "):
-        api_key = auth_header.removeprefix("Bearer ").strip()
-        if not api_key:
+        key = auth_header.removeprefix("Bearer ").strip()
+        if not key:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Empty API key",
             )
+        return key
 
-        # In local mode with local_api_key configured, only accept that key
-        # (SaaS authentication is disabled when local_api_key is set)
-        if settings.is_local_mode and settings.local_api_key:
-            # Use constant-time comparison to prevent timing attacks
-            if secrets.compare_digest(api_key, settings.local_api_key):
-                logger.debug("Authenticated via local API key")
-                return _get_local_user()
-            # Key doesn't match - reject immediately in local mode
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid API key",
-            )
+    session_key = request.headers.get("X-Session-API-Key", "").strip()
+    return session_key or None
 
-        auth_method = AuthMethod.API_KEY
-        credential = api_key
-    else:
-        cookie_value = request.cookies.get("keycloak_auth")
-        if cookie_value:
-            auth_method = AuthMethod.COOKIE
-            credential = cookie_value
-        else:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Authentication required: provide Bearer token "
-                "or keycloak_auth cookie",
-            )
 
-    # Check cache first
-    cache_key = _credential_cache_key(credential)
-    auth_cache = _get_auth_cache()
-    cached_user = auth_cache.get(cache_key)
-    if cached_user is not None:
-        logger.debug("Auth cache hit for user %s", cached_user.user_id)
-        return cached_user
+def _extract_credential(request: Request) -> tuple[str, AuthMethod]:
+    """Extract a credential and its auth method from the request.
 
-    logger.debug("Auth cache miss, validating with OpenHands API")
+    Priority: Authorization: Bearer → X-Session-API-Key → keycloak_auth cookie.
+    Raises 401 if nothing usable is found.
+    """
+    api_key = _extract_api_key(request)
+    if api_key:
+        return api_key, AuthMethod.API_KEY
 
-    # Build outbound headers based on auth method
-    if auth_method == AuthMethod.API_KEY:
-        outbound_headers = {"Authorization": f"Bearer {credential}"}
-    else:
-        outbound_headers = {"Cookie": f"keycloak_auth={credential}"}
+    cookie = request.cookies.get("keycloak_auth")
+    if cookie:
+        return cookie, AuthMethod.COOKIE
 
-    try:
-        resp = await _make_auth_request_with_retry(
-            client,
-            f"{settings.openhands_api_base_url}/api/v1/users/me",
-            headers=outbound_headers,
-        )
-    except httpx.RequestError as e:
-        logger.error("Failed to reach OpenHands API for auth: %s", e)
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Failed to reach OpenHands API for authentication",
-        )
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Authentication required: provide Bearer token, "
+        "X-Session-API-Key header, or keycloak_auth cookie",
+    )
 
-    if resp.status_code == 401:
-        if auth_method == AuthMethod.API_KEY:
-            detail = "Invalid or expired API key"
-        else:
-            detail = "Invalid or expired session cookie"
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=detail,
-        )
-    if resp.status_code == 429:
-        raise HTTPException(
-            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-            detail="Rate limited by authentication service",
-        )
-    if resp.status_code != 200:
-        logger.error(
-            "Unexpected status from OpenHands /api/v1/users/me: %s",
-            resp.status_code,
-        )
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Unexpected response from OpenHands API",
-        )
 
-    data = resp.json()
+def _parse_users_me(data: dict, auth_method: AuthMethod, credential: str) -> AuthenticatedUser:  # type: ignore[type-arg]
+    """Build an AuthenticatedUser from the OpenHands /api/v1/users/me response."""
     user_id_raw = data.get("id")
     org_id_raw = data.get("org_id")
     if not user_id_raw or not org_id_raw:
@@ -387,20 +320,99 @@ async def authenticate_request(
             detail="Invalid user_id or org_id format from OpenHands API",
         )
 
-    email = data.get("email", "")
-    role = data.get("role", "")
-    permissions = data.get("permissions", [])
-
-    user = AuthenticatedUser(
+    return AuthenticatedUser(
         user_id=user_uuid,
         org_id=org_uuid,
-        email=email,
-        role=role,
-        permissions=permissions,
+        email=data.get("email", ""),
+        role=data.get("role", ""),
+        permissions=data.get("permissions", []),
         auth_method=auth_method,
         api_key=credential if auth_method == AuthMethod.API_KEY else None,
         model_profile_names=_extract_model_profile_names(data),
         active_model_profile_name=_extract_active_model_profile_name(data),
     )
+
+
+async def authenticate_request(
+    request: Request,
+    client: httpx.AsyncClient = Depends(get_http_client),
+) -> AuthenticatedUser:
+    """Authenticate via API key (Bearer / X-Session-API-Key) or cookie.
+
+    Local mode: only the configured ``local_api_key`` is accepted;
+    SaaS validation is skipped entirely.
+
+    SaaS mode: credentials are verified against ``GET /api/v1/users/me``
+    with retry + in-memory caching.
+    """
+    settings = get_config().service
+
+    # --- Local-mode fast path (no network call) ---
+    api_key = _extract_api_key(request)
+    if api_key and settings.is_local_mode and settings.local_api_key:
+        if secrets.compare_digest(api_key, settings.local_api_key):
+            logger.debug("Authenticated via local API key")
+            return _get_local_user()
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API key",
+        )
+
+    # --- Resolve credential (API key or cookie) ---
+    credential, auth_method = _extract_credential(request)
+
+    # --- Cache lookup ---
+    cache_key = _credential_cache_key(credential)
+    auth_cache = _get_auth_cache()
+    cached_user = auth_cache.get(cache_key)
+    if cached_user is not None:
+        logger.debug("Auth cache hit for user %s", cached_user.user_id)
+        return cached_user
+
+    # --- Validate against OpenHands API ---
+    logger.debug("Auth cache miss, validating with OpenHands API")
+    outbound_headers = (
+        {"Authorization": f"Bearer {credential}"}
+        if auth_method == AuthMethod.API_KEY
+        else {"Cookie": f"keycloak_auth={credential}"}
+    )
+
+    try:
+        resp = await _make_auth_request_with_retry(
+            client,
+            f"{settings.openhands_api_base_url}/api/v1/users/me",
+            headers=outbound_headers,
+        )
+    except httpx.RequestError as e:
+        logger.error("Failed to reach OpenHands API for auth: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to reach OpenHands API for authentication",
+        )
+
+    if resp.status_code == 401:
+        detail = (
+            "Invalid or expired API key"
+            if auth_method == AuthMethod.API_KEY
+            else "Invalid or expired session cookie"
+        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=detail)
+    if resp.status_code == 429:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Rate limited by authentication service",
+        )
+    if resp.status_code != 200:
+        logger.error(
+            "Unexpected status from OpenHands /api/v1/users/me: %s",
+            resp.status_code,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Unexpected response from OpenHands API",
+        )
+
+    # --- Build user and cache ---
+    user = _parse_users_me(resp.json(), auth_method, credential)
     auth_cache[cache_key] = user
     return user

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -60,6 +60,20 @@ def mock_http_client():
     return client
 
 
+def _make_header_getter(headers_dict: dict[str, str]):
+    """Return a side_effect callable for mock_request.headers.get.
+
+    Allows tests to return different values for different header names,
+    which is needed when the code checks multiple headers (Authorization,
+    X-Session-API-Key).
+    """
+
+    def _get(name: str, default: str = "") -> str:
+        return headers_dict.get(name, default)
+
+    return _get
+
+
 class TestAuthentication:
     """Tests for authenticate_request function with API key auth.
 
@@ -131,8 +145,10 @@ class TestAuthentication:
     async def test_authenticate_invalid_bearer_format(
         self, mock_request, mock_http_client
     ):
-        """Invalid Bearer format with no cookie raises 401."""
-        mock_request.headers.get.return_value = "InvalidFormat token"
+        """Invalid Bearer format with no cookie or X-Session-API-Key raises 401."""
+        mock_request.headers.get.side_effect = _make_header_getter(
+            {"Authorization": "InvalidFormat token"}
+        )
 
         with pytest.raises(HTTPException) as exc_info:
             await authenticate_request(mock_request, client=mock_http_client)
@@ -284,6 +300,144 @@ class TestCookieAuthentication:
             await authenticate_request(mock_request, client=mock_http_client)
 
         assert exc_info.value.status_code == 502
+
+
+class TestXSessionAPIKeyAuthentication:
+    """Tests for X-Session-API-Key header authentication."""
+
+    async def test_x_session_api_key_authenticates(
+        self, mock_request, mock_http_client
+    ):
+        """X-Session-API-Key header is accepted when no Authorization header."""
+        mock_request.headers.get.side_effect = _make_header_getter(
+            {"X-Session-API-Key": "session-key-value"}
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = MOCK_USERS_ME_RESPONSE
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        result = await authenticate_request(mock_request, client=mock_http_client)
+
+        assert isinstance(result, AuthenticatedUser)
+        assert result.user_id == TEST_USER_ID
+        assert result.auth_method == AuthMethod.API_KEY
+        assert result.api_key == "session-key-value"
+
+        # Verify outbound request used Authorization: Bearer
+        call_args = mock_http_client.get.call_args
+        headers = call_args[1]["headers"]
+        assert headers["Authorization"] == "Bearer session-key-value"
+
+    async def test_bearer_takes_priority_over_x_session_api_key(
+        self, mock_request, mock_http_client
+    ):
+        """Authorization: Bearer wins when both headers are present."""
+        mock_request.headers.get.side_effect = _make_header_getter(
+            {
+                "Authorization": "Bearer bearer-key",
+                "X-Session-API-Key": "session-key",
+            }
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = MOCK_USERS_ME_RESPONSE
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        result = await authenticate_request(mock_request, client=mock_http_client)
+
+        assert result.api_key == "bearer-key"
+
+    async def test_x_session_api_key_takes_priority_over_cookie(
+        self, mock_request, mock_http_client
+    ):
+        """X-Session-API-Key wins over keycloak_auth cookie."""
+        mock_request.headers.get.side_effect = _make_header_getter(
+            {"X-Session-API-Key": "session-key"}
+        )
+        mock_request.cookies = {"keycloak_auth": "cookie-value"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = MOCK_USERS_ME_RESPONSE
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        result = await authenticate_request(mock_request, client=mock_http_client)
+
+        assert result.auth_method == AuthMethod.API_KEY
+        assert result.api_key == "session-key"
+
+    async def test_x_session_api_key_empty_falls_through_to_cookie(
+        self, mock_request, mock_http_client
+    ):
+        """Empty X-Session-API-Key falls through to cookie auth."""
+        mock_request.headers.get.side_effect = _make_header_getter(
+            {"X-Session-API-Key": "  "}
+        )
+        mock_request.cookies = {"keycloak_auth": "cookie-value"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = MOCK_USERS_ME_RESPONSE
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        result = await authenticate_request(mock_request, client=mock_http_client)
+
+        assert result.auth_method == AuthMethod.COOKIE
+
+    async def test_x_session_api_key_invalid_raises_401(
+        self, mock_request, mock_http_client
+    ):
+        """Invalid X-Session-API-Key returns 401 from upstream."""
+        mock_request.headers.get.side_effect = _make_header_getter(
+            {"X-Session-API-Key": "bad-key"}
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_request(mock_request, client=mock_http_client)
+
+        assert exc_info.value.status_code == 401
+        assert "Invalid or expired API key" in exc_info.value.detail
+
+    async def test_x_session_api_key_works_with_local_mode(
+        self, mock_request, mock_http_client
+    ):
+        """X-Session-API-Key works with local_api_key authentication."""
+        mock_request.headers.get.side_effect = _make_header_getter(
+            {"X-Session-API-Key": "test-local-api-key"}
+        )
+
+        with patch("openhands.automation.auth.get_config") as mock_get_config:
+            mock_settings = MagicMock()
+            mock_settings.is_local_mode = True
+            mock_settings.local_api_key = "test-local-api-key"
+            mock_config = MagicMock()
+            mock_config.service = mock_settings
+            mock_get_config.return_value = mock_config
+
+            user = await authenticate_request(mock_request, client=mock_http_client)
+
+            mock_http_client.get.assert_not_called()
+            assert user.auth_method == AuthMethod.LOCAL_API_KEY
+
+    async def test_no_headers_no_cookie_raises_401(
+        self, mock_request, mock_http_client
+    ):
+        """No Authorization, no X-Session-API-Key, no cookie → 401."""
+        mock_request.headers.get.side_effect = _make_header_getter({})
+        mock_request.cookies = {}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_request(mock_request, client=mock_http_client)
+
+        assert exc_info.value.status_code == 401
+        assert "X-Session-API-Key" in exc_info.value.detail
 
 
 class TestAuthIntegration:


### PR DESCRIPTION
## Summary

Adds support for the `X-Session-API-Key` header as an alternative to `Authorization: Bearer` for API key authentication. This matches the agent-server convention from the software-agent-sdk and enables running behind reverse proxies (e.g. nginx with basic auth) that overwrite the `Authorization` header.

## Motivation

When hosting behind nginx with HTTP basic auth, the `Authorization` header gets overwritten by nginx before it reaches the automation service. The `X-Session-API-Key` header provides an alternative path that doesn't conflict. This is already the convention used by the agent-server (see `execution.py` lines 186/204/226 and `utils/agent_server.py` line 73 in this repo).

## Changes

### `openhands/automation/auth.py`

Refactored `authenticate_request` from a single nested function into focused helpers with early returns:

| Helper | Responsibility |
|--------|---------------|
| `_extract_api_key(request)` | Checks `Authorization: Bearer` then `X-Session-API-Key`; returns the key or `None` |
| `_extract_credential(request)` | Calls `_extract_api_key`, falls back to cookie, raises 401 if nothing found |
| `_parse_users_me(data, ...)` | Validates and builds `AuthenticatedUser` from the `/api/v1/users/me` response |

`authenticate_request` is now a flat pipeline: **local-mode fast path → resolve credential → cache check → API validation → build & cache**.

**Authentication priority order:** `Authorization: Bearer` → `X-Session-API-Key` → `keycloak_auth` cookie → 401

### `tests/test_auth.py`

- Added `TestXSessionAPIKeyAuthentication` class with 7 tests covering the new header
- Added `_make_header_getter` helper for tests that need to differentiate between header names
- Fixed `test_authenticate_invalid_bearer_format` to use `side_effect` instead of `return_value`

### What's NOT changed

- Outbound requests to the OpenHands API still use `Authorization: Bearer` — this only affects how clients reach the automation service
- No schema, DB, or migration changes
- All existing auth methods continue to work identically

## Test Results

All 497 unit tests pass (excluding Docker-dependent tests which require a Docker daemon).

---

*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/026479ef-33a1-4e06-b03e-8a5b65a43322)