### PR TITLE
Fix automation timeout budget handling

### DIFF
--- a/openhands/automation/backends/base.py
+++ b/openhands/automation/backends/base.py
@@ -44,7 +44,8 @@ class ExecutionBackend(ABC):
 
     @abstractmethod
     async def get_execution_context(
-        self, client: httpx.AsyncClient
+        self,
+        client: httpx.AsyncClient,
     ) -> ExecutionContext:
         """Get the execution context (agent server URL + credentials).
 

--- a/openhands/automation/backends/cloud.py
+++ b/openhands/automation/backends/cloud.py
@@ -157,12 +157,16 @@ class CloudSandboxBackend(ExecutionBackend):
             raise
 
     async def get_execution_context(
-        self, client: httpx.AsyncClient
+        self,
+        client: httpx.AsyncClient,
     ) -> ExecutionContext:
         """Create a sandbox and wait for it to be ready."""
 
         async def _do_acquire() -> tuple[str, str, str]:
-            return await self._create_and_wait(client, await self._ensure_api_key())
+            return await self._create_and_wait(
+                client,
+                await self._ensure_api_key(),
+            )
 
         sandbox_id, session_key, agent_url = await self._with_auth_retry(_do_acquire)
 
@@ -252,7 +256,10 @@ class CloudSandboxBackend(ExecutionBackend):
             ready_timeout = self._ready_timeout
 
         headers = {"Authorization": f"Bearer {api_key}"}
-        sandbox_id = await self._create_sandbox(client, headers)
+        sandbox_id = await self._create_sandbox(
+            client,
+            headers,
+        )
 
         elapsed = 0.0
         while elapsed < ready_timeout:
@@ -282,14 +289,17 @@ class CloudSandboxBackend(ExecutionBackend):
         raise TimeoutError(f"Sandbox {sandbox_id} not ready after {ready_timeout}s")
 
     async def _create_sandbox(
-        self, client: httpx.AsyncClient, headers: dict[str, str]
+        self,
+        client: httpx.AsyncClient,
+        headers: dict[str, str],
     ) -> str:
         """Create a sandbox and return its ID."""
 
         @self._retry
         async def _do_create():
             resp = await client.post(
-                f"{self.api_url}/api/v1/sandboxes", headers=headers
+                f"{self.api_url}/api/v1/sandboxes",
+                headers=headers,
             )
             # A concurrency-limit 429 is not transient: retrying won't free a
             # slot. Raise a non-HTTPStatusError so the retry predicate skips it

--- a/openhands/automation/config.py
+++ b/openhands/automation/config.py
@@ -48,7 +48,7 @@ from functools import cached_property, lru_cache
 from typing import Literal
 from urllib.parse import urlparse
 
-from pydantic import model_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings
 
 
@@ -202,7 +202,9 @@ class SandboxSettings(BaseSettings):
     """Sandbox execution configuration.
 
     Environment variables (AUTOMATION_ prefix):
-        AUTOMATION_MAX_RUN_DURATION: Max run time in seconds (default: 600)
+        AUTOMATION_MAX_RUN_DURATION: Logical max run time in seconds (default: 1800)
+        AUTOMATION_BASH_TIMEOUT_GRACE_PERIOD: Extra seconds added to the logical
+            run timeout for the agent-server bash command timeout (default: 60)
         AUTOMATION_SANDBOX_POLL_INTERVAL: Status check interval (default: 5)
         AUTOMATION_SANDBOX_READY_TIMEOUT: Max wait for ready (default: 300)
         AUTOMATION_EXTERNAL_DOWNLOAD_TIMEOUT: Download timeout (default: 120)
