### PR TITLE
fix: support external Postgres SSL mode

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -23,6 +23,7 @@ import os
 from alembic import context
 from sqlalchemy import create_engine, text
 
+from openhands.automation.db import _build_pg8000_connect_args
 from openhands.automation.models import Base
 
 
@@ -41,6 +42,9 @@ DB_PASS = os.getenv("AUTOMATION_DB_PASS", os.getenv("DB_PASS", "postgres"))
 DB_HOST = os.getenv("AUTOMATION_DB_HOST", os.getenv("DB_HOST", "localhost"))
 DB_PORT = os.getenv("AUTOMATION_DB_PORT", os.getenv("DB_PORT", "5432"))
 DB_NAME = os.getenv("AUTOMATION_DB_NAME", os.getenv("DB_NAME", "automations"))
+DB_SSL_MODE = os.getenv(
+    "AUTOMATION_DB_SSL_MODE", os.getenv("DB_SSL_MODE", os.getenv("PGSSLMODE", ""))
+)
 
 GCP_DB_INSTANCE = os.getenv("AUTOMATION_GCP_DB_INSTANCE", os.getenv("GCP_DB_INSTANCE"))
 GCP_PROJECT = os.getenv("AUTOMATION_GCP_PROJECT", os.getenv("GCP_PROJECT"))
@@ -91,7 +95,11 @@ def get_engine(database_name=DB_NAME):
 
     # Direct PostgreSQL
     url = f"postgresql+pg8000://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{database_name}"
-    return create_engine(url, pool_pre_ping=True)
+    return create_engine(
+        url,
+        connect_args=_build_pg8000_connect_args(DB_SSL_MODE),
+        pool_pre_ping=True,
+    )
 
 
 def run_migrations_offline():

