### PR TITLE
fix: ensure UTC timestamps are parsed correctly in Activity Log

### DIFF
--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -2,7 +2,6 @@
 
 import re
 import uuid
-from datetime import datetime
 from enum import StrEnum
 from typing import Annotated, Literal
 
@@ -11,6 +10,7 @@ from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, field_val
 
 from openhands.automation.config import get_config
 from openhands.automation.constants import MODEL_PROFILE_PATTERN
+from openhands.automation.utils.time import UtcDatetime
 
 
 # Allowed URI schemes for tarball_path (includes internal upload scheme)
@@ -532,8 +532,8 @@ class CustomWebhookResponse(BaseModel):
     event_key_expr: str
     signature_header: str
     enabled: bool
-    created_at: datetime
-    updated_at: datetime
+    created_at: UtcDatetime
+    updated_at: UtcDatetime
 
     model_config = {"from_attributes": True}
 
@@ -587,9 +587,9 @@ class AutomationResponse(BaseModel):
     entrypoint: str
     timeout: int | None
     enabled: bool
-    last_triggered_at: datetime | None
-    created_at: datetime
-    updated_at: datetime
+    last_triggered_at: UtcDatetime | None
+    created_at: UtcDatetime
+    updated_at: UtcDatetime
 
     model_config = {"from_attributes": True}
 
@@ -621,13 +621,13 @@ class AutomationRunResponse(BaseModel):
     status: RunStatus
     error_detail: str | None
     conversation_id: str | None
-    timeout_at: datetime | None
+    timeout_at: UtcDatetime | None
     keep_alive: bool
     sandbox_id: str | None
     bash_command_id: str | None = None
-    created_at: datetime
-    started_at: datetime | None
-    completed_at: datetime | None
+    created_at: UtcDatetime
+    started_at: UtcDatetime | None
+    completed_at: UtcDatetime | None
 
     model_config = {"from_attributes": True}
 

--- a/openhands/automation/utils/__init__.py
+++ b/openhands/automation/utils/__init__.py
@@ -10,7 +10,7 @@ from openhands.automation.utils.cron import (
     is_automation_due,
 )
 from openhands.automation.utils.log_context import log_extra
