### PR TITLE
PLTF-2895: restore missing indexes on automations and automation_runs

### DIFF
--- a/migrations/versions/007_restore_missing_indexes.py
+++ b/migrations/versions/007_restore_missing_indexes.py
@@ -1,0 +1,97 @@
+"""Restore missing indexes on automations and automation_runs
+
+The non-primary-key indexes for these tables are declared on the models and in
+migration 001, but are absent in production: alembic reports the latest revision
+yet only the PK indexes exist. The most likely cause is that the indexes were
+added to migration 001 after it had already been applied, so they were never
+created in already-migrated databases (editing an applied migration does not
+re-run it). This migration recreates them idempotently.
+
+Effect: removes full table scans for the scheduler/dispatcher/watchdog polls and
+the listing queries, notably the dispatcher poll
+``WHERE status = 'PENDING' ORDER BY created_at`` (covered by the partial
+ix_automation_runs_pending) — one of the heaviest queries on the shared CloudSQL
+instance.
+
+Plain CREATE INDEX (not CONCURRENTLY): this migration harness runs on pg8000
+inside a transaction holding an advisory lock, where alembic's autocommit_block
+(required for CREATE INDEX CONCURRENTLY) fails. Both tables are small in prod
+(automation_runs ~52K rows / 16MB, automations ~200 rows), so each build is
+sub-second and the brief write lock is acceptable. if_not_exists keeps this a
+no-op on databases that already have the indexes (e.g. fresh deployments).
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-06-04
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import text
+
+revision: str = "007"
+down_revision: Union[str, None] = "006"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # automations
+    op.create_index(
+        "ix_automations_user_id", "automations", ["user_id"], if_not_exists=True
+    )
+    op.create_index(
+        "ix_automations_org_id", "automations", ["org_id"], if_not_exists=True
+    )
+    op.create_index(
+        "ix_automations_enabled", "automations", ["enabled"], if_not_exists=True
+    )
+    op.create_index(
+        "ix_automations_deleted_at", "automations", ["deleted_at"], if_not_exists=True
+    )
+    op.create_index(
+        "ix_automations_last_polled_at",
+        "automations",
+        ["last_polled_at"],
+        if_not_exists=True,
+    )
+
+    # automation_runs
+    op.create_index(
+        "ix_automation_runs_automation_id",
+        "automation_runs",
+        ["automation_id"],
+        if_not_exists=True,
+    )
+    op.create_index(
+        "ix_automation_runs_status", "automation_runs", ["status"], if_not_exists=True
+    )
+    op.create_index(
+        "ix_automation_runs_pending",
+        "automation_runs",
+        ["created_at"],
+        postgresql_where=text("status = 'PENDING'"),
+        if_not_exists=True,
+    )
+    op.create_index(
+        "ix_automation_runs_timeout_at",
+        "automation_runs",
+        ["timeout_at"],
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    for name, table in [
+        ("ix_automation_runs_timeout_at", "automation_runs"),
+        ("ix_automation_runs_pending", "automation_runs"),
+        ("ix_automation_runs_status", "automation_runs"),
+        ("ix_automation_runs_automation_id", "automation_runs"),
+        ("ix_automations_last_polled_at", "automations"),
+        ("ix_automations_deleted_at", "automations"),
+        ("ix_automations_enabled", "automations"),
+        ("ix_automations_org_id", "automations"),
+        ("ix_automations_user_id", "automations"),
+    ]:
+        op.drop_index(name, table_name=table, if_exists=True)

--- a/migrations/versions/007_restore_missing_indexes.py
+++ b/migrations/versions/007_restore_missing_indexes.py
@@ -25,15 +25,16 @@ Revises: 006
 Create Date: 2026-06-04
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 from alembic import op
 from sqlalchemy import text
 
+
 revision: str = "007"
-down_revision: Union[str, None] = "006"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -241,6 +241,79 @@ class TestSqliteMigrations:
             if os.path.exists(db_path):
                 os.unlink(db_path)
 
+    def test_head_repairs_missing_automation_indexes(self):
+        """Head migration recreates automation indexes missing from prior deploys."""
+        import subprocess
+
+        from sqlalchemy import create_engine, inspect, text
+
+        expected_indexes = {
+            "automations": {
+                "ix_automations_user_id",
+                "ix_automations_org_id",
+                "ix_automations_enabled",
+                "ix_automations_deleted_at",
+                "ix_automations_last_polled_at",
+            },
+            "automation_runs": {
+                "ix_automation_runs_automation_id",
+                "ix_automation_runs_status",
+                "ix_automation_runs_pending",
+                "ix_automation_runs_timeout_at",
+            },
+        }
+
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+
+        try:
+            db_url = f"sqlite:///{db_path}"
+            env = os.environ.copy()
+            env["AUTOMATION_DB_URL"] = db_url
+
+            result = subprocess.run(
+                ["uv", "run", "alembic", "upgrade", "006"],
+                env=env,
+                capture_output=True,
+                text=True,
+                cwd=str(PROJECT_ROOT),
+            )
+            assert result.returncode == 0, f"Alembic upgrade failed: {result.stderr}"
+
+            engine = create_engine(db_url)
+            with engine.begin() as connection:
+                for index_names in expected_indexes.values():
+                    for index_name in index_names:
+                        connection.execute(text(f'DROP INDEX IF EXISTS "{index_name}"'))
+
+            inspector = inspect(engine)
+            for table_name, index_names in expected_indexes.items():
+                existing_names = {
+                    index["name"] for index in inspector.get_indexes(table_name)
+                }
+                assert existing_names.isdisjoint(index_names)
+
+            result = subprocess.run(
+                ["uv", "run", "alembic", "upgrade", "head"],
+                env=env,
+                capture_output=True,
+                text=True,
+                cwd=str(PROJECT_ROOT),
+            )
+            assert result.returncode == 0, f"Alembic upgrade failed: {result.stderr}"
+
+            inspector = inspect(engine)
+            for table_name, index_names in expected_indexes.items():
+                existing_names = {
+                    index["name"] for index in inspector.get_indexes(table_name)
+                }
+                assert index_names <= existing_names
+
+            engine.dispose()
+        finally:
+            if os.path.exists(db_path):
+                os.unlink(db_path)
+
     def test_auto_migration_error_handling(self):
         """Migration failure returns non-zero exit code.
 


