### PR TITLE
fix: eliminate minute-boundary race in scheduler tests

### DIFF
--- a/openhands/automation/scheduler.py
+++ b/openhands/automation/scheduler.py
@@ -77,6 +77,7 @@ async def _fetch_enabled_automations(
 async def poll_and_schedule(
     session_factory: async_sessionmaker[AsyncSession],
     batch_size: int = DEFAULT_BATCH_SIZE,
+    now: datetime | None = None,
 ) -> list[AutomationRun]:
     """Poll for due automations and create pending runs atomically.
 
@@ -91,11 +92,13 @@ async def poll_and_schedule(
     Args:
         session_factory: SQLAlchemy async session factory
         batch_size: Maximum number of automations to poll per batch
+        now: Current time (defaults to utcnow()). Inject in tests for determinism.
 
     Returns:
         List of AutomationRun objects created
     """
-    now = utcnow()
+    if now is None:
+        now = utcnow()
     poll_threshold = now - timedelta(seconds=POLL_INTERVAL_SECONDS)
     created_runs: list[AutomationRun] = []
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -693,8 +693,10 @@ class TestPollAndSchedule:
             await session.commit()
             automation_id = not_due_automation.id
 
-        # Poll - should return no runs since the automation is not due
-        runs = await poll_and_schedule(async_session_factory)
+        # Poll with the same 'now' used for last_triggered_at so that
+        # prev_fire_time (always ≤ now) can never exceed last_triggered_at,
+        # making the result deterministic regardless of minute boundaries.
+        runs = await poll_and_schedule(async_session_factory, now=now)
         assert len(runs) == 0
 
         # But last_polled_at should still be updated
@@ -748,11 +750,17 @@ class TestPollAndSchedule:
             not_due_id = not_due.id
             due_id = due.id
 
-        # First poll with batch_size=1: picks one automation (order not guaranteed)
-        runs_first = await poll_and_schedule(async_session_factory, batch_size=1)
+        # Both polls use the same 'now' so prev_fire_time (≤ now) can never
+        # exceed the not_due automation's last_triggered_at (= now), keeping
+        # the "not due" classification stable across minute boundaries.
+        runs_first = await poll_and_schedule(
+            async_session_factory, batch_size=1, now=now
+        )
 
         # Second poll with batch_size=1: should pick the OTHER automation
-        runs_second = await poll_and_schedule(async_session_factory, batch_size=1)
+        runs_second = await poll_and_schedule(
+            async_session_factory, batch_size=1, now=now
+        )
 
         # Together, we should have exactly 1 run (from the due automation)
         all_runs = runs_first + runs_second


### PR DESCRIPTION
## Summary

Fixes the failing test:
```
FAILED tests/test_scheduler.py::TestPollAndSchedule::test_last_polled_at_updated_even_when_not_due
```

## Root Cause

`test_last_polled_at_updated_even_when_not_due` (and companion `test_batch_rotates_with_mix_of_due_and_not_due`) had a minute-boundary race condition:

1. The test captured `now = utcnow()` and stored it as `last_triggered_at`
2. It then called `poll_and_schedule(...)`, which internally called `utcnow()` again — a slightly later timestamp `T'`
3. With a `"* * * * *"` (every-minute) cron schedule, `get_prev_fire_time` returns the **start of the current minute relative to `T'`**
4. If the wall clock crossed a minute boundary between the two `utcnow()` calls (i.e., the test's `now` fell in the last milliseconds of a minute), `prev_fire_time > last_triggered_at` — so `is_automation_due` returned `True` and a run was spuriously created

## Changes

**`openhands/automation/scheduler.py`**
- Added `now: datetime | None = None` parameter to `poll_and_schedule`
- Production callers pass nothing (defaults to `utcnow()`); no behaviour change in production

**`tests/test_scheduler.py`**
- Both affected tests now pass `now=now` to `poll_and_schedule`
- This pins `prev_fire_time <= now = last_triggered_at`, so `is_automation_due` deterministically returns `False` for the "not due" automation regardless of minute boundaries

_This PR was created by an AI agent (OpenHands) on behalf of the user._