### PR TITLE
chore: release v1.0.0a7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-automation"
-version = "1.0.0a5"
+version = "1.0.0a7"
 description = "OpenHands automation service"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -2158,7 +2158,7 @@ wheels = [
 
 [[package]]
 name = "openhands-automation"
-version = "1.0.0a5"
+version = "1.0.0a7"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Release v1.0.0a7

Bumps version from `1.0.0a5` to `1.0.0a7` (`1.0.0a6` was used on the `dispatch-phase1b` branch).

### Changes since 1.0.0a5

#### Added
- feat: mark rate-limited automation runs as Skipped - Limit Reached (#174)
- feat: add API and UI support to cancel automation runs (#156)
- feat: A/B testing support for plugin automations (#146)
- Add automation promote-to-development dispatch (#162)

#### Fixed
- fix: add tzdata dependency for Windows timezone support (#177)
- fix: support Windows preset launchers (#172)
- Fix automation conversation links on Replicated (#165)
- fix: support external Postgres SSL mode
- fix: use per-run tarball path in execute_in_context to prevent race condition (#151)
- fix: regenerate prompt tarball when an automation's prompt is edited (#145)
- Fix activity log timezone formatting (#112)
- fix(presets): pin venv to Python >=3.12 in setup.sh (#144)
- fix(sdk_main): inject session URL as secret using conversation.id (#142)

#### Dependencies
- chore: bump openhands-sdk and openhands-workspace to 1.27.0 (#180)

#### CI / Chore
- ci: stop auto-triggering deploy previews from automation CI (#167)
- ci: scope prepare-release bot token to public-only fine-grained PAT (#166)
- Add automation run polling indexes (#160)
- chore: remove PR review GitHub Actions workflow (#143)

### After Merging

Once this PR is merged, create and push the release tag:

```bash
git checkout main && git pull origin main
git tag 1.0.0a7
git push origin 1.0.0a7
```

This triggers `pypi-release.yml` (PyPI publish) and `tag-image.yml` (Docker retag).

### Note on Prepare Release workflow

The automated `Prepare Release` workflow failed: `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` was recently scoped to a read-only fine-grained PAT (commit #166) and can no longer push branches. This PR was created manually as a workaround.

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*