### PR TITLE
APP-2217: Add automation run polling indexes

### DIFF
--- a/migrations/versions/007_add_automation_run_composite_indexes.py
+++ b/migrations/versions/007_add_automation_run_composite_indexes.py
@@ -1,0 +1,44 @@
+"""Add composite indexes for automation run polling queries.
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-06-05
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+
+revision: str = "007"
+down_revision: str = "006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_automation_runs_status_created_at",
+        "automation_runs",
+        ["status", "created_at"],
+        if_not_exists=True,
+    )
+    op.create_index(
+        "ix_automation_runs_status_timeout_at",
+        "automation_runs",
+        ["status", "timeout_at"],
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_automation_runs_status_timeout_at",
+        table_name="automation_runs",
+        if_exists=True,
+    )
+    op.drop_index(
+        "ix_automation_runs_status_created_at",
+        table_name="automation_runs",
+        if_exists=True,
+    )

--- a/openhands/automation/models.py
+++ b/openhands/automation/models.py
@@ -191,6 +191,8 @@ class AutomationRun(Base):
             postgresql_where=(status == AutomationRunStatus.PENDING),
         ),
         Index("ix_automation_runs_status", "status"),
+        Index("ix_automation_runs_status_created_at", "status", "created_at"),
+        Index("ix_automation_runs_status_timeout_at", "status", "timeout_at"),
     )
 
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -187,6 +187,12 @@ class TestSqliteMigrations:
             assert "custom_webhooks" in tables
             assert "alembic_version" in tables
 
+            run_indexes = {
+                index["name"] for index in inspector.get_indexes("automation_runs")
+            }
+            assert "ix_automation_runs_status_created_at" in run_indexes
+            assert "ix_automation_runs_status_timeout_at" in run_indexes
+
             engine.dispose()
         finally:
             # Clean up


### PR DESCRIPTION
## Summary

Adds two composite indexes for the hot `automation_runs` polling paths:

- `ix_automation_runs_status_created_at` for dispatcher claims using `WHERE status = $1 ORDER BY created_at ASC LIMIT ... FOR UPDATE SKIP LOCKED`
- `ix_automation_runs_status_timeout_at` for watchdog scans using `WHERE status = $1 AND timeout_at IS NOT NULL AND timeout_at < ...`

The first query already had a partial `created_at WHERE status = 'PENDING'` index, but the observed production SQL is parameterized as `status = $1`; the non-partial composite index is a better fit for generic prepared plans. The second query can use the existing single-column `timeout_at` index, but the composite index lets Postgres apply the status equality before the timeout range scan.

I checked `OpenHands/OpenHands` first. Latest `main` does not contain the `automation_runs` table or automation-service migration chain, so there is no OSS/enterprise migration split to update there for this table. The schema and queries live in `OpenHands/automation`, and this PR updates that repo's Alembic migration plus SQLAlchemy model metadata.

## Validation

- `uv run ruff format openhands/automation/models.py migrations/versions/007_add_automation_run_composite_indexes.py tests/test_db.py`
- `uv run ruff check openhands/automation/models.py migrations/versions/007_add_automation_run_composite_indexes.py tests/test_db.py`
- `uv run pytest tests/test_db.py::TestSqliteMigrations::test_migrations_run_on_sqlite -q`
- `uv run alembic heads`

Attempted `uv run pytest tests/test_dispatcher.py tests/test_watchdog.py -q`, but this environment cannot access the Docker socket required by the Postgres testcontainer fixture (`PermissionError: [Errno 13] Permission denied`).


Issue
Closes #161