-from openhands.automation.utils.time import utcnow
+from openhands.automation.utils.time import UtcDatetime, ensure_utc, utcnow
 
 
 __all__ = [
@@ -20,5 +20,7 @@ __all__ = [
     "get_prev_fire_time",
     "is_automation_due",
     "log_extra",
+    "UtcDatetime",
+    "ensure_utc",
     "utcnow",
 ]

--- a/openhands/automation/utils/time.py
+++ b/openhands/automation/utils/time.py
@@ -1,6 +1,9 @@
 """Time utility functions for the automation service."""
 
 from datetime import UTC, datetime
+from typing import Annotated
+
+from pydantic import AfterValidator
 
 
 def utcnow() -> datetime:
@@ -13,3 +16,26 @@ def utcnow() -> datetime:
     end-to-end.
     """
     return datetime.now(UTC)
+
+
+def ensure_utc(dt: datetime) -> datetime:
+    """Attach UTC tzinfo to a naive datetime, leaving aware datetimes unchanged.
+
+    SQLite ignores ``timezone=True`` on ``DateTime`` columns and always returns
+    naive ``datetime`` objects. Without this, Pydantic serialises those values
+    without a timezone suffix (e.g. ``"2026-03-23T09:00:00"``), which
+    JavaScript's ``Date`` constructor interprets as *local* time instead of UTC.
+
+    Applying this as an ``AfterValidator`` on every response-schema datetime
+    field ensures the JSON output always includes a UTC offset regardless of the
+    database backend.
+    """
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
+
+
+# Annotated datetime type that guarantees UTC-aware serialisation.
+# Use this instead of bare ``datetime`` in Pydantic response schemas so that
+# naive datetimes returned by SQLite are transparently normalised to UTC.
+UtcDatetime = Annotated[datetime, AfterValidator(ensure_utc)]

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -8,18 +8,22 @@ underlying ensure_utc helper) fix this at the serialisation layer.
 """
 
 import uuid
-from datetime import UTC, datetime, timezone, timedelta
+from datetime import UTC, datetime, timedelta, timezone
+from typing import Any
 
-import pytest
-
+from openhands.automation.schemas import (
+    AutomationResponse,
+    AutomationRunResponse,
+    RunStatus,
+)
 from openhands.automation.utils.time import ensure_utc
-from openhands.automation.schemas import AutomationRunResponse, AutomationResponse
-from openhands.automation.schemas import RunStatus
 
 
 _NAIVE = datetime(2026, 3, 23, 9, 0, 0)  # no tzinfo — simulates SQLite output
 _UTC_AWARE = datetime(2026, 3, 23, 9, 0, 0, tzinfo=UTC)
-_OTHER_TZ = datetime(2026, 3, 23, 14, 30, 0, tzinfo=timezone(timedelta(hours=5, minutes=30)))
+_OTHER_TZ = datetime(
+    2026, 3, 23, 14, 30, 0, tzinfo=timezone(timedelta(hours=5, minutes=30))
+)
 
 
 class TestEnsureUtc:
@@ -43,8 +47,8 @@ class TestEnsureUtc:
 class TestAutomationRunResponseUtcSerialisation:
     """AutomationRunResponse must include a UTC offset in all datetime fields."""
 
-    def _make_run(self, **overrides) -> AutomationRunResponse:
-        defaults = dict(
+    def _make_run(self, **overrides: Any) -> AutomationRunResponse:
+        defaults: dict[str, Any] = dict(
             id=uuid.uuid4(),
             automation_id=uuid.uuid4(),
             status=RunStatus.COMPLETED,
@@ -74,7 +78,9 @@ class TestAutomationRunResponseUtcSerialisation:
     def test_naive_completed_at_serialises_with_utc_offset(self):
         run = self._make_run()
         data = run.model_dump(mode="json")
-        assert data["completed_at"].endswith("+00:00") or data["completed_at"].endswith("Z")
+        assert data["completed_at"].endswith("+00:00") or data["completed_at"].endswith(
+            "Z"
+        )
 
     def test_none_optional_fields_remain_none(self):
         run = self._make_run(started_at=None, completed_at=None, timeout_at=None)
@@ -92,8 +98,8 @@ class TestAutomationRunResponseUtcSerialisation:
 class TestAutomationResponseUtcSerialisation:
     """AutomationResponse datetime fields also emit UTC offsets."""
 
-    def _make_automation(self, **overrides) -> AutomationResponse:
-        defaults = dict(
+    def _make_automation(self, **overrides: Any) -> AutomationResponse:
+        defaults: dict[str, Any] = dict(
             id=uuid.uuid4(),
             user_id=uuid.uuid4(),
             org_id=uuid.uuid4(),
@@ -121,7 +127,9 @@ class TestAutomationResponseUtcSerialisation:
     def test_naive_last_triggered_at_serialises_with_utc_offset(self):
         automation = self._make_automation()
         data = automation.model_dump(mode="json")
-        assert data["last_triggered_at"].endswith("+00:00") or data["last_triggered_at"].endswith("Z")
+        assert data["last_triggered_at"].endswith("+00:00") or data[
+            "last_triggered_at"
+        ].endswith("Z")
 
     def test_none_last_triggered_at_remains_none(self):
         automation = self._make_automation(last_triggered_at=None)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,129 @@
+"""Tests for Pydantic response schema UTC datetime normalisation.
+
+SQLite returns naive datetime objects (no tzinfo). Without explicit
+normalisation, Pydantic serialises those as bare ISO 8601 strings such as
+"2026-03-23T09:00:00", which JavaScript's Date constructor interprets as
+*local* time rather than UTC.  The UtcDatetime annotated type (and the
+underlying ensure_utc helper) fix this at the serialisation layer.
+"""
+
+import uuid
+from datetime import UTC, datetime, timezone, timedelta
+
+import pytest
+
+from openhands.automation.utils.time import ensure_utc
+from openhands.automation.schemas import AutomationRunResponse, AutomationResponse
+from openhands.automation.schemas import RunStatus
+
+
+_NAIVE = datetime(2026, 3, 23, 9, 0, 0)  # no tzinfo — simulates SQLite output
+_UTC_AWARE = datetime(2026, 3, 23, 9, 0, 0, tzinfo=UTC)
+_OTHER_TZ = datetime(2026, 3, 23, 14, 30, 0, tzinfo=timezone(timedelta(hours=5, minutes=30)))
+
+
+class TestEnsureUtc:
+    def test_naive_datetime_gets_utc_tzinfo(self):
+        result = ensure_utc(_NAIVE)
+        assert result.tzinfo is UTC
+
+    def test_naive_datetime_value_is_unchanged(self):
+        result = ensure_utc(_NAIVE)
+        assert result.replace(tzinfo=None) == _NAIVE
+
+    def test_utc_aware_datetime_is_unchanged(self):
+        result = ensure_utc(_UTC_AWARE)
+        assert result is _UTC_AWARE
+
+    def test_non_utc_aware_datetime_is_unchanged(self):
+        result = ensure_utc(_OTHER_TZ)
+        assert result is _OTHER_TZ
+
+
+class TestAutomationRunResponseUtcSerialisation:
+    """AutomationRunResponse must include a UTC offset in all datetime fields."""
+
+    def _make_run(self, **overrides) -> AutomationRunResponse:
+        defaults = dict(
+            id=uuid.uuid4(),
+            automation_id=uuid.uuid4(),
+            status=RunStatus.COMPLETED,
+            error_detail=None,
+            conversation_id=None,
+            timeout_at=None,
+            keep_alive=False,
+            sandbox_id=None,
+            bash_command_id=None,
+            created_at=_NAIVE,
+            started_at=_NAIVE,
+            completed_at=_NAIVE,
+        )
+        defaults.update(overrides)
+        return AutomationRunResponse(**defaults)
+
+    def test_naive_created_at_serialises_with_utc_offset(self):
+        run = self._make_run()
+        data = run.model_dump(mode="json")
+        assert data["created_at"].endswith("+00:00") or data["created_at"].endswith("Z")
+
+    def test_naive_started_at_serialises_with_utc_offset(self):
+        run = self._make_run()
+        data = run.model_dump(mode="json")
+        assert data["started_at"].endswith("+00:00") or data["started_at"].endswith("Z")
+
+    def test_naive_completed_at_serialises_with_utc_offset(self):
+        run = self._make_run()
+        data = run.model_dump(mode="json")
+        assert data["completed_at"].endswith("+00:00") or data["completed_at"].endswith("Z")
+
+    def test_none_optional_fields_remain_none(self):
+        run = self._make_run(started_at=None, completed_at=None, timeout_at=None)
+        data = run.model_dump(mode="json")
+        assert data["started_at"] is None
+        assert data["completed_at"] is None
+        assert data["timeout_at"] is None
+
+    def test_already_utc_aware_datetime_serialises_correctly(self):
+        run = self._make_run(created_at=_UTC_AWARE)
+        data = run.model_dump(mode="json")
+        assert data["created_at"].endswith("+00:00") or data["created_at"].endswith("Z")
+
+
+class TestAutomationResponseUtcSerialisation:
+    """AutomationResponse datetime fields also emit UTC offsets."""
+
+    def _make_automation(self, **overrides) -> AutomationResponse:
+        defaults = dict(
+            id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+            org_id=uuid.uuid4(),
+            model=None,
+            name="Test",
+            prompt=None,
+            trigger={"type": "cron", "schedule": "0 9 * * 1", "timezone": "UTC"},
+            tarball_path="s3://bucket/key.tar.gz",
+            setup_script_path=None,
+            entrypoint="python main.py",
+            timeout=None,
+            enabled=True,
+            last_triggered_at=_NAIVE,
+            created_at=_NAIVE,
+            updated_at=_NAIVE,
+        )
+        defaults.update(overrides)
+        return AutomationResponse(**defaults)
+
+    def test_naive_created_at_serialises_with_utc_offset(self):
+        automation = self._make_automation()
+        data = automation.model_dump(mode="json")
+        assert data["created_at"].endswith("+00:00") or data["created_at"].endswith("Z")
+
+    def test_naive_last_triggered_at_serialises_with_utc_offset(self):
+        automation = self._make_automation()
+        data = automation.model_dump(mode="json")
+        assert data["last_triggered_at"].endswith("+00:00") or data["last_triggered_at"].endswith("Z")
+
+    def test_none_last_triggered_at_remains_none(self):
+        automation = self._make_automation(last_triggered_at=None)
+        data = automation.model_dump(mode="json")
+        assert data["last_triggered_at"] is None


### PR DESCRIPTION
## Summary

Fixes incorrect timezone display in the Activity Log for client viewers running in local mode (SQLite).

## Root Cause

SQLite ignores `timezone=True` on `DateTime` columns and always returns naive `datetime` objects (no tzinfo). Pydantic then serialises those without a timezone suffix, e.g. `"2026-03-23T09:00:00"` instead of `"2026-03-23T09:00:00+00:00"`. JavaScript's `Date` constructor treats bare strings as *local* time, so timestamps are shifted by the viewer's UTC offset.

## Fix

### `openhands/automation/utils/time.py` *(modified)*

Adds two things alongside the existing `utcnow()`:

- **`ensure_utc(dt)`** — attaches `UTC` tzinfo to a naive datetime; leaves already-aware datetimes untouched.
- **`UtcDatetime`** — a Pydantic `Annotated` type alias that wraps `ensure_utc` as an `AfterValidator`, so the normalisation happens automatically during schema validation.

### `openhands/automation/schemas.py` *(modified)*

Every `datetime` / `datetime | None` field in the three responseEvery `datetime` / d wEvery `datetime` / `datetime | None` field in the three responseEvery `datetime` / d wEvery `datetime`` | `last_triggereEvery `datetime` / `datetime | None` field in the three responseEvery `datetime` / d wEvery `datetime` / `datetime | None` field in the three responseEvery `datetime` / d wEvery `datetime`` | `last_triggereEvery `datetime` / `datetime | None` field in the three responseEvery `datetime` / d wEvery `datetime` / `datetime | None` field in the three responseEvesure_utc` onEvery `datetime` / `datetime | None` field in the thtomEvery `datetime` / `datetime | None` field in theutput always contains a UTC offset, even when the input datetime is naive (as SQLite returns)
- Optional fields serialise to `null` as expected

---

_This pull request was created by an AI agent (OpenHands) on behalf of the user._