### PR TITLE
fix: harden KV request models with extra=forbid and fix missing-key inconsistency

### DIFF
--- a/openhands/automation/kv_router.py
+++ b/openhands/automation/kv_router.py
@@ -527,6 +527,7 @@ async def set_value(
         key=key,
         value=body,
         created=created,
+        version=_get_version(state),
         updated_at=saved_row.updated_at.isoformat(),
     )
 
@@ -694,7 +695,7 @@ async def increment(
     _check_state_size(state, kv_config)
     await _save_state(session, claims.automation_id, state, kv_config.kv_secret, row)
 
-    return KVIncrResponse(key=key, value=new_value)
+    return KVIncrResponse(key=key, value=new_value, version=_get_version(state))
 
 
 @router.post("/{key}/decr")
@@ -738,7 +739,7 @@ async def decrement(
     _check_state_size(state, kv_config)
     await _save_state(session, claims.automation_id, state, kv_config.kv_secret, row)
 
-    return KVIncrResponse(key=key, value=new_value)
+    return KVIncrResponse(key=key, value=new_value, version=_get_version(state))
 
 
 @router.post("/{key}/lpush")
@@ -777,7 +778,7 @@ async def lpush(
     _check_state_size(state, kv_config)
     await _save_state(session, claims.automation_id, state, kv_config.kv_secret, row)
 
-    return KVListLengthResponse(key=key, length=len(state[key]))
+    return KVListLengthResponse(key=key, length=len(state[key]), version=_get_version(state))
 
 
 @router.post("/{key}/rpush")
@@ -816,7 +817,7 @@ async def rpush(
     _check_state_size(state, kv_config)
     await _save_state(session, claims.automation_id, state, kv_config.kv_secret, row)
 
-    return KVListLengthResponse(key=key, length=len(state[key]))
+    return KVListLengthResponse(key=key, length=len(state[key]), version=_get_version(state))
 
 
 @router.post("/{key}/lpop")
@@ -912,15 +913,12 @@ async def list_length(
     state = _decrypt_state(kv_config.kv_secret, row)
 
     if key not in state:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="key_not_found",
-        )
+        return KVListLengthResponse(key=key, length=0, version=_get_version(state))
 
     value = state[key]
     require_list(value)
 
-    return KVListLengthResponse(key=key, length=len(value))
+    return KVListLengthResponse(key=key, length=len(value), version=_get_version(state))
 
 
 # --- Batch Operations ---

--- a/openhands/automation/kv_schemas.py
+++ b/openhands/automation/kv_schemas.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 # --- Batch Operation Schemas ---
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, model_validator
 
 class KVBatchOpSet(BaseModel):
     """Set operation in a batch."""
+    model_config = ConfigDict(extra="forbid")
 
     op: Literal["set"]
     key: str = Field(..., min_length=1, max_length=255)
@@ -26,6 +27,7 @@ class KVBatchOpSet(BaseModel):
 
 class KVBatchOpDelete(BaseModel):
     """Delete operation in a batch."""
+    model_config = ConfigDict(extra="forbid")
 
     op: Literal["delete"]
     key: str = Field(..., min_length=1, max_length=255)
@@ -33,6 +35,7 @@ class KVBatchOpDelete(BaseModel):
 
 class KVBatchOpIncr(BaseModel):
     """Increment operation in a batch."""
+    model_config = ConfigDict(extra="forbid")
 
     op: Literal["incr"]
     key: str = Field(..., min_length=1, max_length=255)
@@ -41,6 +44,7 @@ class KVBatchOpIncr(BaseModel):
 
 class KVBatchOpDecr(BaseModel):
     """Decrement operation in a batch."""
+    model_config = ConfigDict(extra="forbid")
 
     op: Literal["decr"]
     key: str = Field(..., min_length=1, max_length=255)
@@ -49,6 +53,7 @@ class KVBatchOpDecr(BaseModel):
 
 class KVBatchOpLPush(BaseModel):
     """Left push operation in a batch."""
+    model_config = ConfigDict(extra="forbid")
 
     op: Literal["lpush"]
     key: str = Field(..., min_length=1, max_length=255)
@@ -57,6 +62,7 @@ class KVBatchOpLPush(BaseModel):
 
 class KVBatchOpRPush(BaseModel):
     """Right push operation in a batch."""
+    model_config = ConfigDict(extra="forbid")
 
     op: Literal["rpush"]
     key: str = Field(..., min_length=1, max_length=255)
@@ -65,6 +71,7 @@ class KVBatchOpRPush(BaseModel):
 
 class KVBatchOpLPop(BaseModel):
     """Left pop operation in a batch."""
+    model_config = ConfigDict(extra="forbid")
 
     op: Literal["lpop"]
     key: str = Field(..., min_length=1, max_length=255)
@@ -72,6 +79,7 @@ class KVBatchOpLPop(BaseModel):
 
 class KVBatchOpRPop(BaseModel):
     """Right pop operation in a batch."""
+    model_config = ConfigDict(extra="forbid")
 
     op: Literal["rpop"]
     key: str = Field(..., min_length=1, max_length=255)
@@ -79,6 +87,7 @@ class KVBatchOpRPop(BaseModel):
 
 class KVBatchOpPatch(BaseModel):
     """Patch operation in a batch."""
+    model_config = ConfigDict(extra="forbid")
 
     op: Literal["patch"]
     key: str = Field(..., min_length=1, max_length=255)
@@ -102,6 +111,7 @@ KVBatchOperation = (
 
 class KVBatchRequest(BaseModel):
     """Request body for batch operations."""
+    model_config = ConfigDict(extra="forbid")
 
     if_version: int | None = Field(
         default=None,
@@ -152,11 +162,15 @@ class KVVersionMismatchResponse(BaseModel):
 class KVSetRequest(BaseModel):
     """Request body for setting a KV value (used when body is explicit)."""
 
+    model_config = ConfigDict(extra="forbid")
+
     value: Any = Field(..., description="Any JSON-serializable value")
 
 
 class KVPatchRequest(BaseModel):
     """Request body for patching a nested path."""
+
+    model_config = ConfigDict(extra="forbid")
 
     path: str = Field(
         ..., description="Dot-notation path to update (e.g., 'database.port')"
@@ -167,11 +181,15 @@ class KVPatchRequest(BaseModel):
 class KVIncrRequest(BaseModel):
     """Request body for increment/decrement operations."""
 
+    model_config = ConfigDict(extra="forbid")
+
     by: int = Field(default=1, description="Amount to increment/decrement by")
 
 
 class KVListPushRequest(BaseModel):
     """Request body for list push operations."""
+
+    model_config = ConfigDict(extra="forbid")
 
     value: Any = Field(..., description="Value to push onto the list")
 
@@ -210,6 +228,7 @@ class KVSetResponse(BaseModel):
     key: str
     value: Any
     created: bool
+    version: int
     updated_at: str
 
 
@@ -232,6 +251,7 @@ class KVIncrResponse(BaseModel):
 
     key: str
     value: int
+    version: int
 
 
 class KVListLengthResponse(BaseModel):
@@ -239,6 +259,7 @@ class KVListLengthResponse(BaseModel):
 
     key: str
     length: int
+    version: int
 
 
 class KVConflictResponse(BaseModel):


### PR DESCRIPTION
## Summary

This PR addresses the three issues described in #200:

### 1. Added `extra='forbid'` to all KV request schemas

Added `model_config = ConfigDict(extra='forbid')` to all Pydantic request schemas to reject unknown fields early:

- `KVSetRequest`
- `KVPatchRequest`
- `KVIncrRequest`
- `KVListPushRequest`
- `KVBatchRequest`
- All batch operation schemas (`KVBatchOpSet`, `KVBatchOpDelete`, `KVBatchOpIncr`, `KVBatchOpDecr`, `KVBatchOpLPush`, `KVBatchOpRPush`, `KVBatchOpLPop`, `KVBatchOpRPop`, `KVBatchOpPatch`)

### 2. Fixed missing-key inconsistency in `/len` endpoint

Changed `GET /{key}/len` to return `length=0` for missing keys instead of raising a 404 error. This matches the behavior of `/get` and `/getmeta` which return null for missing keys.

### 3. Added `version` field to write responses

Updated `KVSetResponse`, `KVIncrResponse`, and `KVListLengthResponse` to include a `version` field, providing consistency with read responses that already include version information.

Closes #200