### PR TITLE
fix(presets): tell agent the event payload is inline, not an env var

### DIFF
--- a/openhands/automation/presets/plugin/sdk_main.py
+++ b/openhands/automation/presets/plugin/sdk_main.py
@@ -272,7 +272,10 @@ with workspace_ctx as workspace:
         event_json = json.dumps(event_context["event"], indent=2)
         context_sections.append(f"""## Event Payload
 
-This automation was triggered by a webhook event:
+This automation was triggered by a webhook event. The full event payload is
+included below — use it directly. Do **not** try to read it from a shell
+environment variable (e.g. `$AUTOMATION_EVENT_PAYLOAD`); that variable is not
+set in your environment.
 
 ```json
 {event_json}

--- a/openhands/automation/presets/plugin/sdk_main.py
+++ b/openhands/automation/presets/plugin/sdk_main.py
@@ -273,9 +273,7 @@ with workspace_ctx as workspace:
         context_sections.append(f"""## Event Payload
 
 This automation was triggered by a webhook event. The full event payload is
-included below — use it directly. Do **not** try to read it from a shell
-environment variable (e.g. `$AUTOMATION_EVENT_PAYLOAD`); that variable is not
-set in your environment.
+included below.
 
 ```json
 {event_json}

--- a/openhands/automation/presets/prompt/sdk_main.py
+++ b/openhands/automation/presets/prompt/sdk_main.py
@@ -251,7 +251,10 @@ with workspace_ctx as workspace:
         event_json = json.dumps(event_context["event"], indent=2)
         context_sections.append(f"""## Event Payload
 
-This automation was triggered by a webhook event:
+This automation was triggered by a webhook event. The full event payload is
+included below — use it directly. Do **not** try to read it from a shell
+environment variable (e.g. `$AUTOMATION_EVENT_PAYLOAD`); that variable is not
+set in your environment.
 
 ```json
 {event_json}


### PR DESCRIPTION
HUMAN:
My agent discovered in these logs that $AUTOMATION_EVENT_PAYLOAD was not set in the agent's env. Reference: [Slack response](https://openhands-ai.slack.com/archives/C0B4Z32L064/p1782164327942539?thread_ts=1782150713.328569&cid=C0B4Z32L064)

It seems that:
- the env var is not set
- the contents is sent in the prompt
- but the agent is told that the env var is set, so it tries to read it.

This PR proposes to adapt the prompt to stop telling the agent that it exists when it doesn't.

Do we want to set this in env instead, so the agent knows the right thing? (can we? it should be… bash tool’s env)

I'm not sure though! If this PR/issue doesn't smell right, we can just close it.

---

AGENT:

The Event Payload prompt block previously just embedded the webhook JSON. Agents (especially weaker models) tried to read $AUTOMATION_EVENT_PAYLOAD from their bash tool, where it is not set (it's only exported into the entrypoint process), got an empty value, and hit a JSON parse error — burning turns recovering instead of using the payload already in the prompt.

Make the block explicit: the JSON is provided inline; do not look for a shell env var.

Refs #202