### PR TITLE
fix: guard scheduler against invalid cron schedules

### DIFF
--- a/openhands/automation/scheduler.py
+++ b/openhands/automation/scheduler.py
@@ -11,13 +11,15 @@ SQLite deployments skip row locking (single-process mode assumed).
 import asyncio
 import logging
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfoNotFoundError
 
+from croniter import CroniterBadDateError, CroniterBadTypeRangeError, CroniterError
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from openhands.automation.db import using_sqlite
 from openhands.automation.models import Automation, AutomationRun
-from openhands.automation.utils import is_automation_due, utcnow
+from openhands.automation.utils import get_next_fire_time, is_automation_due, utcnow
 from openhands.automation.utils.run import create_pending_run
 
 
@@ -28,6 +30,71 @@ DEFAULT_BATCH_SIZE = 50
 
 # Minimum interval between polling the same automation (seconds)
 POLL_INTERVAL_SECONDS = 60
+
+_SCHEDULE_EVALUATION_ERRORS = (
+    CroniterError,
+    CroniterBadTypeRangeError,
+    ZoneInfoNotFoundError,
+)
+
+
+def _schedule_log_extra(automation: Automation) -> dict[str, str | None]:
+    trigger = automation.trigger or {}
+    schedule = trigger.get("schedule")
+    timezone = trigger.get("timezone")
+    return {
+        "automation_id": str(automation.id),
+        "schedule": schedule if isinstance(schedule, str) else None,
+        "timezone": timezone if isinstance(timezone, str) else "UTC",
+    }
+
+
+def _disable_invalid_cron_automation(
+    automation: Automation,
+    *,
+    reason: str,
+    error: BaseException,
+) -> None:
+    automation.enabled = False
+    logger.error(
+        "Disabling automation with invalid cron trigger: %s",
+        reason,
+        exc_info=(type(error), error, error.__traceback__),
+        extra=_schedule_log_extra(automation),
+    )
+
+
+def _is_automation_due_safely(automation: Automation, now: datetime) -> bool:
+    try:
+        return is_automation_due(automation, now)
+    except CroniterBadDateError:
+        cron_extra = _schedule_log_extra(automation)
+        schedule = cron_extra["schedule"] or ""
+        timezone = cron_extra["timezone"] or "UTC"
+        try:
+            next_fire_time = get_next_fire_time(schedule, timezone, now)
+        except _SCHEDULE_EVALUATION_ERRORS as next_error:
+            _disable_invalid_cron_automation(
+                automation,
+                reason="cron schedule cannot produce fire times",
+                error=next_error,
+            )
+        else:
+            logger.warning(
+                "Cron schedule has no previous fire time; treating as not due",
+                extra={
+                    **_schedule_log_extra(automation),
+                    "next_fire_time": next_fire_time.isoformat(),
+                },
+            )
+        return False
+    except _SCHEDULE_EVALUATION_ERRORS as e:
+        _disable_invalid_cron_automation(
+            automation,
+            reason="cron schedule could not be evaluated",
+            error=e,
+        )
+        return False
 
 
 async def _fetch_enabled_automations(
@@ -120,7 +187,7 @@ async def poll_and_schedule(
             for automation in automations:
                 automation.last_polled_at = now
 
-        due_automations = [a for a in automations if is_automation_due(a, now)]
+        due_automations = [a for a in automations if _is_automation_due_safely(a, now)]
 
         for automation in due_automations:
             try:

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -5,10 +5,13 @@ import uuid
 from enum import StrEnum
 from typing import Annotated, Literal
 
-from croniter import croniter
 from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, field_validator
 
 from openhands.automation.constants import MODEL_PROFILE_PATTERN
+from openhands.automation.utils.cron import (
+    validate_cron_schedule as validate_cron_schedule_value,
+    validate_timezone_name,
+)
 from openhands.automation.utils.time import UtcDatetime
 from openhands.automation.utils.timeout import (
     build_automation_timeout_description,
@@ -38,9 +41,12 @@ class CronTrigger(BaseModel):
     @field_validator("schedule")
     @classmethod
     def validate_cron_schedule(cls, v: str) -> str:
-        if not croniter.is_valid(v):
-            raise ValueError(f"Invalid cron expression: {v}")
-        return v
+        return validate_cron_schedule_value(v)
+
+    @field_validator("timezone")
+    @classmethod
+    def validate_timezone(cls, v: str) -> str:
+        return validate_timezone_name(v)
 
 
 class EventTrigger(BaseModel):

--- a/openhands/automation/utils/__init__.py
+++ b/openhands/automation/utils/__init__.py
@@ -8,6 +8,8 @@ from openhands.automation.utils.cron import (
     get_next_fire_time,
     get_prev_fire_time,
     is_automation_due,
+    validate_cron_schedule,
+    validate_timezone_name,
 )
 from openhands.automation.utils.log_context import log_extra
 from openhands.automation.utils.time import UtcDatetime, ensure_utc, utcnow
@@ -19,6 +21,8 @@ __all__ = [
     "get_next_fire_time",
     "get_prev_fire_time",
     "is_automation_due",
+    "validate_cron_schedule",
+    "validate_timezone_name",
     "log_extra",
     "UtcDatetime",
     "ensure_utc",

--- a/openhands/automation/utils/cron.py
+++ b/openhands/automation/utils/cron.py
@@ -9,15 +9,54 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import TYPE_CHECKING
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from croniter import croniter
+from croniter import (
+    CroniterBadDateError,
+    CroniterBadTypeRangeError,
+    CroniterError,
+    croniter,
+)
 
 from openhands.automation.utils.time import utcnow
 
 
 if TYPE_CHECKING:
     from openhands.automation.models import Automation
+
+
+_CRON_VALIDATION_BASE_TIME = datetime(2026, 7, 1)
+
+
+def validate_timezone_name(timezone: str) -> str:
+    """Validate and return an IANA timezone name."""
+    try:
+        ZoneInfo(timezone)
+    except ZoneInfoNotFoundError as e:
+        raise ValueError(f"Invalid timezone: {timezone}") from e
+    return timezone
+
+
+def validate_cron_schedule(cron_schedule: str) -> str:
+    """Validate that a cron expression is syntactically valid and can fire.
+
+    ``croniter.is_valid`` accepts impossible dates like ``0 0 31 2 *``.
+    Verify that croniter can compute at least one future fire time so these
+    schedules are rejected before they can poison scheduler polling.
+    """
+    if not croniter.is_valid(cron_schedule):
+        raise ValueError(f"Invalid cron expression: {cron_schedule}")
+
+    try:
+        croniter(cron_schedule, _CRON_VALIDATION_BASE_TIME).get_next(datetime)
+    except CroniterBadDateError as e:
+        raise ValueError(
+            f"Cron expression cannot produce any future fire times: {cron_schedule}"
+        ) from e
+    except (CroniterError, CroniterBadTypeRangeError) as e:
+        raise ValueError(f"Invalid cron expression: {cron_schedule}") from e
+
+    return cron_schedule
 
 
 def get_next_fire_time(

--- a/tests/test_preset_router.py
+++ b/tests/test_preset_router.py
@@ -641,6 +641,20 @@ class TestCreateAutomationFromPrompt:
 
         assert response.status_code == 422
 
+    async def test_create_from_prompt_impossible_cron(self, async_client):
+        """Cron schedules that can never fire return 422."""
+        payload = {
+            "name": "Test",
+            "prompt": "Do something",
+            "trigger": {"type": "cron", "schedule": "0 0 31 2 *"},
+        }
+
+        response = await async_client.post(
+            "/api/automation/v1/preset/prompt", json=payload
+        )
+
+        assert response.status_code == 422
+
     async def test_create_from_prompt_missing_trigger(self, async_client):
         """Missing trigger returns 422."""
         payload = {

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -242,6 +242,48 @@ class TestCreateAutomation:
         assert len(schedule_errors) == 1
         assert "Invalid cron expression" in schedule_errors[0]["msg"]
 
+    async def test_create_automation_impossible_cron(self, async_client):
+        """Cron expressions that can never fire return 422."""
+        payload = {
+            "name": "Impossible Cron",
+            "trigger": {"type": "cron", "schedule": "0 0 31 2 *", "timezone": "UTC"},
+            "tarball_path": "s3://bucket/path/to/code.tar.gz",
+            "entrypoint": "uv run script.py",
+        }
+
+        response = await async_client.post("/api/automation/v1", json=payload)
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        schedule_errors = [
+            e for e in detail if e["loc"] == ["body", "trigger", "cron", "schedule"]
+        ]
+        assert len(schedule_errors) == 1
+        assert "cannot produce any future fire times" in schedule_errors[0]["msg"]
+
+    async def test_create_automation_invalid_timezone(self, async_client):
+        """Invalid timezone names return 422."""
+        payload = {
+            "name": "Bad Timezone",
+            "trigger": {
+                "type": "cron",
+                "schedule": "0 9 * * *",
+                "timezone": "Not/A_Timezone",
+            },
+            "tarball_path": "s3://bucket/path/to/code.tar.gz",
+            "entrypoint": "uv run script.py",
+        }
+
+        response = await async_client.post("/api/automation/v1", json=payload)
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        timezone_errors = [
+            e for e in detail if e["loc"] == ["body", "trigger", "cron", "timezone"]
+        ]
+        assert len(timezone_errors) == 1
+        assert "Invalid timezone" in timezone_errors[0]["msg"]
+
     async def test_create_automation_missing_fields(self, async_client):
         """Missing required fields returns 422."""
         payload = {"name": "Incomplete"}

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -385,6 +385,55 @@ class TestPollAndSchedule:
         assert runs[0].automation_id == automation_id
         assert runs[0].status == AutomationRunStatus.PENDING
 
+    async def test_poll_disables_impossible_cron_without_blocking_batch(
+        self, async_session_factory
+    ):
+        """A bad stored cron row does not abort scheduling other automations."""
+        now = utcnow()
+        created_at = now - timedelta(minutes=5)
+
+        async with async_session_factory() as session:
+            invalid_automation = Automation(
+                user_id=TEST_USER_ID,
+                org_id=TEST_ORG_ID,
+                name="Impossible Cron",
+                trigger={"type": "cron", "schedule": "0 0 31 2 *", "timezone": "UTC"},
+                tarball_path="s3://bucket/code.tar.gz",
+                entrypoint="uv run main.py",
+                enabled=True,
+                last_polled_at=None,
+                created_at=created_at,
+            )
+            due_automation = Automation(
+                user_id=TEST_USER_ID,
+                org_id=TEST_ORG_ID,
+                name="Due Automation",
+                trigger={"type": "cron", "schedule": "* * * * *", "timezone": "UTC"},
+                tarball_path="s3://bucket/code.tar.gz",
+                entrypoint="uv run main.py",
+                enabled=True,
+                last_polled_at=None,
+                last_triggered_at=None,
+                created_at=created_at,
+            )
+            session.add_all([invalid_automation, due_automation])
+            await session.commit()
+            invalid_id = invalid_automation.id
+            due_id = due_automation.id
+
+        runs = await poll_and_schedule(async_session_factory, now=now)
+
+        assert len(runs) == 1
+        assert runs[0].automation_id == due_id
+
+        async with async_session_factory() as session:
+            result = await session.execute(
+                select(Automation).where(Automation.id == invalid_id)
+            )
+            invalid_automation = result.scalars().one()
+            assert invalid_automation.enabled is False
+            assert invalid_automation.last_polled_at is not None
+
     async def test_poll_excludes_disabled(self, async_session_factory):
         """Disabled automations are not returned."""
         async with async_session_factory() as session:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -11,9 +11,13 @@ import uuid
 from datetime import UTC, datetime, timedelta, timezone
 from typing import Any
 
+import pytest
+from pydantic import ValidationError
+
 from openhands.automation.schemas import (
     AutomationResponse,
     AutomationRunResponse,
+    CronTrigger,
     RunStatus,
 )
 from openhands.automation.utils.time import ensure_utc
@@ -42,6 +46,24 @@ class TestEnsureUtc:
     def test_non_utc_aware_datetime_is_unchanged(self):
         result = ensure_utc(_OTHER_TZ)
         assert result is _OTHER_TZ
+
+
+class TestCronTriggerValidation:
+    def test_accepts_valid_cron_and_timezone(self):
+        trigger = CronTrigger(schedule="0 9 * * *", timezone="America/New_York")
+
+        assert trigger.schedule == "0 9 * * *"
+        assert trigger.timezone == "America/New_York"
+
+    def test_rejects_impossible_cron_schedule(self):
+        with pytest.raises(
+            ValidationError, match="cannot produce any future fire times"
+        ):
+            CronTrigger(schedule="0 0 31 2 *")
+
+    def test_rejects_invalid_timezone(self):
+        with pytest.raises(ValidationError, match="Invalid timezone"):
+            CronTrigger(schedule="0 9 * * *", timezone="Not/A_Timezone")
 
 
 class TestAutomationRunResponseUtcSerialisation:


### PR DESCRIPTION
## Summary
- reject syntactically valid but unsatisfiable cron schedules (for example, `0 0 31 2 *`) at trigger validation time
- validate cron trigger timezone names at the API/schema boundary
- isolate scheduler due checks per automation so one bad stored cron row cannot abort the whole poll batch
- disable permanently invalid stored cron automations after logging schedule, timezone, and automation ID
- add regression coverage for schema validation, API/preset validation, and scheduler batch isolation

## Validation
- `uv run ruff format openhands/automation/utils/cron.py openhands/automation/utils/__init__.py openhands/automation/schemas.py openhands/automation/scheduler.py tests/test_scheduler.py tests/test_router.py tests/test_preset_router.py tests/test_schemas.py`
- `uv run ruff check --fix openhands/automation/utils/cron.py openhands/automation/utils/__init__.py openhands/automation/schemas.py openhands/automation/scheduler.py tests/test_scheduler.py tests/test_router.py tests/test_preset_router.py tests/test_schemas.py`
- `uv run pyright openhands/automation/utils/cron.py openhands/automation/scheduler.py openhands/automation/schemas.py tests/test_schemas.py`
- `uv run pytest tests/test_schemas.py tests/test_scheduler.py::TestGetNextFireTime tests/test_scheduler.py::TestGetPrevFireTime tests/test_scheduler.py::TestIsAutomationDue -q`
- `uv run pre-commit run --files openhands/automation/utils/cron.py openhands/automation/utils/__init__.py openhands/automation/schemas.py openhands/automation/scheduler.py tests/test_scheduler.py tests/test_router.py tests/test_preset_router.py tests/test_schemas.py --show-diff-on-failure`

Note: DB-backed tests requiring testcontainers/Postgres could not be run in this local environment because the Docker daemon is unavailable.

This PR was created by an AI agent (OpenHands) on behalf of the user.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c14289b1-eafb-41ab-92e6-79a2456d58f9)