@@ -212,7 +214,8 @@ class SandboxSettings(BaseSettings):
         AUTOMATION_RATE_LIMIT_MAX_RETRIES: Max retries (default: 5)
     """
 
-    max_run_duration: int = 600  # 10 minutes
+    max_run_duration: int = 1800  # 30 minutes logical run budget
+    bash_timeout_grace_period: int = 60
     sandbox_poll_interval: int = 5
     sandbox_ready_timeout: int = 300
     external_download_timeout: int = 120
@@ -220,6 +223,33 @@ class SandboxSettings(BaseSettings):
     rate_limit_min_wait: int = 10
     rate_limit_max_wait: int = 60
     rate_limit_max_retries: int = 5
+
+    @field_validator(
+        "max_run_duration",
+        "sandbox_poll_interval",
+        "sandbox_ready_timeout",
+        "external_download_timeout",
+        "external_max_filesize",
+        "rate_limit_min_wait",
+        "rate_limit_max_wait",
+        "rate_limit_max_retries",
+    )
+    @classmethod
+    def _positive_int(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("value must be positive")
+        return v
+
+    @field_validator("bash_timeout_grace_period")
+    @classmethod
+    def _non_negative_int(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError("value must be non-negative")
+        return v
+
+    def bash_timeout_for(self, logical_timeout: int) -> int:
+        """Return the agent-server bash timeout for a logical run timeout."""
+        return logical_timeout + self.bash_timeout_grace_period
 
     model_config = {"env_prefix": "AUTOMATION_"}
 

--- a/openhands/automation/dispatcher.py
+++ b/openhands/automation/dispatcher.py
@@ -189,12 +189,21 @@ async def _execute_run(
         if disable:
             await disable_automation(session_factory, automation.id, error)
 
-    # 1. Calculate effective timeout (doesn't depend on ctx)
-    max_run_duration = get_config().sandbox.max_run_duration
-    effective_timeout = (
+    # 1. Calculate timeout budgets. The automation timeout is the logical
+    # deadline used by the watchdog; the bash timeout is an outer cap.
+    sandbox_config = get_config().sandbox
+    max_run_duration = sandbox_config.max_run_duration
+    logical_timeout = (
         min(automation.timeout, max_run_duration)
         if automation.timeout
         else max_run_duration
+    )
+    bash_timeout = sandbox_config.bash_timeout_for(logical_timeout)
+    logger.info(
+        "Run timeout budgets: logical=%ss bash=%ss",
+        logical_timeout,
+        bash_timeout,
+        extra=_log_ctx(),
     )
 
     # 2. Get execution context - if this fails, nothing to clean up
@@ -301,7 +310,7 @@ async def _execute_run(
             tarball_source=tarball_source,
             work_dir=work_dir,
             env_vars=env_vars,
-            timeout=effective_timeout,
+            timeout=bash_timeout,
             run_id=run_id,
             sandbox_id=ctx.sandbox_id,
         )
@@ -384,12 +393,12 @@ async def dispatch_pending_runs(
             extra = log_extra(run_id=run_id, automation_id=automation_id)
             try:
                 logger.info("Dispatching automation run", extra=extra)
-                # Use automation's custom timeout if set, otherwise use default
-                run_max_duration = (
-                    timedelta(seconds=run.automation.timeout)
-                    if run.automation and run.automation.timeout
-                    else max_run_duration
-                )
+                # Use the automation's logical timeout if set, capped by the
+                # service maximum so stale-run detection stays within policy.
+                timeout_seconds = int(max_run_duration.total_seconds())
+                if run.automation and run.automation.timeout:
+                    timeout_seconds = min(run.automation.timeout, timeout_seconds)
+                run_max_duration = timedelta(seconds=timeout_seconds)
                 await mark_run_status(
                     session,
                     run,

--- a/openhands/automation/execution.py
+++ b/openhands/automation/execution.py
@@ -80,7 +80,9 @@ def _find_agent_server_url(sandbox: dict) -> tuple[str, str] | None:
 
 
 async def _create_sandbox(
-    client: httpx.AsyncClient, api_url: str, headers: dict[str, str]
+    client: httpx.AsyncClient,
+    api_url: str,
+    headers: dict[str, str],
 ) -> str:
     """Create a sandbox and return its ID. Retries on rate limit."""
 
@@ -197,7 +199,8 @@ async def _bash(
 ) -> tuple[int | None, str, str]:
     """Run a bash command synchronously. Returns ``(exit_code, stdout, stderr)``."""
     if timeout is None:
-        timeout = get_config().sandbox.max_run_duration
+        sandbox_config = get_config().sandbox
+        timeout = sandbox_config.bash_timeout_for(sandbox_config.max_run_duration)
     resp = await client.post(
         f"{agent_url}/api/bash/execute_bash_command",
         json={"command": command, "timeout": timeout},
@@ -218,7 +221,8 @@ async def _start_bash(
 ) -> str:
     """Start a bash command in the background. Returns the command ID."""
     if timeout is None:
-        timeout = get_config().sandbox.max_run_duration
+        sandbox_config = get_config().sandbox
+        timeout = sandbox_config.bash_timeout_for(sandbox_config.max_run_duration)
     http_timeout = get_config().http.http_timeout
     resp = await client.post(
         f"{agent_url}/api/bash/start_bash_command",
@@ -357,7 +361,7 @@ async def execute_in_context(
         tarball_source: Either raw bytes or URL string
         work_dir: Working directory for tarball extraction
         env_vars: Environment variables to export
-        timeout: Max execution time
+        timeout: Agent-server bash command timeout in seconds
         run_id: Run ID — used for logging and to derive an isolated tarball
             path (/tmp/automation-<run_id>.tar.gz) that prevents collisions
             when concurrent runs share the same filesystem (sandboxless mode)
@@ -367,7 +371,8 @@ async def execute_in_context(
         DispatchResult with success status
     """
     if timeout is None:
