### PR TITLE
Fix automation conversation links on Replicated

### DIFF
--- a/frontend/src/__tests__/components/automations/detail/activity-log-item.test.tsx
+++ b/frontend/src/__tests__/components/automations/detail/activity-log-item.test.tsx
@@ -7,7 +7,11 @@ import { ActivityLogItem } from "#/components/automations/detail/activity-log-it
 describe("ActivityLogItem", () => {
   beforeEach(() => {
     Object.defineProperty(window, "location", {
-      value: { hostname: "app.all-hands.dev" },
+      value: {
+        hostname: "app.all-hands.dev",
+        origin: "https://app.all-hands.dev",
+        pathname: "/automations/1",
+      },
       writable: true,
     });
   });
@@ -107,7 +111,11 @@ describe("ActivityLogItem", () => {
 
   it("uses staging host when on staging domain", () => {
     Object.defineProperty(window, "location", {
-      value: { hostname: "staging.all-hands.dev" },
+      value: {
+        hostname: "staging.all-hands.dev",
+        origin: "https://staging.all-hands.dev",
+        pathname: "/automations/1",
+      },
       writable: true,
     });
 
@@ -121,9 +129,74 @@ describe("ActivityLogItem", () => {
     );
   });
 
+  it("uses the current host on replicated deployments", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        hostname: "app.replicated-02.aws.alona.platform-team.all-hands.dev",
+        origin:
+          "https://app.replicated-02.aws.alona.platform-team.all-hands.dev",
+        pathname: "/automations/1",
+      },
+      writable: true,
+    });
+
+    const run = createRun({ conversation_id: "conv-abc123" });
+    render(<ActivityLogItem run={run} />);
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute(
+      "href",
+      "https://app.replicated-02.aws.alona.platform-team.all-hands.dev/conversations/conv-abc123",
+    );
+  });
+
+  it("preserves path prefixes before the automations route", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        hostname: "example.com",
+        origin: "https://example.com",
+        pathname: "/acmecorp/automations/1",
+      },
+      writable: true,
+    });
+
+    const run = createRun({ conversation_id: "conv-abc123" });
+    render(<ActivityLogItem run={run} />);
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute(
+      "href",
+      "https://example.com/acmecorp/conversations/conv-abc123",
+    );
+  });
+
+  it("falls back to root when the current path is not an automations route", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        hostname: "example.com",
+        origin: "https://example.com",
+        pathname: "/settings",
+      },
+      writable: true,
+    });
+
+    const run = createRun({ conversation_id: "conv-abc123" });
+    render(<ActivityLogItem run={run} />);
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute(
+      "href",
+      "https://example.com/conversations/conv-abc123",
+    );
+  });
+
   it("uses app.all-hands.dev for localhost", () => {
     Object.defineProperty(window, "location", {
-      value: { hostname: "localhost" },
+      value: {
+        hostname: "localhost",
+        origin: "http://localhost:3002",
+        pathname: "/automations/1",
+      },
       writable: true,
     });
 

--- a/frontend/src/components/automations/detail/activity-log-item.tsx
+++ b/frontend/src/components/automations/detail/activity-log-item.tsx
@@ -38,11 +38,17 @@ function formatRunTimestamp(
 }
 
 function getConversationUrl(conversationId: string): string {
-  const { hostname } = window.location;
-  const baseHost = hostname.includes("staging.all-hands.dev")
-    ? "staging.all-hands.dev"
-    : "app.all-hands.dev";
-  return `https://${baseHost}/conversations/${conversationId}`;
+  const { hostname, origin, pathname } = window.location;
+  const isLocalHost = hostname === "localhost" || hostname === "127.0.0.1";
+
+  if (isLocalHost) {
+    return `https://app.all-hands.dev/conversations/${conversationId}`;
+  }
+
+  const automationsPathIndex = pathname.indexOf("/automations");
+  const prefix =
+    automationsPathIndex >= 0 ? pathname.slice(0, automationsPathIndex) : "";
+  return `${origin}${prefix}/conversations/${conversationId}`;
 }
 
 export function ActivityLogItem({ run, timeZone }: ActivityLogItemProps) {


### PR DESCRIPTION
## Summary

- Build automation run conversation links from the current deployment origin instead of hardcoding Cloud for every non-staging host.
- Preserve any path prefix before `/automations` so prefixed deployments still link to the matching OpenHands conversation route.
- Keep localhost and `127.0.0.1` on the existing Cloud dev fallback.

## Root Cause

Automation activity log rows hardcoded `app.all-hands.dev` for any host that was not staging. On Replicated/OHE, clicking a run with a `conversation_id` sent users to Cloud instead of the local OHE instance.

## Validation

- `npm test -- --run src/__tests__/components/automations/detail/activity-log-item.test.tsx`
- `npm run lint`
- Built image `ghcr.io/openhands/automation:sha-2738e75` through `ghcr-build.yml`.
- Deployed to R01 OHE through a KOTS validation release with `automations_enabled=1`.
- Confirmed live R01 automation detail bundle uses current `window.location.origin` for non-localhost conversation links.
- Created and dispatched a prompt automation through the R01 API; the run completed and produced conversation `2a7713ec-9e08-41ad-8d8d-f48835233b35` on the R01 app host.