### PR DESCRIPTION
Closes #157

## Problem
Every non-PK index on `automations` and `automation_runs` is **missing in production** — confirmed against the prod `automations` DB, only `automations_pkey` and `automation_runs_pkey` exist — even though they're declared on the models and in migration `001`, and alembic reports the latest revision.

This makes the dispatcher poll (`automation_runs WHERE status = 'PENDING' ORDER BY created_at ASC … FOR UPDATE SKIP LOCKED`) do a full table scan on every poll — it's currently among the top queries by total execution time on the shared CloudSQL instance.

## Root cause
The indexes were almost certainly added to migration `001` **after** it had already been applied in prod. Editing an already-applied migration never re-runs it, so already-migrated databases never got the indexes (fresh deployments that ran the corrected `001` do have them). A new migration is the fix.

## Fix
Migration `007` recreates all 9 indexes exactly as declared in the models / migration `001`, with `if_not_exists=True` so it's a **no-op** where they already exist:

**automations:** `user_id`, `org_id`, `enabled`, `deleted_at`, `last_polled_at`
**automation_runs:** `automation_id`, `status`, partial `(created_at) WHERE status='PENDING'`, `timeout_at`

No model changes — the models already declare these.

### Plain `CREATE INDEX`, not `CONCURRENTLY`
#157 suggests `CONCURRENTLY`, but this migration harness runs on **pg8000 inside a transaction holding an advisory lock**, where alembic's `autocommit_block` (required for `CONCURRENTLY`) fails — the same incompatibility recently hit on an OpenHands enterprise migration. Both tables are small in prod (`automation_runs` ~52K rows / 16 MB, `automations` ~200 rows), so each build is sub-second and the brief write-lock is acceptable.

## Follow-ups (not in this PR)
- Add the startup/smoke check from #157 point 3 to assert expected indexes exist, so this can't silently recur.
- Other models also declare `index=True` columns (e.g. `TarballUpload`, `CustomWebhook`) — worth verifying those indexes exist in prod too.

## Verification plan
On deploy I'll confirm the indexes exist and that the dispatcher poll switches from Seq Scan to an index/partial-index scan, and capture the before/after seq-scan rate (same method used for the `event_callback` fix).