-        timeout = get_config().sandbox.max_run_duration
+        sandbox_config = get_config().sandbox
+        timeout = sandbox_config.bash_timeout_for(sandbox_config.max_run_duration)
 
     env_vars = dict(env_vars) if env_vars else {}
 
@@ -482,8 +487,10 @@ async def run_automation(
     *work_dir* is the working directory for tarball extraction
     (default: /workspace/project).
     """
+    sandbox_config = get_config().sandbox
     if timeout is None:
-        timeout = get_config().sandbox.max_run_duration
+        timeout = sandbox_config.max_run_duration
+    bash_timeout = sandbox_config.bash_timeout_for(timeout)
     http_timeout = get_config().http.http_long_timeout
 
     env_vars = dict(env_vars) if env_vars else {}
@@ -549,7 +556,7 @@ async def run_automation(
 
             logger.info("Executing entrypoint: %s", entrypoint, extra=_log_ctx())
             exit_code, stdout, stderr = await _bash(
-                client, agent_url, session_key, cmd, timeout=timeout
+                client, agent_url, session_key, cmd, timeout=bash_timeout
             )
 
             success = exit_code == 0

--- a/openhands/automation/models.py
+++ b/openhands/automation/models.py
@@ -136,7 +136,7 @@ class AutomationRun(Base):
         default=AutomationRunStatus.PENDING,
     )
 
-    # Error details if status is FAILED
+    # Human-readable error details if status is FAILED
     error_detail: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Conversation created by the SDK script (set by completion callback)

--- a/openhands/automation/utils/run.py
+++ b/openhands/automation/utils/run.py
@@ -143,8 +143,10 @@ async def mark_run_status(
     if status == AutomationRunStatus.RUNNING:
         values["started_at"] = now
         values["timeout_at"] = now + max_duration
+        values["error_detail"] = None
         run.started_at = now
         run.timeout_at = now + max_duration
+        run.error_detail = None
     elif status in (
         AutomationRunStatus.COMPLETED,
         AutomationRunStatus.FAILED,
@@ -154,9 +156,14 @@ async def mark_run_status(
         values["completed_at"] = now
         run.completed_at = now
 
-    if error_detail and status == AutomationRunStatus.FAILED:
-        values["error_detail"] = error_detail
-        run.error_detail = error_detail
+    if status == AutomationRunStatus.COMPLETED:
+        values["error_detail"] = None
+        run.error_detail = None
+
+    if status == AutomationRunStatus.FAILED:
+        if error_detail:
+            values["error_detail"] = error_detail
+            run.error_detail = error_detail
 
     await session.execute(
         update(AutomationRun).where(AutomationRun.id == run.id).values(**values)

--- a/openhands/automation/watchdog.py
+++ b/openhands/automation/watchdog.py
@@ -1,8 +1,8 @@
-"""Staleness watchdog for stuck RUNNING automation runs.
+"""Watchdog for RUNNING automation runs.
 
-Periodically scans for runs stuck in RUNNING state past their pre-computed
-``timeout_at`` deadline. Before marking as FAILED, attempts to verify the
-actual run status by querying the execution environment.
+Periodically scans for runs past their pre-computed ``timeout_at`` deadline,
+verifies their final state when possible, and marks stale/unverifiable runs
+FAILED.
 
 The ``timeout_at`` column is set to ``started_at + max_duration`` when the
 dispatcher transitions a run to RUNNING (see ``mark_run_status``).
@@ -38,6 +38,10 @@ async def _verify_and_mark_run(
 
     Mode-agnostic: all verification logic is encapsulated in the backend.
 
+    Args:
+        session: Database session.
+        run: RUNNING run to verify.
+        settings: Service settings, kept for API compatibility.
     Returns True if the run was marked with a terminal status.
     """
     run_id = str(run.id)
@@ -89,6 +93,7 @@ async def _verify_and_mark_run(
                 .values(
                     status=AutomationRunStatus.COMPLETED,
                     completed_at=now,
+                    error_detail=None,
                 )
             )
 
@@ -146,8 +151,8 @@ async def _verify_and_mark_run(
         result = await session.execute(stmt)  # type: ignore[assignment]
         return result.rowcount > 0
 
-    # Verification failed - execution environment not available or command still running
-    # This likely means the sandbox crashed or was cleaned up
+    # Verification failed. For stale runs, this likely means the sandbox crashed or was
+    # cleaned up before the callback arrived.
     logger.warning(
         "Could not verify run status: %s, marking as timed out",
         verification.error,
@@ -278,9 +283,9 @@ async def watchdog_loop(
             break
 
         try:
-            marked = await mark_stale_runs(session_factory, settings)
-            if marked:
-                logger.info("Processed %d stale run(s)", marked)
+            stale = await mark_stale_runs(session_factory, settings)
+            if stale:
+                logger.info("Processed %d stale run(s)", stale)
         except Exception:
             logger.exception("Error in watchdog scan")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -182,7 +182,9 @@ class TestSandboxSettings:
     def test_default_values(self):
         """Default values are reasonable."""
         settings = SandboxSettings()
-        assert settings.max_run_duration == 600
+        assert settings.max_run_duration == 1800
+        assert settings.bash_timeout_grace_period == 60
+        assert settings.bash_timeout_for(1800) == 1860
         assert settings.sandbox_poll_interval == 5
         assert settings.sandbox_ready_timeout == 300
         assert settings.rate_limit_min_wait == 10
@@ -193,9 +195,11 @@ class TestSandboxSettings:
         """Custom values are accepted."""
         settings = SandboxSettings(
             max_run_duration=1200,
+            bash_timeout_grace_period=30,
             sandbox_poll_interval=10,
         )
         assert settings.max_run_duration == 1200
+        assert settings.bash_timeout_for(1200) == 1230
         assert settings.sandbox_poll_interval == 10
 
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -444,7 +444,7 @@ class TestCreateAutomation:
             "trigger": {"type": "cron", "schedule": "0 9 * * *"},
             "tarball_path": "s3://bucket/code.tar.gz",
             "entrypoint": "python main.py",
-            "timeout": 601,  # MAX_RUN_DURATION_SECONDS is 600 (10 minutes)
+            "timeout": 1801,  # AUTOMATION_MAX_RUN_DURATION default is 1800
         }
 
         response = await async_client.post("/api/automation/v1", json=payload)
@@ -458,14 +458,14 @@ class TestCreateAutomation:
             "trigger": {"type": "cron", "schedule": "0 9 * * *"},
             "tarball_path": "s3://bucket/code.tar.gz",
             "entrypoint": "python main.py",
-            "timeout": 600,  # MAX_RUN_DURATION_SECONDS is 600 (10 minutes)
+            "timeout": 1800,  # AUTOMATION_MAX_RUN_DURATION default is 1800
         }
 
         response = await async_client.post("/api/automation/v1", json=payload)
 
         assert response.status_code == 201
         data = response.json()
-        assert data["timeout"] == 600
+        assert data["timeout"] == 1800
 
 
 class TestListAutomations:
@@ -1118,7 +1118,7 @@ class TestUpdateAutomation:
 
         response = await async_client.patch(
             f"/api/automation/v1/{automation.id}",
-            json={"timeout": 700},  # MAX_RUN_DURATION_SECONDS is 600 (10 minutes)
+            json={"timeout": 1801},  # AUTOMATION_MAX_RUN_DURATION default is 1800
         )
 
         assert response.status_code == 422


### PR DESCRIPTION
## Summary
- separate logical automation timeout from the outer agent-server bash command timeout
- add a configurable grace period for the bash command timeout
- pass the extended bash timeout through dispatch/execution without changing the user-facing watchdog deadline
- simplify watchdog behavior to only process stale runs while preserving human-readable timeout/failure details

Fixes #203.

## Tests
- `uv run ruff check openhands/automation tests/test_config.py tests/test_schemas.py tests/test_router.py tests/test_watchdog.py tests/test_backends.py tests/test_disable_automation.py tests/test_execution.py`
- `uv run pytest tests/test_config.py tests/test_schemas.py tests/test_backends.py tests/test_execution.py -q`

_DB-backed router/watchdog tests were not run locally because this environment does not provide the Docker daemon required by testcontainers._

---

This PR was updated by an AI agent (OpenHands) on behalf of the user.