### PR TITLE
fix(presets): fire completion callback on hard termination (SIGTERM/timeout)

### DIFF
--- a/.pr/live_test_termination.py
+++ b/.pr/live_test_termination.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Live integration test: demonstrates SIGTERM callback behavior before and after the fix.
+
+Simulates the automation service killing a long-running preset run:
+
+BEFORE (main branch behavior):
+  - No SIGTERM handlers installed
+  - SIGTERM kills the process with no callback fired
+  - Run would sit in RUNNING until watchdog (default: 10 min)
+
+AFTER (fix/graceful-termination-cleanup behavior):
+  - install_termination_handlers() wires SIGTERM → failure callback
+  - SIGTERM fires a FAILED completion callback before exit
+  - Run is marked FAILED immediately, cleanup can run promptly
+
+Usage:
+    python .pr/live_test_termination.py
+"""
+from __future__ import annotations
+
+import http.server
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import textwrap
+import threading
+import time
+from datetime import datetime, timezone
+
+# ── Captured-callback store ──────────────────────────────────────────────────
+
+_callbacks: list[dict] = []
+_lock = threading.Lock()
+
+
+class _CallbackHandler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length).decode()
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            payload = {"raw": body}
+        ts = datetime.now(timezone.utc).isoformat()
+        with _lock:
+            _callbacks.append({"received_at": ts, "payload": payload, "path": self.path})
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, *_):
+        pass  # suppress server log noise
+
+
+def _start_callback_server() -> int:
+    """Start a local HTTP server on a free port; return port number."""
+    server = http.server.HTTPServer(("127.0.0.1", 0), _CallbackHandler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    return port
+
+
+# ── Simulated preset script: BEFORE (no termination handlers) ───────────────
+
+BEFORE_SCRIPT = textwrap.dedent("""\
+    import os, sys, time
+
+    callback_url = os.environ["AUTOMATION_CALLBACK_URL"]
+    run_id = os.environ["AUTOMATION_RUN_ID"]
+
+    print("[before] started -- sleeping 60 s to simulate a long-running LLM task")
+    sys.stdout.flush()
+    # No install_termination_handlers() call.
+    # If SIGTERM arrives, the process dies silently -- no callback fired.
+    time.sleep(60)
+
+    # This line (and any cleanup) is never reached on hard termination.
+    print("[before] completed (never reached on SIGTERM)")
+""")
+
+# ── Simulated preset script: AFTER (with termination handlers) ──────────────
+
+# Copy _termination.py into the temp dir so the script can import it.
+TERMINATION_SRC = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "openhands",
+    "automation",
+    "presets",
+    "_termination.py",
+)
+
+AFTER_SCRIPT = textwrap.dedent("""\
+    import os, sys, time
+
+    callback_url = os.environ["AUTOMATION_CALLBACK_URL"]
+    run_id = os.environ["AUTOMATION_RUN_ID"]
+
+    # Wire up termination handlers -- this is the fix.
+    from _termination import install_termination_handlers, mark_completed
+    install_termination_handlers()
+
+    print("[after] started -- sleeping 60 s to simulate a long-running LLM task")
+    sys.stdout.flush()
+    time.sleep(60)
+
+    # Clean exit: record success so atexit hook does not fire spurious FAILED.
+    mark_completed()
+    print("[after] completed cleanly (never reached on SIGTERM)")
+""")
+
+
+# ── Run a script, send SIGTERM after `kill_after` seconds ───────────────────
+
+def run_with_sigterm(
+    label: str,
+    script: str,
+    callback_url: str,
+    run_id: str,
+    kill_after: float = 2.0,
+) -> dict:
+    """Spawn `script` in a subprocess, send SIGTERM after `kill_after`s."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Write the preset script
+        script_path = os.path.join(tmpdir, "sdk_main.py")
+        with open(script_path, "w") as f:
+            f.write(script)
+
+        # Copy _termination.py into tmpdir so the AFTER script can import it
+        term_dst = os.path.join(tmpdir, "_termination.py")
+        with open(TERMINATION_SRC) as src, open(term_dst, "w") as dst:
+            dst.write(src.read())
+
+        env = {
+            **os.environ,
+            "AUTOMATION_CALLBACK_URL": callback_url,
+            "AUTOMATION_RUN_ID": run_id,
+            "PYTHONPATH": tmpdir,
+        }
+
+        proc = subprocess.Popen(
+            [sys.executable, script_path],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        started_at = time.monotonic()
+        time.sleep(kill_after)
+        kill_at = time.monotonic()
+        print(f"  -> sending SIGTERM to {label} PID {proc.pid} "
+              f"after {round(kill_at - started_at, 2)}s")
+        proc.send_signal(signal.SIGTERM)
+
+        # Give the handler 3 s to fire and the process to exit
+        try:
+            proc.wait(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+        elapsed = time.monotonic() - started_at
+        stdout = proc.stdout.read().decode()
+        stderr = proc.stderr.read().decode()
+
+        return {
+            "label": label,
+            "returncode": proc.returncode,
+            "elapsed_s": round(elapsed, 2),
+            "stdout": stdout.strip(),
+            "stderr": stderr.strip(),
+            "sigterm_after_s": round(kill_at - started_at, 2),
+        }
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    print("=" * 72)
+    print("Live Termination Test -- BEFORE vs AFTER the fix")
+    print(f"Started: {datetime.now(timezone.utc).isoformat()}")
+    print("=" * 72)
+
+    port = _start_callback_server()
+    base_url = f"http://127.0.0.1:{port}"
+    print(f"\nCallback server listening on {base_url}\n")
+
+    results = []
+
+    # ── BEFORE ──────────────────────────────────────────────────────────────
+    print("-- BEFORE (main branch -- no termination handlers) --")
+    before_cb_count_before = len(_callbacks)
+    r_before = run_with_sigterm(
+        label="BEFORE",
+        script=BEFORE_SCRIPT,
+        callback_url=f"{base_url}/runs/before-run-id/complete",
+        run_id="before-run-id",
+        kill_after=2.0,
+    )
+    time.sleep(0.5)  # let callback arrive if somehow sent
+    before_cb_count_after = len(_callbacks)
+    callbacks_fired_before = before_cb_count_after - before_cb_count_before
+    results.append({**r_before, "callbacks_fired": callbacks_fired_before})
+
+    print(f"  returncode : {r_before['returncode']}")
+    print(f"  stdout     : {r_before['stdout'] or '(empty)'}")
+    print(f"  stderr     : {r_before['stderr'] or '(empty)'}")
+    print(f"  callbacks  : {callbacks_fired_before}  <- expected 0 (run stuck in RUNNING)")
+    print()
+
+    # ── AFTER ───────────────────────────────────────────────────────────────
+    print("-- AFTER (fix branch -- install_termination_handlers() wired) --")
+    after_cb_count_before = len(_callbacks)
+    r_after = run_with_sigterm(
+        label="AFTER",
+        script=AFTER_SCRIPT,
+        callback_url=f"{base_url}/runs/after-run-id/complete",
+        run_id="after-run-id",
+        kill_after=2.0,
+    )
+    time.sleep(0.5)  # let callback arrive
+    after_cb_count_after = len(_callbacks)
+    callbacks_fired_after = after_cb_count_after - after_cb_count_before
+    results.append({**r_after, "callbacks_fired": callbacks_fired_after})
+
+    print(f"  returncode : {r_after['returncode']}")
+    print(f"  stdout     : {r_after['stdout'] or '(empty)'}")
+    print(f"  stderr     : {r_after['stderr'] or '(empty)'}")
+    print(f"  callbacks  : {callbacks_fired_after}  <- expected 1 (FAILED callback fired promptly)")
+    print()
+
+    # ── Summary ─────────────────────────────────────────────────────────────
+    print("=" * 72)
+    print("SUMMARY")
+    print("=" * 72)
+    for r in results:
+        status = "PASS" if (
+            (r["label"] == "BEFORE" and r["callbacks_fired"] == 0) or
+            (r["label"] == "AFTER" and r["callbacks_fired"] >= 1)
+        ) else "FAIL"
+        print(f"  {r['label']:8s}  callbacks_fired={r['callbacks_fired']}  "
+              f"exit={r['returncode']}  [{status}]")
+
+    print()
+    print("Callback payloads received:")
+    with _lock:
+        for i, cb in enumerate(_callbacks, 1):
+            print(f"  [{i}] {cb['received_at']}  {cb['path']}")
+            print(f"       payload: {json.dumps(cb['payload'])}")
+
+    # Emit machine-readable JSON for PR evidence capture
+    evidence = {
+        "test_time": datetime.now(timezone.utc).isoformat(),
+        "results": results,
+        "callbacks": list(_callbacks),
+    }
+    evidence_path = os.path.join(os.path.dirname(__file__), "termination_evidence.json")
+    with open(evidence_path, "w") as f:
+        json.dump(evidence, f, indent=2)
+    print(f"\nEvidence written to: {evidence_path}")
+
+    # Exit non-zero if expectations not met
+    ok = (
+        results[0]["callbacks_fired"] == 0
+        and results[1]["callbacks_fired"] >= 1
+    )
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.pr/termination_evidence.json
+++ b/.pr/termination_evidence.json
@@ -1,0 +1,34 @@
+{
+  "test_time": "2026-06-23T11:19:18.076020+00:00",
+  "results": [
+    {
+      "label": "BEFORE",
+      "returncode": -15,
+      "elapsed_s": 2.0,
+      "stdout": "[before] started -- sleeping 60 s to simulate a long-running LLM task",
+      "stderr": "",
+      "sigterm_after_s": 2.0,
+      "callbacks_fired": 0
+    },
+    {
+      "label": "AFTER",
+      "returncode": 143,
+      "elapsed_s": 2.03,
+      "stdout": "[after] started -- sleeping 60 s to simulate a long-running LLM task",
+      "stderr": "[termination] received SIGTERM, firing failure callback",
+      "sigterm_after_s": 2.0,
+      "callbacks_fired": 1
+    }
+  ],
+  "callbacks": [
+    {
+      "received_at": "2026-06-23T11:19:17.554184+00:00",
+      "payload": {
+        "status": "FAILED",
+        "run_id": "after-run-id",
+        "error": "Automation run terminated before completing: received SIGTERM"
+      },
+      "path": "/runs/after-run-id/complete"
+    }
+  ]
+}

--- a/openhands/automation/preset_router.py
+++ b/openhands/automation/preset_router.py
@@ -76,6 +76,9 @@ def _load_prompt_preset_files() -> dict[str, str]:
         _PROMPT_PRESET_CACHE = {
             "main.py": (PROMPT_PRESET_DIR / "sdk_main.py").read_text(),
             "setup.sh": (PROMPT_PRESET_DIR / "setup.sh").read_text(),
+            # Shared stdlib-only helper shipped alongside main.py so it can be
+            # imported as ``from _termination import ...`` inside the sandbox.
+            "_termination.py": (PRESETS_DIR / "_termination.py").read_text(),
         }
     return _PROMPT_PRESET_CACHE
 
@@ -90,6 +93,7 @@ def _load_plugin_preset_files() -> dict[str, str]:
         _PLUGIN_PRESET_CACHE = {
             "main.py": (PLUGIN_PRESET_DIR / "sdk_main.py").read_text(),
             "setup.sh": (PLUGIN_PRESET_DIR / "setup.sh").read_text(),
+            "_termination.py": (PRESETS_DIR / "_termination.py").read_text(),
         }
     return _PLUGIN_PRESET_CACHE
 
@@ -194,6 +198,7 @@ def _generate_tarball(prompt: str, repos: list[RepoSource] | None = None) -> byt
 
     with tarfile.open(fileobj=tarball_buffer, mode="w:gz") as tar:
         _add_file_to_tar(tar, "main.py", preset_files["main.py"])
+        _add_file_to_tar(tar, "_termination.py", preset_files["_termination.py"])
         _add_file_to_tar(tar, "prompt.txt", prompt)
         _add_file_to_tar(tar, "setup.sh", preset_files["setup.sh"], mode=0o755)
 
@@ -653,6 +658,7 @@ def _generate_plugin_tarball(
 
     with tarfile.open(fileobj=tarball_buffer, mode="w:gz") as tar:
         _add_file_to_tar(tar, "main.py", preset_files["main.py"])
+        _add_file_to_tar(tar, "_termination.py", preset_files["_termination.py"])
         _add_file_to_tar(tar, "prompt.txt", prompt)
         _add_file_to_tar(tar, "setup.sh", preset_files["setup.sh"], mode=0o755)
 

--- a/openhands/automation/presets/_termination.py
+++ b/openhands/automation/presets/_termination.py
@@ -1,0 +1,149 @@
+"""Best-effort cleanup on automation-run termination.
+
+Preset ``sdk_main.py`` scripts run inside a single bash command that the
+automation service kills after ``max_run_duration`` (default 600s). When that
+happens the process receives ``SIGTERM`` and Python's ``finally`` blocks /
+``atexit`` handlers / context-manager ``__exit__`` methods are *not* guaranteed
+to run, so the completion callback (normally sent by the workspace context
+manager) is never delivered and the run is left for the watchdog to mark
+``FAILED``.
+
+This module registers a ``SIGTERM``/``SIGINT`` handler and an ``atexit`` hook
+that fire a *failure* completion callback (``AUTOMATION_CALLBACK_URL``) before
+the process is torn down. This is best-effort:
+
+- ``SIGTERM`` (the signal the bash service sends on timeout) gives the handler
+  a short window to run before the process exits.
+- ``SIGKILL`` / OOM / abrupt host termination cannot be caught; for those the
+  watchdog remains the source of truth (it marks the run ``FAILED`` and cleans
+  up the sandbox).
+
+The module is stdlib-only so it can be imported and unit-tested without the
+OpenHands SDK, and so it can be packaged into both the prompt and plugin
+preset tarballs.
+
+Usage (in ``sdk_main.py``, after env vars are read)::
+
+    from _termination import install_termination_handlers
+    install_termination_handlers(callback_url=os.environ.get("AUTOMATION_CALLBACK_URL"))
+
+The handler is idempotent: firing the callback more than once (e.g. once from
+the signal handler and again from normal ``__exit__``) is harmless because the
+automation service only honors the first terminal status transition per run.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+import signal
+import sys
+import urllib.error
+import urllib.request
+
+# How long (seconds) the signal handler may spend trying to deliver the
+# callback before letting the process exit. Kept short so we don't delay
+# teardown, and bounded so a dead callback endpoint can't hang the handler.
+_CALLBACK_TIMEOUT_SECONDS = 5.0
+
+_STATE = {
+    "installed": False,
+    "fired": False,
+    "callback_url": "",
+    "callback_api_key": "",
+    "run_id": "",
+}
+
+
+def _send_failure_callback(reason: str) -> None:
+    """POST a FAILED completion callback. Idempotent and non-raising."""
+    if _STATE["fired"]:
+        return
+    url = _STATE["callback_url"]
+    if not url:
+        return
+    _STATE["fired"] = True
+    body = {
+        "status": "FAILED",
+        "run_id": _STATE["run_id"],
+        "error": f"Automation run terminated before completing: {reason}",
+    }
+    headers = {"Content-Type": "application/json"}
+    api_key = _STATE["callback_api_key"]
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        req = urllib.request.Request(
+            url, data=json.dumps(body).encode(), headers=headers
+        )
+        urllib.request.urlopen(req, timeout=_CALLBACK_TIMEOUT_SECONDS)
+    except (urllib.error.URLError, OSError, TimeoutError) as exc:
+        # Best-effort: if the callback can't be delivered, the watchdog will
+        # still mark the run FAILED. Never raise from a signal/atexit handler.
+        print(f"[termination] callback failed (non-fatal): {exc}", file=sys.stderr)
+
+
+def _signal_handler(signum: int, _frame) -> None:
+    """Handle SIGTERM/SIGINT by firing the failure callback, then re-raise."""
+    name = signal.Signals(signum).name
+    print(f"[termination] received {name}, firing failure callback", file=sys.stderr)
+    _send_failure_callback(reason=f"received {name}")
+    # Restore default behavior and re-deliver so the process actually exits.
+    signal.signal(signum, signal.SIG_DFL)
+    raise SystemExit(128 + signum)
+
+
+def install_termination_handlers(
+    callback_url: str | None = None,
+    callback_api_key: str | None = None,
+    run_id: str | None = None,
+) -> None:
+    """Register SIGTERM/SIGINT + atexit handlers that fire a failure callback.
+
+    Safe to call once per process; subsequent calls are no-ops. Reads env vars
+    (``AUTOMATION_CALLBACK_URL``, ``AUTOMATION_CALLBACK_API_KEY``,
+    ``AUTOMATION_RUN_ID``) when arguments are omitted, so the typical call from
+    ``sdk_main.py`` is ``install_termination_handlers()`` with no arguments.
+
+    ``callback_url`` may be empty/None — in that case the handlers are still
+    installed (so at least a log line is emitted on termination) but no HTTP
+    callback is attempted.
+    """
+    if _STATE["installed"]:
+        return
+    _STATE["installed"] = True
+    _STATE["callback_url"] = callback_url or os.environ.get(
+        "AUTOMATION_CALLBACK_URL", ""
+    )
+    _STATE["callback_api_key"] = callback_api_key or os.environ.get(
+        "AUTOMATION_CALLBACK_API_KEY", ""
+    )
+    _STATE["run_id"] = run_id or os.environ.get("AUTOMATION_RUN_ID", "")
+
+    # atexit runs on normal interpreter shutdown (including SystemExit raised
+    # from the signal handler), giving us a second chance if the signal path
+    # didn't fire. It will *not* fire on SIGKILL.
+    def _atexit_cb() -> None:
+        _send_failure_callback(reason="interpreter shutdown")
+
+    _STATE["_atexit_cb"] = _atexit_cb
+    atexit.register(_atexit_cb)
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        # signal.signal can only be called from the main thread; preset
+        # scripts always run in the main thread.
+        try:
+            signal.signal(sig, _signal_handler)
+        except (ValueError, OSError):
+            # Not in main thread or signal unsupported — skip silently.
+            pass
+
+
+def mark_completed() -> None:
+    """Record that the run completed successfully.
+
+    Call this at the very end of ``sdk_main.py`` (after ``ALL_OK`` is printed)
+    so that the atexit hook knows *not* to send a spurious FAILED callback
+    during normal shutdown.
+    """
+    _STATE["fired"] = True

--- a/openhands/automation/presets/plugin/sdk_main.py
+++ b/openhands/automation/presets/plugin/sdk_main.py
@@ -127,6 +127,15 @@ print(f"  AUTOMATION_USER_ID: {'OK' if automation_user_id else 'NONE'}")
 print(f"  AUTOMATION_ORG_ID: {'OK' if os.environ.get('AUTOMATION_ORG_ID') else 'NONE'}")
 print(f"  AUTOMATION_RUN_ID: {os.environ.get('AUTOMATION_RUN_ID') or 'NONE'}")
 
+# Install SIGTERM/SIGINT + atexit handlers that fire a FAILED completion
+# callback if the run is terminated (e.g. the service kills the bash command
+# on the 600s max_run_duration ceiling). Without this, a hard SIGTERM skips
+# the workspace context manager's __exit__ callback entirely and the run is
+# left for the watchdog. See presets/_termination.py for details.
+from _termination import install_termination_handlers, mark_completed
+
+install_termination_handlers()
+
 # SDK imports (before workspace context so import errors are caught)
 from openhands.sdk import Conversation, RemoteConversation
 from openhands.sdk.plugin import PluginSource
@@ -427,3 +436,7 @@ This automation was triggered by a webhook event:
 
     print("\n=== RESULT ===")
     print("ALL_OK")
+
+# Record that we reached a clean exit so the atexit hook does not emit a
+# spurious FAILED callback during normal interpreter shutdown.
+mark_completed()

--- a/openhands/automation/presets/prompt/sdk_main.py
+++ b/openhands/automation/presets/prompt/sdk_main.py
@@ -131,6 +131,15 @@ print(f"  AUTOMATION_ORG_ID: {'OK' if os.environ.get('AUTOMATION_ORG_ID') else '
 
 print(f"  AUTOMATION_RUN_ID: {os.environ.get('AUTOMATION_RUN_ID') or 'NONE'}")
 
+# Install SIGTERM/SIGINT + atexit handlers that fire a FAILED completion
+# callback if the run is terminated (e.g. the service kills the bash command
+# on the 600s max_run_duration ceiling). Without this, a hard SIGTERM skips
+# the workspace context manager's __exit__ callback entirely and the run is
+# left for the watchdog. See presets/_termination.py for details.
+from _termination import install_termination_handlers, mark_completed
+
+install_termination_handlers()
+
 # SDK imports (before workspace context so import errors are caught)
 from openhands.sdk import Conversation, RemoteConversation
 from openhands.sdk.workspace.remote.base import RemoteWorkspace
@@ -376,3 +385,7 @@ This automation was triggered by a webhook event:
 
     print("\n=== RESULT ===")
     print("ALL_OK")
+
+# Record that we reached a clean exit so the atexit hook does not emit a
+# spurious FAILED callback during normal interpreter shutdown.
+mark_completed()

--- a/tests/test_preset_termination.py
+++ b/tests/test_preset_termination.py
@@ -1,0 +1,200 @@
+"""Tests for graceful-termination cleanup in preset automations.
+
+Covers:
+- ``_termination.py`` ships in both prompt and plugin preset tarballs.
+- ``_termination.py`` is valid Python and stdlib-only (importable standalone).
+- The termination handlers fire a FAILED completion callback on SIGTERM, are
+  idempotent, and stay quiet (no spurious FAILED) on a clean exit.
+"""
+
+import importlib.util
+import io
+import json
+import signal
+import tarfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from openhands.automation.preset_router import (
+    _generate_plugin_tarball,
+    _generate_tarball,
+)
+from openhands.sdk.plugin import PluginSource
+
+
+PRESETS_DIR = Path(__file__).parent.parent / "openhands" / "automation" / "presets"
+TERMINATION_PATH = PRESETS_DIR / "_termination.py"
+PROMPT_SDK_MAIN = PRESETS_DIR / "prompt" / "sdk_main.py"
+PLUGIN_SDK_MAIN = PRESETS_DIR / "plugin" / "sdk_main.py"
+
+
+def _load_termination_module():
+    """Load _termination.py as an isolated module (no package context needed)."""
+    spec = importlib.util.spec_from_file_location(
+        "preset_termination_under_test", TERMINATION_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestTerminationFile:
+    def test_termination_file_exists(self):
+        assert TERMINATION_PATH.exists(), f"Not found: {TERMINATION_PATH}"
+
+    def test_termination_file_valid_syntax(self):
+        compile(TERMINATION_PATH.read_text(), str(TERMINATION_PATH), "exec")
+
+    def test_termination_file_is_stdlib_only(self):
+        """The helper must not import the OpenHands SDK so it loads in any env."""
+        source = TERMINATION_PATH.read_text()
+        # Disallow openhands imports anywhere in the module body.
+        assert "import openhands" not in source
+        assert "from openhands" not in source
+
+
+class TestTerminationTarballInclusion:
+    def test_prompt_tarball_includes_termination(self):
+        tarball_bytes = _generate_tarball("do something")
+        with tarfile.open(fileobj=io.BytesIO(tarball_bytes), mode="r:gz") as tar:
+            names = tar.getnames()
+            assert "_termination.py" in names
+            # And it is the same content as the source file.
+            extracted = tar.extractfile("_termination.py")
+            assert extracted is not None
+            assert extracted.read().decode() == TERMINATION_PATH.read_text()
+
+    def test_plugin_tarball_includes_termination(self):
+        tarball_bytes = _generate_plugin_tarball(
+            [PluginSource(source="github:owner/repo")], "do something"
+        )
+        with tarfile.open(fileobj=io.BytesIO(tarball_bytes), mode="r:gz") as tar:
+            names = tar.getnames()
+            assert "_termination.py" in names
+
+    def test_prompt_sdk_main_installs_handlers_and_marks_completed(self):
+        source = PROMPT_SDK_MAIN.read_text()
+        assert "from _termination import install_termination_handlers" in source
+        assert "install_termination_handlers()" in source
+        assert "mark_completed()" in source
+
+    def test_plugin_sdk_main_installs_handlers_and_marks_completed(self):
+        source = PLUGIN_SDK_MAIN.read_text()
+        assert "from _termination import install_termination_handlers" in source
+        assert "install_termination_handlers()" in source
+        assert "mark_completed()" in source
+
+
+class TestTerminationBehavior:
+    """Behavioral tests for the stdlib termination helper."""
+
+    def _fresh_module(self):
+        """Load a freshly isolated copy of the module so _STATE is pristine."""
+        mod = _load_termination_module()
+        mod._STATE.update(
+            installed=False,
+            fired=False,
+            callback_url="",
+            callback_api_key="",
+            run_id="",
+        )
+        return mod
+
+    def _unregister_atexit(self, mod):
+        """Remove any atexit handler our install registered for this module."""
+        cb = mod._STATE.get("_atexit_cb")
+        if cb is not None:
+            try:
+                mod.atexit.unregister(cb)
+            except (AttributeError, ValueError):
+                pass
+
+    def test_install_is_idempotent(self):
+        mod = self._fresh_module()
+        register_calls = 0
+        real_register = mod.atexit.register
+
+        def counting_register(func, *args, **kwargs):
+            nonlocal register_calls
+            register_calls += 1
+            return real_register(func, *args, **kwargs)
+
+        with patch.object(mod.atexit, "register", side_effect=counting_register):
+            mod.install_termination_handlers(
+                callback_url="http://example.invalid/cb", run_id="r1"
+            )
+            first_count = register_calls
+            # Second call must be a no-op (no duplicate atexit registration).
+            mod.install_termination_handlers()
+            assert register_calls == first_count
+        self._unregister_atexit(mod)
+
+    def test_clean_exit_does_not_fire_failure_callback(self):
+        mod = self._fresh_module()
+        mod.install_termination_handlers(callback_url="http://example.invalid/cb")
+        with patch.object(mod.urllib.request, "urlopen") as mock_open:
+            mod.mark_completed()
+            # Simulate normal interpreter shutdown.
+            mod._send_failure_callback(reason="interpreter shutdown")
+            assert mock_open.call_count == 0, (
+                "no FAILED callback should fire after a clean exit"
+            )
+        self._unregister_atexit(mod)
+
+    def test_sigterm_fires_failure_callback_once(self):
+        mod = self._fresh_module()
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured["body"] = json.loads(req.data.decode())
+            captured["auth"] = req.headers.get("Authorization")
+            captured["url"] = req.full_url
+
+            class _Resp:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *a):
+                    return False
+
+                def read(self):
+                    return b"{}"
+
+            return _Resp()
+
+        mod.install_termination_handlers(
+            callback_url="http://example.invalid/cb",
+            callback_api_key="tok",
+            run_id="r1",
+        )
+        with patch.object(
+            mod.urllib.request, "urlopen", side_effect=fake_urlopen
+        ) as mock_open:
+            # The signal handler re-raises SystemExit to terminate the process;
+            # catch it so the test can assert on the callback.
+            with pytest.raises(SystemExit) as exc_info:
+                mod._signal_handler(signal.SIGTERM, None)
+            assert exc_info.value.code == 128 + signal.SIGTERM
+            # And atexit firing during shutdown must be a no-op (already fired).
+            mod._send_failure_callback(reason="interpreter shutdown")
+
+        assert captured["body"]["status"] == "FAILED"
+        assert captured["body"]["run_id"] == "r1"
+        assert "terminated before completing" in captured["body"]["error"]
+        assert captured["auth"] == "Bearer tok"
+        # Idempotent: urlopen only called once despite signal + atexit.
+        assert mock_open.call_count == 1
+        self._unregister_atexit(mod)
+
+    def test_missing_callback_url_does_not_raise(self):
+        mod = self._fresh_module()
+        mod.install_termination_handlers(callback_url="")
+        with patch.object(mod.urllib.request, "urlopen") as mock_open:
+            # No callback URL -> handler must be a no-op, not raise.
+            with pytest.raises(SystemExit):
+                mod._signal_handler(signal.SIGTERM, None)
+            assert mock_open.call_count == 0
+        self._unregister_atexit(mod)


### PR DESCRIPTION
## Summary

Closes OpenHands/OpenHands#203. Related: OpenHands/software-agent-sdk#4260.

When the automation service kills a preset run's bash command at the `max_run_duration` ceiling (default 600s) — or on OOM — the process receives `SIGTERM` and the workspace context manager's `__exit__` completion callback never runs. The run then sits in `RUNNING` until the watchdog marks it `FAILED`, and **no agent/automation cleanup executes** (e.g. the PR reviewer never updates its `🔍 Review in progress…` comment). Today the preset scripts have no `signal`/`atexit`/`trap` handler for the hard-termination path; only graceful exits (Python exceptions / success) trigger cleanup.

This PR adds a stdlib-only termination helper (`presets/_termination.py`) shipped inside both the prompt and plugin preset tarballs, and wires it into both `sdk_main.py` files:

- Installs `SIGTERM`/`SIGINT` handlers + an `atexit` hook that fire a `FAILED` completion callback (`AUTOMATION_CALLBACK_URL`) **before** the process exits.
- The signal handler restores the default disposition and re-raises `SystemExit(128+signum)` so the process still terminates promptly (it does not swallow the kill).
- **Idempotent**: the callback fires at most once per run (`mark_completed()` guards against a spurious `FAILED` on clean shutdown; the service only honors the first terminal transition anyway).
- **Best-effort by design**: `SIGKILL`/OOM/abrupt host termination cannot be caught; for those the watchdog remains the source of truth. This is defense-in-depth on top of the watchdog, not a replacement for it.

This makes the completion-callback path reliable for the common `SIGTERM`-on-timeout case seen in Datadog, so downstream cleanup (including a future service-side orphaned-comment cleanup keyed off the callback) can actually trigger promptly instead of waiting for the watchdog.

This does **not** fix the root 600s ceiling itself (tracked in OpenHands/software-agent-sdk#4260: raise/cache the budget, bound the empty-LLM-response loop). It makes the *termination* graceful.

## Changes

- `openhands/automation/presets/_termination.py` (new) — stdlib-only termination helper (`install_termination_handlers`, `mark_completed`).
- `openhands/automation/presets/prompt/sdk_main.py` — call `install_termination_handlers()` after env vars are read; `mark_completed()` at the clean-exit tail.
- `openhands/automation/presets/plugin/sdk_main.py` — same wiring.
- `openhands/automation/preset_router.py` — load and include `_termination.py` in both prompt and plugin tarballs.
- `tests/test_preset_termination.py` (new) — 11 tests: tarball inclusion, stdlib-only, valid syntax, idempotent install, `SIGTERM` fires `FAILED` exactly once, clean exit stays quiet, missing-callback-URL is a no-op.

## Test plan

- [x] `uv run pytest tests/test_preset_termination.py` → 11 passed
- [x] `uv run pytest tests/test_preset_router.py tests/test_preset_termination.py` → 69 passed, 26 skipped (no regressions)
- [x] `uv run ruff check openhands/automation/preset_router.py tests/test_preset_termination.py` → clean (presets are excluded from ruff per `pyproject.toml`; the existing `compile()` syntax tests still cover them)
- [x] All three preset files `compile()` cleanly
- [x] Live simulation: SIGTERM on `main`-branch script fires 0 callbacks; SIGTERM on this-PR script fires 1 `FAILED` callback immediately (see **Live Testing Evidence** below).

The remaining `ERROR`s in the full suite (`test_auth`, `test_watchdog`, DB tests) are pre-existing testcontainers/Docker-socket setup failures in this environment, unrelated to this change.

## Live Testing Evidence

A controlled simulation was run (2026-06-23T11:19 UTC) to demonstrate the concrete before/after behavior. Setup:

- A local HTTP server captured any completion callbacks posted to `AUTOMATION_CALLBACK_URL`.
- Two simulated preset scripts were each sent `SIGTERM` after 2 seconds, modeling the automation service killing a run that exceeds `max_run_duration`.
- **BEFORE script** mirrors `main`: a long-running `time.sleep(60)` with no termination handlers.
- **AFTER script** mirrors this PR: same `time.sleep(60)` but `install_termination_handlers()` called at startup.

### Results

| Scenario | SIGTERM exit code | Callbacks fired | Run state |
|---|---|---|---|
| **`main` branch** (no handlers) | `-15` (killed by signal) | **0 — none** | Stuck in `RUNNING` until watchdog (~10 min) |
| **This PR** (`install_termination_handlers()`) | `143` (128 + SIGTERM=15) | **1 — `FAILED` immediately** | Marked `FAILED` within 30 ms of signal |

### BEFORE — main branch (no termination handlers)

```
-- BEFORE (main branch -- no termination handlers) --
  -> sending SIGTERM to BEFORE PID 625 after 2.0s
  returncode : -15
  stdout     : [before] started -- sleeping 60 s to simulate a long-running LLM task
  stderr     : (empty)
  callbacks  : 0  <- run stuck in RUNNING, no callback fired
```

**Consequence:** the run remains in `RUNNING`. No cleanup executes. The watchdog eventually marks it `FAILED` — but only after the staleness window elapses (default ~10 min), long after the process is already dead.

### AFTER — this PR (install_termination_handlers wired)

```
-- AFTER (fix branch -- install_termination_handlers() wired) --
  -> sending SIGTERM to AFTER PID 631 after 2.0s
  returncode : 143
  stdout     : [after] started -- sleeping 60 s to simulate a long-running LLM task
  stderr     : [termination] received SIGTERM, firing failure callback
  callbacks  : 1  <- FAILED callback fired promptly
```

**Callback payload received at `2026-06-23T11:19:17.554184+00:00`:**

```json
{
  "status": "FAILED",
  "run_id": "after-run-id",
  "error": "Automation run terminated before completing: received SIGTERM"
}
```

The process exited with code 143 (POSIX convention: 128 + signal 15), confirming it terminated promptly and did not hang.

**Consequence:** the run is marked `FAILED` immediately. Any downstream cleanup (orphaned-comment cleanup, future `on_failed` hooks) fires within seconds of the timeout, not minutes.

### Test script

The simulation script (`.pr/live_test_termination.py`) and raw evidence JSON (`.pr/termination_evidence.json`) are committed on this branch. Run `python .pr/live_test_termination.py` to reproduce.

---

_Note: This PR was created by an AI agent (OpenHands) on behalf of the user investigating failing automation runs._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f63ab9d5-2c50-442f-96e0-bc5635147268)
