### PR TITLE
fix: acknowledge unknown webhook event types with 200 instead of 400

### DIFF
--- a/openhands/automation/event_router.py
+++ b/openhands/automation/event_router.py
@@ -140,6 +140,18 @@ async def receive_event(
             )
     except HTTPException:
         raise  # Re-raise HTTPExceptions as-is
+    except ValueError as e:
+        # Unknown event type (e.g. a GitHub event we don't have a detection
+        # rule for). This is normal - the service supports a subset of event
+        # types from each source - so acknowledge the webhook with matched=0
+        # rather than failing with 400. See APP-2668.
+        logger.info(
+            "Ignoring unrecognized event from source=%s org=%s: %s",
+            source,
+            org_id,
+            e,
+        )
+        return EventResponse(received=True, matched=0, runs_created=[])
     except Exception as e:
         logger.warning("Failed to parse event: %s", e)
         raise HTTPException(status_code=400, detail=f"Failed to parse event: {e}")

--- a/tests/test_event_router.py
+++ b/tests/test_event_router.py
@@ -358,12 +358,16 @@ async def test_receive_github_event_missing_signature(
 
 
 @pytest.mark.asyncio
-async def test_receive_github_event_undetectable_payload(
+async def test_receive_github_event_undetectable_payload_returns_200(
     async_client: AsyncClient,
     org_id: uuid.UUID,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Test that undetectable payload structure returns 400."""
+    """Payload whose structure doesn't match any known GitHub event is treated
+    as an unrecognized event type. We acknowledge the webhook with matched=0
+    rather than failing with 400, since the payload is structurally valid - the
+    service just doesn't have a detection rule for it. See APP-2668.
+    """
     monkeypatch.setenv("AUTOMATION_WEBHOOK_SECRET", "test-secret")
 
     # Payload with payload that doesn't match any known GitHub event structure
@@ -379,8 +383,11 @@ async def test_receive_github_event_undetectable_payload(
         },
     )
 
-    assert response.status_code == 400
-    assert "Cannot detect github event type" in response.json()["detail"]
+    assert response.status_code == 200
+    body = response.json()
+    assert body["received"] is True
+    assert body["matched"] == 0
+    assert body["runs_created"] == []
 
 
 @pytest.mark.asyncio
@@ -410,18 +417,22 @@ async def test_receive_github_event_missing_payload(
 
 
 @pytest.mark.asyncio
-async def test_receive_github_event_malformed_payload(
+async def test_receive_github_event_unrecognised_payload_shape_returns_200(
     async_client: AsyncClient,
     org_id: uuid.UUID,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Test that malformed payload returns 400."""
+    """A claim of a known event_type with a payload that doesn't match the
+    service's detection rules is treated as an unrecognized event type and
+    acknowledged with matched=0 rather than failing with 400. See APP-2668.
+    """
     monkeypatch.setenv("AUTOMATION_WEBHOOK_SECRET", "test-secret")
 
-    # Payload with event_type but invalid payload for that type
+    # event_type says "push" but the inner payload doesn't have ref/commits,
+    # so the service can't recognise the event type
     payload = {
         "event_type": "push",
-        "payload": {"invalid": "data"},  # Missing required fields
+        "payload": {"invalid": "data"},
     }
     signature, body = sign_payload(payload, "test-secret")
 
@@ -434,8 +445,11 @@ async def test_receive_github_event_malformed_payload(
         },
     )
 
-    assert response.status_code == 400
-    assert "Failed to parse event" in response.json()["detail"]
+    assert response.status_code == 200
+    body = response.json()
+    assert body["received"] is True
+    assert body["matched"] == 0
+    assert body["runs_created"] == []
 
 
 @pytest.mark.asyncio
@@ -444,12 +458,21 @@ async def test_receive_github_event_unknown_event_type(
     org_id: uuid.UUID,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Test that unknown GitHub event type returns 400."""
+    """Unknown GitHub event types are acknowledged with matched=0. The webhook
+    is well-formed and authenticated; the service simply doesn't have a
+    detection rule for the event type. See APP-2668.
+    """
     monkeypatch.setenv("AUTOMATION_WEBHOOK_SECRET", "test-secret")
 
     payload = {
-        "event_type": "unknown_github_event",
-        "payload": {"data": "test"},
+        "event_type": "workflow_job",
+        "payload": {
+            "action": "in_progress",
+            "workflow_job": {"id": 1},
+            "repository": {"id": 1, "name": "r", "full_name": "o/r", "private": False},
+            "sender": {"id": 1, "login": "u"},
+            "installation": {"id": 1},
+        },
     }
     signature, body = sign_payload(payload, "test-secret")
 
@@ -462,8 +485,11 @@ async def test_receive_github_event_unknown_event_type(
         },
     )
 
-    assert response.status_code == 400
-    assert "Failed to parse event" in response.json()["detail"]
+    assert response.status_code == 200
+    body = response.json()
+    assert body["received"] is True
+    assert body["matched"] == 0
+    assert body["runs_created"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Cloud automations were generating 2/3 of all production errors in Datadog
([APP-2668](https://linear.app/all-hands-ai/issue/APP-2668/cloud-automations-is-failing-in-production)).
The errors all looked like:

```
[AutomationEventService] Automation service returned 400 for github org ...:
  {'detail': "Failed to parse event: Cannot detect github event type from
  payload. Top-level keys: ['action', 'workflow_job', 'repository',
  'sender', 'installation']"}
```

GitHub forwards many event types to OpenHands (`workflow_job`, `deployment`,
`ping`, `star`, `fork`, etc.) that the automation service does not have
detection rules for. The webhook handler treated these as parse failures
and returned 400, which OpenHands logged as an error and shipped to
Datadog.

The webhook itself is well-formed and authenticated — the service just
doesn't recognize the event type. Treat that the same as a recognized
event that matches no automations: **200 with `matched: 0`**, plus an
`INFO` log line so the service can later see what real traffic looks
like vs. what user automations are subscribed to.

Pydantic validation failures for *known* event types with malformed
payloads still return 400 — those are genuine client errors.

## Changes

- `openhands/automation/event_router.py` — split the catch-all exception
  handler into two cases: `ValueError` (unknown event type) returns
  200 with `matched: 0`; other exceptions (Pydantic validation errors
  on a recognized event type) still return 400.
- `tests/test_event_router.py` — update the three tests that asserted
  400 for unknown event types to assert 200 + `matched: 0`. Renamed
  them to make the new semantics clear. The `unknown_event_type` test
  now uses a realistic `workflow_job` payload (the exact shape from
  the production error).

## Why this fix and not "log the 400 as INFO in OpenHands"

- 4xx should generally be treated as a client error. Special-casing
  automation's 400 in OpenHands means future maintainers (or other
  automation clients) will trip on the same gotcha.
- Webhook providers may treat 4xx as a delivery failure and retry,
  leading to duplicate deliveries later if the unknown event type ever
  does get a rule added.
- The signal is still useful: the automation service should know what
  event types it sees but doesn't have rules for, so it can later
  extend coverage. The new `Ignoring unrecognized event` log line at
  INFO level gives us that.

## Test plan

- [x] Unit tests pass (`uv run pytest tests/test_event_router.py -v`)
- [x] Pre-commit passes (`uv run pre-commit run --files <changed>`)
- [ ] Deploy to staging and confirm Datadog stops receiving the
      "Automation service returned 400 for github org" error.
- [ ] Watch the new `Ignoring unrecognized event` INFO log to see what
      event types GitHub is actually forwarding.

## Out of scope (follow-up ideas)

- Add detection rules for common GitHub event types GitHub forwards
  (`workflow_job`, `deployment`, `ping`, `star`, `fork`, etc.) so they
  show up as `matched: 0` in the matched-count log line, not just the
  ignore-unrecognized log line. (Requires adding Pydantic models too.)
- Same applies to `bitbucket_data_center` and `jira_dc` parsers — they
  have the same "Cannot detect X event type" pattern.

This PR was created by an AI agent (OpenHands) on behalf of the user.