### PR TITLE
fix(frontend): render CANCELLED run status instead of crashing the detail page

### DIFF
--- a/frontend/src/__tests__/components/automations/detail/run-status-badge.test.tsx
+++ b/frontend/src/__tests__/components/automations/detail/run-status-badge.test.tsx
@@ -16,6 +16,13 @@ describe("RunStatusBadge", () => {
     expect(screen.getByText("AUTOMATIONS$DETAIL$FAILED")).toBeInTheDocument();
   });
 
+  it("renders cancelled label for cancelled status", () => {
+    render(<RunStatusBadge status={AutomationRunStatus.CANCELLED} />);
+    expect(
+      screen.getByText("AUTOMATIONS$DETAIL$CANCELLED"),
+    ).toBeInTheDocument();
+  });
+
   it("renders pending label for pending status", () => {
     render(<RunStatusBadge status={AutomationRunStatus.PENDING} />);
     expect(screen.getByText("AUTOMATIONS$DETAIL$PENDING")).toBeInTheDocument();

--- a/frontend/src/components/automations/detail/run-status-badge.tsx
+++ b/frontend/src/components/automations/detail/run-status-badge.tsx
@@ -22,6 +22,10 @@ const statusConfig: Record<
     label: I18nKey.AUTOMATIONS$DETAIL$FAILED,
     style: "border-status-fail-border bg-status-fail-bg text-status-fail-text",
   },
+  [AutomationRunStatus.CANCELLED]: {
+    label: I18nKey.AUTOMATIONS$DETAIL$CANCELLED,
+    style: "border-border bg-surface-elevated text-content-muted",
+  },
   [AutomationRunStatus.PENDING]: {
     label: I18nKey.AUTOMATIONS$DETAIL$PENDING,
     style: "border-border bg-surface-elevated text-content-muted",
@@ -41,6 +45,7 @@ function StatusIcon({ status }: { status: AutomationRunStatus }) {
     case AutomationRunStatus.COMPLETED:
       return <CheckCircleIcon className="size-3.5" />;
     case AutomationRunStatus.FAILED:
+    case AutomationRunStatus.CANCELLED:
       return <XCircleIcon className="size-3.5" />;
     default:
       return <ClockIcon className="size-3.5" />;

--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -339,6 +339,23 @@
     "tr": "Başarısız",
     "uk": "Невдало"
   },
+  "AUTOMATIONS$DETAIL$CANCELLED": {
+    "en": "Cancelled",
+    "ja": "キャンセル",
+    "zh-CN": "已取消",
+    "zh-TW": "已取消",
+    "ko-KR": "취소됨",
+    "no": "Avbrutt",
+    "ar": "أُلغيت",
+    "de": "Abgebrochen",
+    "fr": "Annulé",
+    "it": "Annullato",
+    "pt": "Cancelado",
+    "es": "Cancelado",
+    "ca": "Cancel·lat",
+    "tr": "İptal edildi",
+    "uk": "Скасовано"
+  },
   "AUTOMATIONS$DETAIL$PENDING": {
     "en": "Pending",
     "ja": "保留中",

--- a/frontend/src/types/automation.ts
+++ b/frontend/src/types/automation.ts
@@ -34,6 +34,7 @@ export enum AutomationRunStatus {
   RUNNING = "RUNNING",
   COMPLETED = "COMPLETED",
   FAILED = "FAILED",
+  CANCELLED = "CANCELLED",
   SKIPPED = "SKIPPED",
 }
 


### PR DESCRIPTION
## Summary

The automation **detail page crashes** with `Cannot read properties of undefined (reading 'style')` whenever an automation has a **cancelled** run. The automations *list* page works; only the detail view breaks.

<img width="730" height="458" alt="image" src="https://github.com/user-attachments/assets/3ca6cf11-95fb-4e29-b1c3-ad85723f4b87" />

## Root cause

The backend `AutomationRunStatus` enum includes `CANCELLED` (`openhands/automation/models.py`), but the frontend was out of sync:

- `frontend/src/types/automation.ts` — `AutomationRunStatus` was missing `CANCELLED`.
- `RunStatusBadge` — `statusConfig` had no `CANCELLED` entry.

So for a cancelled run, `RunStatusBadge` evaluates:

```ts
const config = statusConfig[status]; // statusConfig["CANCELLED"] -> undefined
// ...
className={`... ${config.style}`}    // undefined.style -> throws, gives error screen
```

Because `status` is cast from the API response without runtime validation, the exhaustive `Record<AutomationRunStatus, ...>` type couldn't catch this frontend/backend drift at compile time.

## Fix

- Add `CANCELLED` to the frontend `AutomationRunStatus` enum so it matches the backend.
- Add a `CANCELLED` badge config (neutral style) and icon (reuses the `x-circle` icon alongside `FAILED`).
- Add the `AUTOMATIONS$DETAIL$CANCELLED` i18n strings for all locales.
- Add a `RunStatusBadge` test for the cancelled status.

The generated `src/i18n/declaration.ts` (gitignored, produced by `make-i18n`) picks up the new key automatically during `prelint`/`build`.

## Testing

- `node scripts/make-i18n-translations.cjs` regenerates `declaration.ts` with `AUTOMATIONS$DETAIL$CANCELLED`.
- Added unit test renders `<RunStatusBadge status={AutomationRunStatus.CANCELLED} />` without throwing.
