### PR TITLE
fix: add tzdata dependency for Windows timezone support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "python-json-logger>=3",
   "sqlalchemy[asyncio]>=2",
   "tenacity>=9.1.4",
+  "tzdata>=2024.1",
   "uvicorn[standard]>=0.30",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2180,6 +2180,7 @@ dependencies = [
     { name = "python-json-logger" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "tenacity" },
+    { name = "tzdata" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -2218,6 +2219,7 @@ requires-dist = [
     { name = "python-json-logger", specifier = ">=3" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2" },
     { name = "tenacity", specifier = ">=9.1.4" },
+    { name = "tzdata", specifier = ">=2024.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
 
@@ -3729,6 +3731,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add tzdata>=2024.1 to dependencies. croniter and Python's zoneinfo require timezone data; on Windows this must be provided by the tzdata package. Without it, the scheduler crashes with ModuleNotFoundError: tzdata / ZoneInfoNotFoundError.

Per reviewer feedback on [agent-canvas#1257](https://github.com/OpenHands/agent-canvas/pull/1257), this dependency belongs here rather than being patched downstream.

PR #1257 on agent-canvas
That PR is already closed with zero diff — all the workaround patches were properly stripped out. No cleanup needed there.

Related context
OpenHands/automation#172 (already merged) — Fixed the Windows .venv/bin/python vs .venv/Scripts/python.exe issue
OpenHands/automation#170 — Open issue about Windows venv entrypoint (partially covered by #172)
The shared conversation you linked was the earlier session that stripped PR #1257 down to just the tzdata fix, which then got stripped further to zero based on @malhotra5's review