### PR TITLE
chore: bump version to 1.0.0a5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-automation"
-version = "1.0.0a4"
+version = "1.0.0a5"
 description = "OpenHands automation service"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -2158,7 +2158,7 @@ wheels = [
 
 [[package]]
 name = "openhands-automation"
-version = "1.0.0a4"
+version = "1.0.0a5"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Bump pre-release version from `1.0.0a4` → `1.0.0a5`.

This PR only updates `pyproject.toml` and regenerates `uv.lock`. It does **not** cut the release — after merging, tag `1.0.0a5` and push the tag to trigger the PyPI publish and Docker image tagging workflows.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8a27ef02-f93c-4704-aeba-8298991fd074)