### PR TITLE
feat: grant permissive CORS to API-key requests

### DIFF
--- a/openhands/automation/app.py
+++ b/openhands/automation/app.py
@@ -8,7 +8,6 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy import text
@@ -23,6 +22,7 @@ from openhands.automation.db import (
 from openhands.automation.dispatcher import dispatcher_loop
 from openhands.automation.event_router import router as event_router
 from openhands.automation.logger import setup_all_loggers
+from openhands.automation.middleware import ApiKeyAwareCORSMiddleware
 from openhands.automation.preset_router import router as preset_router
 from openhands.automation.router import router
 from openhands.automation.scheduler import scheduler_loop
@@ -207,12 +207,12 @@ def _create_app() -> FastAPI:
 
 app = _create_app()
 
+# API-key requests (e.g. the local agent-server GUI calling directly from the
+# browser) get permissive CORS; cookie/session requests keep the strict
+# allowlist below. Mirrors the main cloud API's ApiKeyAwareCORSMiddleware.
 app.add_middleware(
-    CORSMiddleware,
+    ApiKeyAwareCORSMiddleware,
     allow_origins=_build_cors_origins(),
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
 )
 
 _base_path = get_settings().base_path

--- a/openhands/automation/middleware.py
+++ b/openhands/automation/middleware.py
@@ -1,0 +1,69 @@
+"""ASGI middleware for the automations service."""
+
+from starlette.middleware.cors import CORSMiddleware
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+# Header names (lowercase) that carry an explicit API key. Cookie auth is
+# deliberately excluded — cookie requests must stay on the strict policy.
+_API_KEY_HEADERS = {"authorization", "x-session-api-key"}
+
+
+class ApiKeyAwareCORSMiddleware:
+    """CORS dispatcher that loosens the policy for credential-less requests.
+
+    Requests that authenticate via API key (``Authorization: Bearer …`` or
+    ``X-Session-API-Key``) get ``Access-Control-Allow-Origin: *`` with
+    credentials disabled — the wildcard is safe because the browser cannot
+    attach cookies when credentials are off, so the only way to authenticate
+    is the explicit key. This lets API-key clients (e.g. the local
+    agent-server GUI on ``localhost``) call the service directly from the
+    browser without a server-side proxy hop.
+
+    Cookie/session requests keep the strict origin allowlist with
+    credentials enabled, exactly as before.
+    """
+
+    def __init__(self, app: ASGIApp, allow_origins: list[str]) -> None:
+        self._permissive = CORSMiddleware(
+            app,
+            allow_origins=["*"],
+            allow_credentials=False,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+        self._strict = CORSMiddleware(
+            app,
+            allow_origins=allow_origins,
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http" and self._is_credentialless(scope):
+            await self._permissive(scope, receive, send)
+        else:
+            await self._strict(scope, receive, send)
+
+    @staticmethod
+    def _is_credentialless(scope: Scope) -> bool:
+        if scope["method"] == "OPTIONS":
+            # Preflight: the auth header hasn't been sent yet, so look at the
+            # headers the browser is asking permission to send. Parse the
+            # comma-separated list into a set so we match whole header names
+            # only — otherwise something like ``x-my-authorization-token``
+            # would substring-match ``authorization``.
+            for name, value in scope["headers"]:
+                if name == b"access-control-request-headers":
+                    requested_headers = {
+                        h.strip() for h in value.decode("latin-1").lower().split(",")
+                    }
+                    return bool(requested_headers & _API_KEY_HEADERS)
+            return False
+        for name, value in scope["headers"]:
+            if name == b"authorization" and value[:7].lower() == b"bearer ":
+                return True
+            if name == b"x-session-api-key":
+                return True
+        return False

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,193 @@
+"""Behavioral tests for the API-key-aware CORS policy.
+
+ApiKeyAwareCORSMiddleware splits incoming requests into two CORS regimes:
+
+  * API-key requests (``Authorization: Bearer …`` or ``X-Session-API-Key``)
+    get a permissive policy — ``Access-Control-Allow-Origin: *`` with
+    credentials disabled — so API-key clients such as the local
+    agent-server GUI can call the service directly from the browser.
+  * Cookie / anonymous requests keep the strict origin allowlist with
+    credentials enabled, exactly as before the middleware was introduced.
+
+Exercised from a browser's perspective with Starlette's TestClient: a
+preflight + a real request from a non-allowlisted origin must be accepted
+with an API key and rejected without one.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from openhands.automation.app import app
+from openhands.automation.middleware import ApiKeyAwareCORSMiddleware
+
+
+ALLOWED_ORIGIN = "https://app.all-hands.dev"
+FOREIGN_ORIGIN = "http://localhost:3001"
+
+
+def _build_client() -> TestClient:
+    """Build a throwaway app so the dispatch matrix is tested in isolation."""
+    test_app = FastAPI()
+
+    @test_app.get("/resource")
+    def resource():
+        return {"ok": True}
+
+    test_app.add_middleware(
+        ApiKeyAwareCORSMiddleware,
+        allow_origins=[ALLOWED_ORIGIN],
+    )
+    return TestClient(test_app)
+
+
+class TestApiKeyAwareCORSMiddleware:
+    """Dispatch-matrix tests for the middleware in isolation."""
+
+    @pytest.mark.parametrize(
+        "requested_headers",
+        ["authorization, x-org-id", "x-session-api-key"],
+    )
+    def test_api_key_preflight_from_foreign_origin_gets_wildcard(
+        self, requested_headers
+    ):
+        """Preflights advertising an API-key header get wildcard CORS."""
+        # Arrange
+        client = _build_client()
+
+        # Act
+        response = client.options(
+            "/resource",
+            headers={
+                "Origin": FOREIGN_ORIGIN,
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": requested_headers,
+            },
+        )
+
+        # Assert — wildcard origin, and credentials MUST be absent: browsers
+        # reject `*` combined with allow-credentials.
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == "*"
+        assert "access-control-allow-credentials" not in {
+            k.lower() for k in response.headers
+        }
+
+    @pytest.mark.parametrize(
+        "auth_headers",
+        [
+            {"Authorization": "Bearer test-api-key"},
+            {"X-Session-API-Key": "test-session-key"},
+        ],
+    )
+    def test_api_key_request_from_foreign_origin_gets_wildcard(self, auth_headers):
+        """Actual (non-preflight) requests carrying an API key get wildcard CORS."""
+        # Arrange
+        client = _build_client()
+
+        # Act
+        response = client.get(
+            "/resource",
+            headers={"Origin": FOREIGN_ORIGIN, **auth_headers},
+        )
+
+        # Assert
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == "*"
+        assert "access-control-allow-credentials" not in {
+            k.lower() for k in response.headers
+        }
+
+    def test_credentialless_preflight_from_foreign_origin_is_blocked(self):
+        """Preflights without API-key headers stay on the strict allowlist."""
+        # Arrange
+        client = _build_client()
+
+        # Act
+        response = client.options(
+            "/resource",
+            headers={
+                "Origin": FOREIGN_ORIGIN,
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "content-type",
+            },
+        )
+
+        # Assert — no allow-origin header means the browser will block.
+        assert response.headers.get("access-control-allow-origin") is None
+
+    def test_cookie_request_from_allowed_origin_preserves_strict_cors(self):
+        """The pre-existing cookie/session path is unchanged: the specific
+        origin is echoed (never wildcard) with credentials enabled."""
+        # Arrange
+        client = _build_client()
+
+        # Act
+        response = client.get("/resource", headers={"Origin": ALLOWED_ORIGIN})
+
+        # Assert
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == ALLOWED_ORIGIN
+        assert response.headers.get("access-control-allow-credentials") == "true"
+
+    def test_preflight_with_lookalike_header_does_not_match_authorization(self):
+        """Whole-header-name matching: ``x-my-authorization-token`` must not
+        be treated as an API-key request via substring match."""
+        # Arrange
+        client = _build_client()
+
+        # Act
+        response = client.options(
+            "/resource",
+            headers={
+                "Origin": FOREIGN_ORIGIN,
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "x-my-authorization-token",
+            },
+        )
+
+        # Assert
+        assert response.headers.get("access-control-allow-origin") is None
+
+
+class TestAppCORSIntegration:
+    """The real app must dispatch API-key CORS for the GUI's direct calls."""
+
+    def test_health_preflight_with_authorization_gets_wildcard(self):
+        """The preflight a browser sends before the GUI's automation health
+        check is answered with wildcard CORS by the real app."""
+        # Arrange
+        client = TestClient(app)
+
+        # Act
+        response = client.options(
+            "/api/automation/health",
+            headers={
+                "Origin": FOREIGN_ORIGIN,
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "authorization, x-org-id",
+            },
+        )
+
+        # Assert — the strict allowlist used to answer this with 400 and no
+        # allow-origin header, forcing the GUI through its local proxy hop.
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == "*"
+
+    def test_health_request_with_bearer_gets_wildcard(self):
+        """The bearer-authenticated health request itself carries wildcard
+        CORS through the real app's middleware stack."""
+        # Arrange
+        client = TestClient(app)
+
+        # Act
+        response = client.get(
+            "/api/automation/health",
+            headers={
+                "Origin": FOREIGN_ORIGIN,
+                "Authorization": "Bearer test-api-key",
+            },
+        )
+
+        # Assert
+        assert response.headers.get("access-control-allow-origin") == "*"


### PR DESCRIPTION
## Summary

Browser clients that authenticate with API keys can now call the automation API directly — cross-origin — without a server-side proxy hop. Cookie/session traffic is completely unaffected.

This unblocks the agent-server GUI's automations page, which currently tunnels every cloud call through the bundled agent-server's `POST /api/cloud-proxy` because this service rejects its CORS preflights.

## Problem

All cross-origin requests were answered by a single strict `CORSMiddleware` (allowlist from `AUTOMATION_CORS_ORIGINS`, fallback `openhands_api_base_url`, `allow_credentials=True`). The agent-server GUI on `http://localhost:3001` therefore failed preflight on `/api/automation/*`. The main cloud API solved the identical problem in OpenHands/OpenHands#14473; this service lagged behind, and the GUI singled it out with a `forceProxy` workaround.

## Changes

- **`openhands/automation/middleware.py` (new):** `ApiKeyAwareCORSMiddleware` — a CORS dispatcher wrapping two `CORSMiddleware` policies:
  - **Permissive** (`Access-Control-Allow-Origin: *`, credentials off) for requests authenticating via `Authorization: Bearer …` or `X-Session-API-Key`. Detected on preflights via whole-word matching of `Access-Control-Request-Headers` (so `x-my-authorization-token` cannot substring-match), and on actual requests via the headers themselves. The wildcard is safe because browsers cannot attach cookies when credentials are off.
  - **Strict** (existing allowlist via the unchanged `_build_cors_origins()`, credentials on) for cookie/anonymous traffic — identical to the previous behavior.
  - Deliberate differences from the OpenHands reference: no RFC 8628 device-flow path exemptions and no `X-Access-Token` detection (this service supports neither).
- **`openhands/automation/app.py`:** register `ApiKeyAwareCORSMiddleware` in place of the plain `CORSMiddleware`.

## Tests

New `tests/test_cors.py` (9 tests):
- **Middleware dispatch matrix** (isolated app): API-key preflights and actual requests from a foreign origin get wildcard CORS without credentials; credential-less preflights from a foreign origin are blocked; allowlisted-origin cookie traffic keeps strict CORS with credentials; lookalike-header regression guard.
- **Real-app integration:** `OPTIONS`/`GET /api/automation/health` with API-key headers from `http://localhost:3001` get `Access-Control-Allow-Origin: *` (previously the preflight was answered `400` with no allow-origin header).

Full suite: **782 passed**. `ruff` and `pyright` clean.