### PR TITLE
ci: scope prepare-release bot token to public-only fine-grained PAT

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
               with:
-                  token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
                   fetch-depth: 0
 
             - name: Install uv
@@ -99,7 +99,7 @@ jobs:
 
             - name: Create Pull Request
               env:
-                  GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  GH_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
               run: |
                   VERSION="${{ inputs.version }}"
                   CURRENT="${{ steps.current.outputs.version }}"


### PR DESCRIPTION
Use `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` (a fine-grained token limited to public repos) for the release-PR checkout and creation in `prepare-release.yml`, instead of the broad org bot PAT.

This workflow is `workflow_dispatch`-only and operates entirely on this repo (pushes a `release/*` branch and opens a PR here), so the public-scoped token is a drop-in with no behavior change. Part of the OpenHands credential trust-boundary cleanup so public-repo automation only carries a credential scoped to public repos.

Not touched here: `ghcr-build.yml` / `trigger-deploy-preview.yml`, which involve the cross-repo deploy-preview path and are handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)