### PR TITLE
[APP-1961] Add Jira Data Center automation event source

### DIFF
--- a/openhands/automation/event_schemas/__init__.py
+++ b/openhands/automation/event_schemas/__init__.py
@@ -119,8 +119,10 @@ def parse_event(
 def _register_builtin_parsers() -> None:
     """Register parsers for built-in sources. Called at module load."""
     from openhands.automation.event_schemas.github import parse_github_event_auto
+    from openhands.automation.event_schemas.jira_dc import parse_jira_dc_event
 
     register_parser("github", parse_github_event_auto)
+    register_parser("jira_dc", parse_jira_dc_event)
 
 
 _register_builtin_parsers()

--- a/openhands/automation/event_schemas/jira_dc.py
+++ b/openhands/automation/event_schemas/jira_dc.py
@@ -1,0 +1,35 @@
+"""Jira Data Center webhook event parsing."""
+
+from typing import Any, ClassVar
+
+from pydantic import Field, computed_field
+
+from openhands.automation.event_schemas import WebhookEvent
+
+
+class JiraDcEvent(WebhookEvent):
+    """Jira Data Center webhook event.
+
+    Jira DC exposes the event identity in the top-level ``webhookEvent`` field.
+    The raw payload is preserved for automation code and filtering.
+    """
+
+    _source: ClassVar[str] = "jira_dc"
+
+    webhook_event: str = Field(alias="webhookEvent")
+    payload: dict[str, Any]
+
+    @computed_field
+    @property
+    def event_key(self) -> str:
+        """Return the Jira DC webhook event key."""
+        return self.webhook_event
+
+
+def parse_jira_dc_event(payload: dict[str, Any]) -> JiraDcEvent:
+    """Parse a Jira DC webhook payload."""
+    event_key = payload.get("webhookEvent")
+    if not isinstance(event_key, str) or not event_key:
+        raise ValueError("Cannot detect jira_dc event type")
+
+    return JiraDcEvent(webhookEvent=event_key, payload=payload)

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -370,7 +370,7 @@ class WebhookConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     secret: str
-    is_builtin: bool = False  # True for github
+    is_builtin: bool = False  # True for built-in OpenHands-forwarded sources
     event_key_expr: str = "type"  # JMESPath expression for extracting event key
     signature_header: str = "X-Hub-Signature-256"  # HTTP header for signature
 
@@ -387,7 +387,7 @@ class EventResponse(BaseModel):
 _SOURCE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,48}[a-z0-9]$|^[a-z0-9]$")
 
 # Reserved source names (built-in integrations)
-RESERVED_SOURCES = frozenset({"github"})
+RESERVED_SOURCES = frozenset({"github", "jira_dc"})
 
 
 # Valid HTTP header name pattern

--- a/openhands/automation/utils/webhook.py
+++ b/openhands/automation/utils/webhook.py
@@ -34,6 +34,7 @@ BuiltinConfigFunc = Callable[[Settings], str | None]
 
 BUILTIN_SOURCES: dict[str, BuiltinConfigFunc] = {
     "github": lambda s: s.webhook_secret or None,
+    "jira_dc": lambda s: s.webhook_secret or None,
 }
 
 

--- a/tests/test_event_router.py
+++ b/tests/test_event_router.py
@@ -83,6 +83,26 @@ def github_pr_payload() -> dict:
     }
 
 
