### PR TITLE
fix(presets): pin venv to Python >=3.12 in setup.sh

### DIFF
--- a/openhands/automation/presets/plugin/setup.sh
+++ b/openhands/automation/presets/plugin/setup.sh
@@ -24,7 +24,9 @@ if [ -z "$SDK_VERSION" ]; then
 fi
 
 echo "[setup] Creating isolated virtual environment"
-uv venv .venv --quiet
+# Pin >=3.12 so uv doesn't default to an older system Python (e.g. macOS
+# CommandLineTools 3.9), which can't satisfy openhands-sdk's requires-python.
+uv venv .venv --python '>=3.12' --quiet
 
 echo "[setup] Installing OpenHands SDK from PyPI (version: $SDK_VERSION)"
 uv pip install --quiet \

--- a/openhands/automation/presets/prompt/setup.sh
+++ b/openhands/automation/presets/prompt/setup.sh
@@ -24,7 +24,9 @@ if [ -z "$SDK_VERSION" ]; then
 fi
 
 echo "[setup] Creating isolated virtual environment"
-uv venv .venv --quiet
+# Pin >=3.12 so uv doesn't default to an older system Python (e.g. macOS
+# CommandLineTools 3.9), which can't satisfy openhands-sdk's requires-python.
+uv venv .venv --python '>=3.12' --quiet
 
 echo "[setup] Installing OpenHands SDK from PyPI (version: $SDK_VERSION)"
 uv pip install --quiet \


### PR DESCRIPTION
uv venv with no --python defaults to the first system interpreter, which on macOS is CommandLineTools Python 3.9. That fails the subsequent openhands-sdk install since the SDK requires Python >=3.12.

This fixes https://github.com/OpenHands/agent-canvas/issues/2157 for me when I load locally:
```
OH_AUTOMATION_REPO=https://github.com/DevinVinson/automation \
OH_AUTOMATION_GIT_REF=dv/setup-venv-python-312 \
npm run dev
```
