### PR TITLE
chore: bump version to 1.0.0a6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-automation"
-version = "1.0.0a5"
+version = "1.0.0a6"
 description = "OpenHands automation service"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -2158,7 +2158,7 @@ wheels = [
 
 [[package]]
 name = "openhands-automation"
-version = "1.0.0a5"
+version = "1.0.0a6"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## What's Changed

### Added
- A/B testing support for plugin automations (#146)

### Fixed
- Use per-run tarball path in `execute_in_context` to prevent race condition (#151)
- Regenerate prompt tarball when an automation's prompt is edited (#145)
- Activity log timezone formatting (#112)
- Pin venv to Python >=3.12 in setup.sh (#144)
- Inject session URL as secret using `conversation.id` in `sdk_main` (#142)

### Chores
- Remove PR review GitHub Actions workflow (#143)

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._