### PR TITLE
Support chunked OpenHands session cookies

### DIFF
--- a/openhands/automation/auth.py
+++ b/openhands/automation/auth.py
@@ -36,6 +36,8 @@ logger = logging.getLogger("automation.auth")
 
 # Auth cache - initialized lazily to use config values
 _auth_cache: TTLCache[str, "AuthenticatedUser"] | None = None
+SESSION_COOKIE_NAME = "keycloak_auth"
+MAX_SESSION_COOKIE_CHUNKS = 8
 
 
 def _get_auth_cache() -> TTLCache[str, "AuthenticatedUser"]:
@@ -280,6 +282,26 @@ def _extract_api_key(request: Request) -> str | None:
     return session_key or None
 
 
+def _extract_session_cookie(request: Request) -> str | None:
+    """Read OpenHands' possibly chunked session cookie.
+
+    OpenHands splits large keycloak_auth values across keycloak_auth,
+    keycloak_auth_1, keycloak_auth_2, etc. Automation validates by forwarding
+    the reassembled token back to OpenHands /api/v1/users/me.
+    """
+    first = request.cookies.get(SESSION_COOKIE_NAME)
+    if not first:
+        return None
+
+    parts = [first]
+    for index in range(1, MAX_SESSION_COOKIE_CHUNKS):
+        part = request.cookies.get(f"{SESSION_COOKIE_NAME}_{index}")
+        if part is None:
+            break
+        parts.append(part)
+    return "".join(parts)
+
+
 def _extract_credential(request: Request) -> tuple[str, AuthMethod]:
     """Extract a credential and its auth method from the request.
 
@@ -290,7 +312,7 @@ def _extract_credential(request: Request) -> tuple[str, AuthMethod]:
     if api_key:
         return api_key, AuthMethod.API_KEY
 
-    cookie = request.cookies.get("keycloak_auth")
+    cookie = _extract_session_cookie(request)
     if cookie:
         return cookie, AuthMethod.COOKIE
 
@@ -376,7 +398,7 @@ async def authenticate_request(
     outbound_headers = (
         {"Authorization": f"Bearer {credential}"}
         if auth_method == AuthMethod.API_KEY
-        else {"Cookie": f"keycloak_auth={credential}"}
+        else {"Cookie": f"{SESSION_COOKIE_NAME}={credential}"}
     )
 
     try:

--- a/openhands/automation/auth.py
+++ b/openhands/automation/auth.py
@@ -37,6 +37,8 @@ logger = logging.getLogger("automation.auth")
 # Auth cache - initialized lazily to use config values
 _auth_cache: TTLCache[str, "AuthenticatedUser"] | None = None
 SESSION_COOKIE_NAME = "keycloak_auth"
+# Keep parity with OpenHands' cookie chunking helper: 8 * 3000 bytes is
+# comfortably above expected session token sizes while staying bounded.
 MAX_SESSION_COOKIE_CHUNKS = 8
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -239,6 +239,30 @@ class TestCookieAuthentication:
         assert headers["Cookie"] == "keycloak_auth=valid-cookie-value"
         assert "Authorization" not in headers
 
+    async def test_authenticate_chunked_cookie(
+        self, mock_request, mock_http_client
+    ):
+        """Chunked keycloak_auth cookies are reassembled before validation."""
+        mock_request.headers.get.return_value = ""
+        mock_request.cookies = {
+            "keycloak_auth": "chunk-0.",
+            "keycloak_auth_1": "chunk-1.",
+            "keycloak_auth_2": "chunk-2",
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = MOCK_USERS_ME_RESPONSE
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        result = await authenticate_request(mock_request, client=mock_http_client)
+
+        assert result.auth_method == AuthMethod.COOKIE
+        call_args = mock_http_client.get.call_args
+        headers = call_args[1]["headers"]
+        assert headers["Cookie"] == "keycloak_auth=chunk-0.chunk-1.chunk-2"
+        assert "Authorization" not in headers
+
     async def test_cookie_invalid_raises_401(self, mock_request, mock_http_client):
         """Invalid cookie (401 from OpenHands) raises 401."""
         mock_request.headers.get.return_value = ""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -239,9 +239,7 @@ class TestCookieAuthentication:
         assert headers["Cookie"] == "keycloak_auth=valid-cookie-value"
         assert "Authorization" not in headers
 
-    async def test_authenticate_chunked_cookie(
-        self, mock_request, mock_http_client
-    ):
+    async def test_authenticate_chunked_cookie(self, mock_request, mock_http_client):
         """Chunked keycloak_auth cookies are reassembled before validation."""
         mock_request.headers.get.return_value = ""
         mock_request.cookies = {


### PR DESCRIPTION
## Summary
- Reassemble chunked OpenHands session cookies (`keycloak_auth`, `keycloak_auth_1`, ...) before validating UI requests against `/api/v1/users/me`
- Keep API-key and `X-Session-API-Key` auth behavior unchanged
- Add unit coverage for chunked cookie auth forwarding

## Validation
- [x] `uv run ruff check openhands/automation/auth.py tests/test_auth.py`
- [x] `uv run pytest tests/test_auth.py -k 'not AuthIntegration'` (42 passed, 4 deselected; the full file still requires local Docker/Testcontainers)
- [x] Human tested the changes on R01 OHE: before the patch, `/automations/` loaded but `/api/automation/v1?limit=50&offset=0` returned `401 {"detail":"Invalid or expired session cookie"}` with chunked browser cookies. After applying the patched auth file as a temporary ConfigMap overlay, the same BBDC login and `/automations/` UI flow returned `200 {"automations":[],"total":0}` and rendered the real empty Automations state.