--- a/openhands/automation/config.py
+++ b/openhands/automation/config.py
@@ -41,6 +41,7 @@ where repeated config lookups would add overhead. If you need to test with
 different values, use monkeypatching or reload the affected modules.
 """
 
+import os
 import warnings
 from functools import cached_property, lru_cache
 from typing import Literal
@@ -379,6 +380,13 @@ class ServiceSettings(BaseSettings):
     webhook_secret: str = ""
 
     model_config = {"env_prefix": "AUTOMATION_"}
+
+    @model_validator(mode="after")
+    def apply_db_ssl_mode_env_fallback(self) -> "ServiceSettings":
+        """Match migration env fallback for standard Postgres SSL variables."""
+        if "db_ssl_mode" not in self.model_fields_set:
+            self.db_ssl_mode = os.getenv("DB_SSL_MODE", os.getenv("PGSSLMODE", ""))
+        return self
 
     @property
     def is_local_mode(self) -> bool:

--- a/openhands/automation/config.py
+++ b/openhands/automation/config.py
@@ -237,6 +237,8 @@ class ServiceSettings(BaseSettings):
         AUTOMATION_DB_NAME: Database name (default: automations)
         AUTOMATION_DB_USER: Database user (default: postgres)
         AUTOMATION_DB_PASS: Database password (default: postgres)
+        AUTOMATION_DB_SSL_MODE: PostgreSQL SSL mode: prefer, require, or disable
+            (default: empty, use driver default)
         AUTOMATION_DB_POOL_SIZE: Connection pool size (default: 10)
         AUTOMATION_DB_MAX_OVERFLOW: Max overflow connections (default: 5)
         AUTOMATION_DB_POOL_RECYCLE: Pool recycle time in seconds (default: 1800)
@@ -291,6 +293,7 @@ class ServiceSettings(BaseSettings):
     db_name: str = "automations"
     db_user: str = "postgres"
     db_pass: str = "postgres"
+    db_ssl_mode: str = ""
     db_pool_size: int = 10
     db_max_overflow: int = 5
     db_pool_recycle: int = 1800  # 30 minutes

--- a/openhands/automation/db.py
+++ b/openhands/automation/db.py
@@ -27,6 +27,38 @@ from openhands.automation.config import ServiceSettings, get_config
 
 
 logger = logging.getLogger("automation.db")
+SUPPORTED_DB_SSL_MODES = {"prefer", "require", "disable"}
+
+
+def _normalize_db_ssl_mode(db_ssl_mode: str | None) -> str | None:
+    if db_ssl_mode is None:
+        return None
+
+    mode = db_ssl_mode.strip().lower()
+    if not mode or mode == "prefer":
+        return None
+    if mode not in SUPPORTED_DB_SSL_MODES:
+        raise ValueError(
+            f'Unsupported AUTOMATION_DB_SSL_MODE "{db_ssl_mode}". '
+            f"Supported values are: {', '.join(sorted(SUPPORTED_DB_SSL_MODES))}."
+        )
+    return mode
+
+
+def _build_asyncpg_connect_args(db_ssl_mode: str | None) -> dict:
+    mode = _normalize_db_ssl_mode(db_ssl_mode)
+    if mode:
+        return {"ssl": mode}
+    return {}
+
+
+def _build_pg8000_connect_args(db_ssl_mode: str | None) -> dict:
+    mode = _normalize_db_ssl_mode(db_ssl_mode)
+    if mode == "require":
+        return {"ssl_context": True}
+    if mode == "disable":
+        return {"ssl_context": False}
+    return {}
 
 
 def is_sqlite_url(url: str) -> bool:
@@ -103,6 +135,7 @@ async def create_engine(settings: ServiceSettings | None = None) -> EngineResult
     )
     engine = create_async_engine(
         url,
+        connect_args=_build_asyncpg_connect_args(settings.db_ssl_mode),
         pool_size=settings.db_pool_size,
         max_overflow=settings.db_max_overflow,
         pool_recycle=settings.db_pool_recycle,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -299,6 +299,41 @@ class TestLocalModeSettings:
         settings = Settings()
         assert settings.db_ssl_mode == ""
 
+    def test_db_ssl_mode_falls_back_to_db_ssl_mode(self, monkeypatch):
+        """db_ssl_mode falls back to standard DB_SSL_MODE."""
+        monkeypatch.setenv("DB_SSL_MODE", "require")
+
+        settings = Settings()
+
+        assert settings.db_ssl_mode == "require"
+
+    def test_db_ssl_mode_falls_back_to_pgsslmode(self, monkeypatch):
+        """db_ssl_mode falls back to standard PGSSLMODE."""
+        monkeypatch.setenv("PGSSLMODE", "disable")
+
+        settings = Settings()
+
+        assert settings.db_ssl_mode == "disable"
+
+    def test_automation_db_ssl_mode_takes_precedence(self, monkeypatch):
+        """AUTOMATION_DB_SSL_MODE takes precedence over standard fallbacks."""
+        monkeypatch.setenv("AUTOMATION_DB_SSL_MODE", "require")
+        monkeypatch.setenv("DB_SSL_MODE", "disable")
+        monkeypatch.setenv("PGSSLMODE", "prefer")
+
+        settings = Settings()
+
+        assert settings.db_ssl_mode == "require"
+
+    def test_db_ssl_mode_takes_precedence_over_pgsslmode(self, monkeypatch):
+        """DB_SSL_MODE takes precedence over PGSSLMODE."""
+        monkeypatch.setenv("DB_SSL_MODE", "require")
+        monkeypatch.setenv("PGSSLMODE", "disable")
+
+        settings = Settings()
+
+        assert settings.db_ssl_mode == "require"
+
     def test_local_mode_full_configuration(self):
         """All local mode settings can be configured together."""
         settings = Settings(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -294,6 +294,11 @@ class TestLocalModeSettings:
         settings = Settings()
         assert settings.db_url == ""
 
+    def test_db_ssl_mode_default(self):
+        """db_ssl_mode defaults to empty string."""
+        settings = Settings()
+        assert settings.db_ssl_mode == ""
+
     def test_local_mode_full_configuration(self):
         """All local mode settings can be configured together."""
         settings = Settings(
@@ -314,6 +319,7 @@ class TestLocalModeSettings:
         monkeypatch.setenv("AUTOMATION_AGENT_SERVER_API_KEY", "env-key")
         monkeypatch.setenv("AUTOMATION_WORKSPACE_BASE", "/env/workspace")
         monkeypatch.setenv("AUTOMATION_DB_URL", "sqlite+aiosqlite:////data/test.db")
+        monkeypatch.setenv("AUTOMATION_DB_SSL_MODE", "require")
         clear_config_cache()
 
         settings = Settings()
@@ -322,6 +328,7 @@ class TestLocalModeSettings:
         assert settings.agent_server_api_key == "env-key"
         assert settings.workspace_base == "/env/workspace"
         assert settings.db_url == "sqlite+aiosqlite:////data/test.db"
+        assert settings.db_ssl_mode == "require"
 
 
 class TestDeprecatedFunctionWarnings:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import pytest
 
 from openhands.automation.db import (
+    _build_asyncpg_connect_args,
+    _build_pg8000_connect_args,
     _create_sqlite_engine,
     is_sqlite_url,
     normalize_sqlite_url_for_alembic,
@@ -109,6 +111,28 @@ class TestEngineResult:
         """Dispose works when connector is None."""
         result = _create_sqlite_engine("sqlite+aiosqlite:///:memory:")
         await result.dispose()  # Should not raise
+
+
+class TestPostgresSslMode:
+    """Tests for PostgreSQL SSL mode mapping."""
+
+    def test_build_asyncpg_connect_args_for_ssl_modes(self):
+        assert _build_asyncpg_connect_args(None) == {}
+        assert _build_asyncpg_connect_args("") == {}
+        assert _build_asyncpg_connect_args("prefer") == {}
+        assert _build_asyncpg_connect_args("require") == {"ssl": "require"}
+        assert _build_asyncpg_connect_args("disable") == {"ssl": "disable"}
+
+    def test_build_pg8000_connect_args_for_ssl_modes(self):
+        assert _build_pg8000_connect_args(None) == {}
+        assert _build_pg8000_connect_args("") == {}
+        assert _build_pg8000_connect_args("prefer") == {}
+        assert _build_pg8000_connect_args("require") == {"ssl_context": True}
+        assert _build_pg8000_connect_args("disable") == {"ssl_context": False}
+
+    def test_build_connect_args_rejects_unsupported_ssl_mode(self):
+        with pytest.raises(ValueError, match="Unsupported AUTOMATION_DB_SSL_MODE"):
+            _build_asyncpg_connect_args("verify-full")
 
 
 class TestNormalizeSqliteUrlForAlembic:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -3,9 +3,12 @@
 import os
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 
+from openhands.automation import db as db_module
+from openhands.automation.config import ServiceSettings
 from openhands.automation.db import (
     _build_asyncpg_connect_args,
     _build_pg8000_connect_args,
@@ -133,6 +136,41 @@ class TestPostgresSslMode:
     def test_build_connect_args_rejects_unsupported_ssl_mode(self):
         with pytest.raises(ValueError, match="Unsupported AUTOMATION_DB_SSL_MODE"):
             _build_asyncpg_connect_args("verify-full")
+
+    @pytest.mark.asyncio
+    async def test_create_engine_passes_asyncpg_ssl_connect_args(self, monkeypatch):
+        captured: dict[str, Any] = {}
+        fake_engine: Any = object()
+
+        def fake_create_async_engine(*args: Any, **kwargs: Any) -> Any:
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return fake_engine
+
+        monkeypatch.setattr(db_module, "create_async_engine", fake_create_async_engine)
+        settings = ServiceSettings(
+            db_host="db.example.com",
+            db_port=5433,
+            db_name="automations",
+            db_user="openhands",
+            db_pass="secret",
+            db_ssl_mode="require",
+            db_url="",
+            gcp_db_instance=None,
+        )
+
+        result = await db_module.create_engine(settings)
+
+        assert result.engine is fake_engine
+        url = captured["args"][0]
+        assert url.drivername == "postgresql+asyncpg"
+        assert url.host == "db.example.com"
+        assert url.port == 5433
+        assert captured["kwargs"]["connect_args"] == {"ssl": "require"}
+        assert captured["kwargs"]["pool_size"] == settings.db_pool_size
+        assert captured["kwargs"]["max_overflow"] == settings.db_max_overflow
+        assert captured["kwargs"]["pool_recycle"] == settings.db_pool_recycle
+        assert captured["kwargs"]["pool_pre_ping"] is True
 
 
 class TestNormalizeSqliteUrlForAlembic:


### PR DESCRIPTION
## Summary
- Add `AUTOMATION_DB_SSL_MODE` support for automation service direct Postgres connections.
- Propagate SSL mode through asyncpg runtime connections and pg8000 Alembic migrations.
- Support `prefer`, `require`, and `disable` with focused unit coverage.
  - Successfully validated `sslmode=require` on a real Replicated OHE instance using an external Postgres endpoint on port `5433`; app login and a test conversation passed.
  
## Validation
- `uv run pytest tests/test_config.py tests/test_db.py`
- `git diff --check`