+@pytest.fixture
+def jira_dc_comment_payload() -> dict:
+    """Sample OpenHands-forwarded Jira DC comment event payload."""
+    return {
+        "organization": {
+            "jira_dc_workspace": "jira.company.com",
+            "openhands_org_id": "00000000-0000-0000-0000-000000000123",
+        },
+        "payload": {
+            "webhookEvent": "comment_created",
+            "comment": {"body": "please review @openhands"},
+            "issue": {
+                "id": "12345",
+                "key": "PROJ-123",
+                "self": "https://jira.company.com/rest/api/2/issue/12345",
+            },
+        },
+    }
+
+
 def sign_payload(payload: dict, secret: str) -> tuple[str, bytes]:
     """Generate HMAC signature for payload.
 
@@ -156,6 +176,53 @@ async def test_receive_github_event_with_matching_automation(
 
     response = await async_client.post(
         f"/api/automation/v1/events/{org_id}/github",
+        content=body,
+        headers={
+            "X-Hub-Signature-256": signature,
+            "Content-Type": "application/json",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["received"] is True
+    assert data["matched"] == 1
+    assert len(data["runs_created"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_receive_jira_dc_event_with_matching_automation(
+    async_client: AsyncClient,
+    org_id: uuid.UUID,
+    jira_dc_comment_payload: dict,
+    async_session,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_authenticated_user,
+):
+    """Test receiving Jira DC event that matches an automation."""
+    monkeypatch.setenv("AUTOMATION_WEBHOOK_SECRET", "test-secret")
+
+    automation = Automation(
+        id=uuid.uuid4(),
+        user_id=mock_authenticated_user.user_id,
+        org_id=org_id,
+        name="Test Jira DC Automation",
+        tarball_path="oh-internal://uploads/test.tar.gz",
+        entrypoint="python main.py",
+        trigger={
+            "type": "event",
+            "source": "jira_dc",
+            "on": "comment_created",
+            "filter": "icontains(comment.body, '@openhands')",
+        },
+    )
+    async_session.add(automation)
+    await async_session.commit()
+
+    signature, body = sign_payload(jira_dc_comment_payload, "test-secret")
+
+    response = await async_client.post(
+        f"/api/automation/v1/events/{org_id}/jira_dc",
         content=body,
         headers={
             "X-Hub-Signature-256": signature,

--- a/tests/test_event_schemas.py
+++ b/tests/test_event_schemas.py
@@ -605,6 +605,58 @@ class TestCustomWebhookEvent:
         assert result is False
 
 
+class TestJiraDcEvent:
+    """Tests for Jira Data Center webhook events."""
+
+    def test_parse_jira_dc_comment_created(self):
+        """Jira DC event keys come from webhookEvent."""
+        payload = {
+            "webhookEvent": "comment_created",
+            "comment": {"body": "hello"},
+            "issue": {"key": "PROJ-123"},
+        }
+
+        event = parse_event("jira_dc", payload)
+
+        assert event.source == "jira_dc"
+        assert event.event_key == "comment_created"
+        assert event.payload == payload
+
+    def test_parse_jira_dc_issue_updated(self):
+        """Jira DC issue update events are exposed as their webhookEvent."""
+        payload = {
+            "webhookEvent": "jira:issue_updated",
+            "changelog": {"items": []},
+            "issue": {"key": "PROJ-123"},
+        }
+
+        event = parse_event("jira_dc", payload)
+
+        assert event.source == "jira_dc"
+        assert event.event_key == "jira:issue_updated"
+
+    def test_jira_dc_trigger_matching_with_filter(self):
+        """Jira DC events support normal trigger filters."""
+        payload = {
+            "webhookEvent": "comment_created",
+            "comment": {"body": "please review @openhands"},
+            "issue": {"key": "PROJ-123"},
+        }
+
+        trigger = EventTrigger(
+            source="jira_dc",
+            on="comment_created",
+            filter="icontains(comment.body, '@openhands')",
+        )
+
+        assert matches_trigger(trigger, "jira_dc", "comment_created", payload) is True
+
+    def test_jira_dc_missing_webhook_event(self):
+        """Jira DC events require webhookEvent."""
+        with pytest.raises(ValueError, match="Cannot detect jira_dc event type"):
+            parse_event("jira_dc", {"issue": {"key": "PROJ-123"}})
+
+
 class TestMalformedPayloads:
     """Tests for handling malformed payloads."""
 

--- a/tests/test_event_schemas.py
+++ b/tests/test_event_schemas.py
@@ -17,6 +17,7 @@ from openhands.automation.event_schemas.github import (
     detect_github_event_type,
     parse_github_event_auto,
 )
+from openhands.automation.event_schemas.jira_dc import JiraDcEvent
 from openhands.automation.schemas import EventTrigger
 from openhands.automation.trigger_matcher import matches_trigger
 
@@ -618,6 +619,7 @@ class TestJiraDcEvent:
 
         event = parse_event("jira_dc", payload)
 
+        assert isinstance(event, JiraDcEvent)
         assert event.source == "jira_dc"
         assert event.event_key == "comment_created"
         assert event.payload == payload

--- a/tests/test_webhook_router.py
+++ b/tests/test_webhook_router.py
@@ -54,6 +54,12 @@ class TestCustomWebhookCreateSchema:
             CustomWebhookCreate(name="Test", source="github")
         assert "reserved source name" in str(exc_info.value)
 
+    def test_reserved_source_jira_dc_rejected(self):
+        """Reserved source 'jira_dc' should be rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            CustomWebhookCreate(name="Test", source="jira_dc")
+        assert "reserved source name" in str(exc_info.value)
+
     def test_reserved_source_case_insensitive(self):
         """Reserved source check is case-insensitive."""
         with pytest.raises(ValidationError) as exc_info:
@@ -198,9 +204,9 @@ class TestReservedSources:
         """GitHub should be reserved."""
         assert "github" in RESERVED_SOURCES
 
-    def test_only_github_reserved(self):
-        """Only GitHub should be reserved (for now)."""
-        assert RESERVED_SOURCES == {"github"}
+    def test_builtin_sources_reserved(self):
+        """Built-in sources should be reserved."""
+        assert RESERVED_SOURCES == {"github", "jira_dc"}
 
 
 class TestWebhookSecretGeneration:


### PR DESCRIPTION
## Summary

Adds a built-in `jira_dc` automation event source for OpenHands-forwarded Jira Data Center webhook events.

- registers a Jira DC event parser using the webhook `webhookEvent` field
- reserves `jira_dc` so it cannot be used as a custom webhook source
- reuses the built-in automation webhook secret path for signed OpenHands forwarding
- adds coverage for parsing, filtering, reserved source validation, and DB-backed event router behavior

## Validation

- `uv run pytest tests/test_event_schemas.py tests/test_webhook_router.py -q`
- `uv run ruff check openhands/automation/event_schemas/jira_dc.py openhands/automation/event_schemas/__init__.py openhands/automation/schemas.py openhands/automation/utils/webhook.py tests/test_event_schemas.py tests/test_webhook_router.py tests/test_event_router.py`
- `uv run ruff format --check openhands/automation/event_schemas/jira_dc.py openhands/automation/event_schemas/__init__.py openhands/automation/schemas.py openhands/automation/utils/webhook.py tests/test_event_schemas.py tests/test_webhook_router.py tests/test_event_router.py`
- CI passed: Docker, ci, Run tests (`pytest tests/`)
- OHE E2E on `replicated-02`: built-in `jira_dc` `comment_created` event was received by automation, matched `1/1`, dispatched run `17b66b18-8e16-4660-9fa4-5510cc0ca8e7`, and completed successfully.
- OHE E2E on `replicated-02`: built-in `jira_dc` `jira:issue_updated` event was received by automation, matched `1/1`, dispatched run `4c17c4b2-e7e1-4c37-a11a-39c06cc49258`, and completed successfully.

Local note: the DB-backed event router test depends on Docker/Testcontainers, so it was not run from the local workstation. It is covered by CI's full `pytest tests/` run and by the OHE E2E checks above.

---
Linear: APP-1961

_AI-generated metadata update by OpenHands on behalf of ak684._
