### PR TITLE
Add qa-this OpenHands QA workflow

### DIFF
--- a/.github/workflows/qa-changes-by-openhands.yml
+++ b/.github/workflows/qa-changes-by-openhands.yml
@@ -1,0 +1,41 @@
+---
+# Automated QA validation of PR changes using OpenHands.
+#
+# This workflow runs only when the `qa-this` label is added to a same-repo PR.
+# Unlike code review, the QA agent executes the changed code and posts a
+# functional verification report.
+name: QA Changes by OpenHands
+
+on:
+    pull_request:
+        types: [labeled]
+
+permissions:
+    contents: read
+    pull-requests: write
+    issues: write
+
+jobs:
+    qa-changes:
+        # Only run for same-repo PRs (secrets are not available to forks), and
+        # only when explicitly triggered by the `qa-this` label.
+        if: |
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            github.event.label.name == 'qa-this'
+        concurrency:
+            group: qa-changes-${{ github.event.pull_request.number }}
+            cancel-in-progress: true
+        runs-on: ubuntu-24.04
+        timeout-minutes: 30
+        steps:
+            - name: Run QA Changes
+              uses: OpenHands/extensions/plugins/qa-changes@main
+              with:
+                  llm-model: litellm_proxy/openai/gpt-5.5
+                  llm-base-url: https://llm-proxy.app.all-hands.dev
+                  max-budget: '10.0'
+                  timeout-minutes: '30'
+                  max-iterations: '500'
+                  llm-api-key: ${{ secrets.LLM_API_KEY }}
+                  github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC || github.token }}
+                  lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}


### PR DESCRIPTION
## Summary

- Adds a `QA Changes by OpenHands` workflow for same-repo PRs labeled `qa-this`
- Uses the existing `OpenHands/extensions/plugins/qa-changes@main` QA plugin configuration from the reference repos
- Keeps the workflow opt-in so QA runs only when the label is applied

## Verification

- Confirmed `OpenHands/software-agent-sdk` has a `qa-this` label with color `ededed` and a QA workflow using `OpenHands/extensions/plugins/qa-changes@main`
- Confirmed `OpenHands/agent-canvas` also has a `qa-this` label and label-triggered QA workflow using the same plugin
- Created the `qa-this` label in this repo with color `ededed`
- Ran `git diff --cached --check`

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5c324311-643d-4102-9e7d-ef9b1ce51985)