### PR TITLE
feat(webhooks): add signature_scheme with Standard Webhooks support

### DIFF
--- a/migrations/versions/010_add_webhook_signature_scheme.py
+++ b/migrations/versions/010_add_webhook_signature_scheme.py
@@ -1,0 +1,50 @@
+"""Add signature_scheme to custom_webhooks.
+
+Adds a per-webhook signature verification scheme so custom sources can use
+schemes other than the default GitHub-style hex HMAC — notably Standard
+Webhooks (GitLab 19.1+ signing tokens, Svix).
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-07-20
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "010"
+down_revision: str = "009"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sqlite() -> bool:
+    """Check if we are running against SQLite (test/dev only)."""
+    return op.get_bind().dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "custom_webhooks",
+        sa.Column(
+            "signature_scheme",
+            sa.String(length=50),
+            nullable=False,
+            server_default="hmac_sha256_hex",
+        ),
+    )
+
+    if not _is_sqlite():
+        op.execute(
+            "COMMENT ON COLUMN custom_webhooks.signature_scheme IS "
+            "'HMAC verification scheme: hmac_sha256_hex (default, GitHub/Linear "
+            "style) or standard_webhooks (standardwebhooks.com; GitLab 19.1+ "
+            "signing tokens, Svix).'"
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("custom_webhooks", "signature_scheme")

--- a/openhands/automation/event_router.py
+++ b/openhands/automation/event_router.py
@@ -46,6 +46,7 @@ from openhands.automation.utils.webhook import (
     get_event_automations,
     get_webhook_config,
     verify_signature,
+    verify_standard_webhooks,
 )
 
 
@@ -90,9 +91,8 @@ async def receive_event(
             detail=f"Unknown webhook source: {source}",
         )
 
-    # 3. Get signature from the configured header (source-specific)
+    # 3. Verify the signature according to the configured scheme.
     signature = request.headers.get(config.signature_header)
-
     if not signature:
         logger.warning(
             "Missing signature header '%s' for event from source=%s org_id=%s",
@@ -105,9 +105,24 @@ async def receive_event(
             detail=f"Missing signature header: {config.signature_header}",
         )
 
-    if not verify_signature(body, signature, config.secret):
+    if config.signature_scheme == "standard_webhooks":
+        # Standard Webhooks (e.g. GitLab 19.1+ signing tokens): the signature is
+        # a "v1,<base64>" value plus webhook-id / webhook-timestamp headers.
+        valid = verify_standard_webhooks(
+            body,
+            config.secret,
+            request.headers.get("webhook-id"),
+            request.headers.get("webhook-timestamp"),
+            signature,
+        )
+    else:
+        # Default: GitHub/Linear style hex HMAC over the raw body.
+        valid = verify_signature(body, signature, config.secret)
+
+    if not valid:
         logger.warning(
-            "Invalid signature for event from source=%s org_id=%s",
+            "Invalid signature (scheme=%s) for event from source=%s org_id=%s",
+            config.signature_scheme,
             source,
             org_id,
         )

--- a/openhands/automation/models.py
+++ b/openhands/automation/models.py
@@ -309,6 +309,18 @@ class CustomWebhook(Base):
         String(100), nullable=False, default="X-Signature-256"
     )
 
+    # Signature verification scheme. Determines how the HMAC carried in
+    # `signature_header` is computed/encoded:
+    # - "hmac_sha256_hex" (default): hex(HMAC-SHA256(secret, body)); GitHub/Linear
+    #   style, accepts an optional "sha256=" prefix.
+    # - "standard_webhooks": Standard Webhooks spec (standardwebhooks.com) used by
+    #   GitLab 19.1+ signing tokens, Svix, etc. Verifies a "v1,<base64>" value over
+    #   "{id}.{timestamp}.{body}" with key=base64decode(secret without "whsec_"),
+    #   plus a timestamp freshness check.
+    signature_scheme: Mapped[str] = mapped_column(
+        String(50), nullable=False, default="hmac_sha256_hex"
+    )
+
     # Timestamp when the webhook integration was created
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -372,6 +372,9 @@ class UpdateAutomationRequest(BaseModel):
 # --- Webhook Schemas ---
 
 
+VALID_SIGNATURE_SCHEMES = {"hmac_sha256_hex", "standard_webhooks"}
+
+
 class WebhookConfig(BaseModel):
     """Configuration for processing a webhook."""
 
@@ -381,6 +384,7 @@ class WebhookConfig(BaseModel):
     is_builtin: bool = False  # True for built-in OpenHands-forwarded sources
     event_key_expr: str = "type"  # JMESPath expression for extracting event key
     signature_header: str = "X-Hub-Signature-256"  # HTTP header for signature
+    signature_scheme: str = "hmac_sha256_hex"  # HMAC scheme; see CustomWebhook model
 
 
 class EventResponse(BaseModel):
@@ -438,6 +442,16 @@ class CustomWebhookCreate(BaseModel):
             "Examples: 'X-Signature-256', 'Stripe-Signature', 'X-Slack-Signature'"
         ),
     )
+    signature_scheme: str = Field(
+        default="hmac_sha256_hex",
+        description=(
+            "HMAC signature scheme. 'hmac_sha256_hex' (default) verifies a hex "
+            "digest over the raw body (GitHub/Linear). 'standard_webhooks' follows "
+            "standardwebhooks.com (GitLab 19.1+ signing tokens, Svix): reads a "
+            "'v1,<base64>' value from `signature_header` (typically "
+            "'webhook-signature') with webhook-id/webhook-timestamp headers."
+        ),
+    )
     webhook_secret: str | None = Field(
         default=None,
         min_length=8,
@@ -464,6 +478,17 @@ class CustomWebhookCreate(BaseModel):
                 "starting and ending with alphanumeric"
             )
         return v_lower
+
+    @field_validator("signature_scheme")
+    @classmethod
+    def validate_signature_scheme(cls, v: str) -> str:
+        """Validate the signature scheme is supported."""
+        if v not in VALID_SIGNATURE_SCHEMES:
+            raise ValueError(
+                f"Invalid signature_scheme '{v}'. Must be one of: "
+                f"{', '.join(sorted(VALID_SIGNATURE_SCHEMES))}"
+            )
+        return v
 
     @field_validator("event_key_expr")
     @classmethod
@@ -498,7 +523,21 @@ class CustomWebhookUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=255)
     event_key_expr: str | None = Field(default=None, max_length=500)
     signature_header: str | None = Field(default=None, max_length=100)
+    signature_scheme: str | None = Field(default=None, max_length=50)
     enabled: bool | None = None
+
+    @field_validator("signature_scheme")
+    @classmethod
+    def validate_signature_scheme(cls, v: str | None) -> str | None:
+        """Validate the signature scheme is supported if provided."""
+        if v is None:
+            return v
+        if v not in VALID_SIGNATURE_SCHEMES:
+            raise ValueError(
+                f"Invalid signature_scheme '{v}'. Must be one of: "
+                f"{', '.join(sorted(VALID_SIGNATURE_SCHEMES))}"
+            )
+        return v
 
     @field_validator("event_key_expr")
     @classmethod
@@ -539,6 +578,7 @@ class CustomWebhookResponse(BaseModel):
     webhook_url: str
     event_key_expr: str
     signature_header: str
+    signature_scheme: str
     enabled: bool
     created_at: UtcDatetime
     updated_at: UtcDatetime

--- a/openhands/automation/utils/webhook.py
+++ b/openhands/automation/utils/webhook.py
@@ -5,9 +5,12 @@ Contains helpers for signature verification, webhook configuration lookup,
 and automation run creation for event-triggered automations.
 """
 
+import base64
+import binascii
 import hashlib
 import hmac
 import logging
+import time
 import uuid
 from collections.abc import Callable
 from typing import Any
@@ -88,6 +91,78 @@ def verify_signature(payload: bytes, signature: str, secret: str) -> bool:
     return hmac.compare_digest(computed, signature)
 
 
+# Standard Webhooks (https://www.standardwebhooks.com) — used by GitLab 19.1+
+# signing tokens, Svix, and others. Signature = base64(HMAC-SHA256(key, msg))
+# where msg = "{id}.{timestamp}.{body}" and key = base64decode(secret w/o whsec_).
+STANDARD_WEBHOOKS_TOLERANCE_SECONDS = 300
+
+
+def _standard_webhooks_key(secret: str) -> bytes:
+    """Derive the signing key from a Standard Webhooks secret.
+
+    Secrets are conventionally "whsec_<base64>": strip the prefix and
+    base64-decode. Fall back to raw UTF-8 bytes if not valid base64.
+    """
+    key_material = secret
+    if key_material.startswith("whsec_"):
+        key_material = key_material[len("whsec_") :]
+    try:
+        return base64.b64decode(key_material)
+    except (binascii.Error, ValueError):
+        return secret.encode("utf-8")
+
+
+def verify_standard_webhooks(
+    payload: bytes,
+    secret: str,
+    msg_id: str | None,
+    timestamp: str | None,
+    signature_header_value: str | None,
+    tolerance_seconds: int = STANDARD_WEBHOOKS_TOLERANCE_SECONDS,
+    now: int | None = None,
+) -> bool:
+    """Verify a Standard Webhooks signature.
+
+    Args:
+        payload: Raw request body bytes.
+        secret: Shared signing secret (e.g. "whsec_...").
+        msg_id: Value of the "webhook-id" header.
+        timestamp: Value of the "webhook-timestamp" header (unix seconds).
+        signature_header_value: Signature header value; a space-separated list
+            of "v1,<base64>" tokens.
+        tolerance_seconds: Max allowed clock skew (replay protection).
+        now: Current unix time; injectable for tests.
+
+    Returns:
+        True if a provided signature matches and the timestamp is fresh.
+    """
+    if not msg_id or not timestamp or not signature_header_value:
+        return False
+
+    try:
+        ts_int = int(timestamp)
+    except (TypeError, ValueError):
+        return False
+
+    current = int(time.time()) if now is None else now
+    if abs(current - ts_int) > tolerance_seconds:
+        return False
+
+    key = _standard_webhooks_key(secret)
+    signed_content = f"{msg_id}.{timestamp}.".encode() + payload
+    expected = base64.b64encode(
+        hmac.new(key, signed_content, hashlib.sha256).digest()
+    ).decode("utf-8")
+
+    for token in signature_header_value.split():
+        # Each token is "v{version},{signature}"; we support v1.
+        _version, _, sig = token.partition(",")
+        candidate = sig if sig else token
+        if hmac.compare_digest(candidate, expected):
+            return True
+    return False
+
+
 async def get_webhook_config(
     source: str,
     org_id: uuid.UUID,
@@ -136,6 +211,7 @@ async def get_webhook_config(
             is_builtin=False,
             event_key_expr=webhook.event_key_expr,
             signature_header=webhook.signature_header,
+            signature_scheme=webhook.signature_scheme,
         )
     return None
 

--- a/openhands/automation/webhook_router.py
+++ b/openhands/automation/webhook_router.py
@@ -62,6 +62,7 @@ def _webhook_to_response(webhook: CustomWebhook) -> CustomWebhookResponse:
         webhook_url=_build_webhook_url(webhook.org_id, webhook.source),
         event_key_expr=webhook.event_key_expr,
         signature_header=webhook.signature_header,
+        signature_scheme=webhook.signature_scheme,
         enabled=webhook.enabled,
         created_at=webhook.created_at,
         updated_at=webhook.updated_at,
@@ -120,6 +121,7 @@ async def create_webhook(
         webhook_secret=secret,
         event_key_expr=data.event_key_expr,
         signature_header=data.signature_header,
+        signature_scheme=data.signature_scheme,
         enabled=True,
     )
 

--- a/tests/test_webhook_utils.py
+++ b/tests/test_webhook_utils.py
@@ -9,8 +9,13 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from openhands.automation.db import set_sqlite_mode
-from openhands.automation.models import Automation, Base
-from openhands.automation.utils.webhook import get_event_automations, verify_signature
+from openhands.automation.models import Automation, Base, CustomWebhook
+from openhands.automation.utils.webhook import (
+    get_event_automations,
+    get_webhook_config,
+    verify_signature,
+    verify_standard_webhooks,
+)
 
 
 class TestVerifySignature:
@@ -320,3 +325,196 @@ class TestGetEventAutomationsSqliteJsonFiltering:
             assert result[0][0].id == active_automation.id
         finally:
             set_sqlite_mode(False)
+
+
+class TestVerifyStandardWebhooks:
+    """Tests for Standard Webhooks signature verification (GitLab 19.1+, Svix)."""
+
+    SECRET = "whsec_uX0GkGuuABEuIJhcJxNEotfG8+WjeIkZuJJqJdsm/CQ="
+    MSG_ID = "msg_2abc"
+    TS = "1752900000"
+
+    def _sign(
+        self,
+        payload: bytes,
+        secret: str | None = None,
+        msg_id: str | None = None,
+        ts: str | None = None,
+    ) -> str:
+        import base64 as _b64
+
+        secret = secret or self.SECRET
+        msg_id = msg_id or self.MSG_ID
+        ts = ts or self.TS
+        key_material = (
+            secret[len("whsec_") :] if secret.startswith("whsec_") else secret
+        )
+        try:
+            key = _b64.b64decode(key_material)
+        except Exception:
+            key = secret.encode()
+        signed = f"{msg_id}.{ts}.".encode() + payload
+        sig = _b64.b64encode(hmac.new(key, signed, hashlib.sha256).digest()).decode()
+        return f"v1,{sig}"
+
+    def test_valid_signature(self):
+        payload = b'{"object_kind":"note"}'
+        header = self._sign(payload)
+        assert (
+            verify_standard_webhooks(
+                payload, self.SECRET, self.MSG_ID, self.TS, header, now=int(self.TS)
+            )
+            is True
+        )
+
+    def test_missing_headers_return_false(self):
+        payload = b"{}"
+        header = self._sign(payload)
+        assert (
+            verify_standard_webhooks(
+                payload, self.SECRET, None, self.TS, header, now=int(self.TS)
+            )
+            is False
+        )
+        assert (
+            verify_standard_webhooks(
+                payload, self.SECRET, self.MSG_ID, None, header, now=int(self.TS)
+            )
+            is False
+        )
+        assert (
+            verify_standard_webhooks(
+                payload, self.SECRET, self.MSG_ID, self.TS, None, now=int(self.TS)
+            )
+            is False
+        )
+
+    def test_expired_timestamp(self):
+        payload = b"{}"
+        header = self._sign(payload)
+        # now is 10 minutes after the signed timestamp -> outside 300s tolerance
+        assert (
+            verify_standard_webhooks(
+                payload,
+                self.SECRET,
+                self.MSG_ID,
+                self.TS,
+                header,
+                now=int(self.TS) + 600,
+            )
+            is False
+        )
+
+    def test_within_tolerance(self):
+        payload = b"{}"
+        header = self._sign(payload)
+        assert (
+            verify_standard_webhooks(
+                payload,
+                self.SECRET,
+                self.MSG_ID,
+                self.TS,
+                header,
+                now=int(self.TS) + 120,
+            )
+            is True
+        )
+
+    def test_tampered_body(self):
+        header = self._sign(b'{"object_kind":"note"}')
+        assert (
+            verify_standard_webhooks(
+                b'{"object_kind":"issue"}',
+                self.SECRET,
+                self.MSG_ID,
+                self.TS,
+                header,
+                now=int(self.TS),
+            )
+            is False
+        )
+
+    def test_wrong_secret(self):
+        payload = b"{}"
+        header = self._sign(payload, secret="whsec_" + "A" * 32)
+        assert (
+            verify_standard_webhooks(
+                payload, self.SECRET, self.MSG_ID, self.TS, header, now=int(self.TS)
+            )
+            is False
+        )
+
+    def test_multiple_space_separated_signatures(self):
+        payload = b"{}"
+        good = self._sign(payload)
+        header = (
+            f"v1,AAAA{good.split(',', 1)[1][4:]} {good}"  # a bogus one + the good one
+        )
+        assert (
+            verify_standard_webhooks(
+                payload, self.SECRET, self.MSG_ID, self.TS, header, now=int(self.TS)
+            )
+            is True
+        )
+
+    def test_bad_timestamp_not_int(self):
+        payload = b"{}"
+        header = self._sign(payload)
+        assert (
+            verify_standard_webhooks(
+                payload,
+                self.SECRET,
+                self.MSG_ID,
+                "not-a-number",
+                header,
+                now=int(self.TS),
+            )
+            is False
+        )
+
+
+class TestGetWebhookConfigSignatureScheme:
+    """get_webhook_config threads the custom webhook's signature_scheme through."""
+
+    @pytest.mark.asyncio
+    async def test_custom_webhook_standard_webhooks_scheme(self, sqlite_session):
+        org_id = uuid.uuid4()
+        sqlite_session.add(
+            CustomWebhook(
+                id=uuid.uuid4(),
+                org_id=org_id,
+                name="GitLab",
+                source="gitlab",
+                webhook_secret="whsec_uX0GkGuuABEuIJhcJxNEotfG8+WjeIkZuJJqJdsm/CQ=",
+                event_key_expr="object_kind",
+                signature_header="webhook-signature",
+                signature_scheme="standard_webhooks",
+                enabled=True,
+            )
+        )
+        await sqlite_session.commit()
+
+        config = await get_webhook_config("gitlab", org_id, sqlite_session)
+        assert config is not None
+        assert config.signature_scheme == "standard_webhooks"
+        assert config.signature_header == "webhook-signature"
+        assert config.is_builtin is False
+
+    @pytest.mark.asyncio
+    async def test_custom_webhook_defaults_to_hex_scheme(self, sqlite_session):
+        org_id = uuid.uuid4()
+        sqlite_session.add(
+            CustomWebhook(
+                id=uuid.uuid4(),
+                org_id=org_id,
+                name="Generic",
+                source="generic",
+                webhook_secret="a-secret-value",
+                enabled=True,
+            )
+        )
+        await sqlite_session.commit()
+
+        config = await get_webhook_config("generic", org_id, sqlite_session)
+        assert config is not None
+        assert config.signature_scheme == "hmac_sha256_hex"


### PR DESCRIPTION
# feat(webhooks): add `signature_scheme` with Standard Webhooks support

## Problem
Custom webhooks always verify signatures using the **GitHub convention**:
`hex(HMAC-SHA256(secret, body))` in a single configurable header (`signature_header`).
Only the header *name* is configurable — the algorithm, encoding, key derivation, and
signed message are hard-coded in `verify_signature`.

This makes it impossible to receive **GitLab** webhooks. GitLab 19.1+ signs with the
[Standard Webhooks](https://www.standardwebhooks.com) spec, which differs on four axes:

| Attribute | OpenHands expects | GitLab / Standard Webhooks sends |
|---|---|---|
| Header | `X-Gitlab-Token` (name only) | `webhook-signature` |
| Message | `body` | `{id}.{timestamp}.{body}` |
| Encoding | hex | base64 |
| Key | literal secret string | `base64decode(secret without "whsec_")` |

Because none of message/encoding/key are configurable, GitLab (and Svix, and any other
Standard Webhooks producer) cannot be validated — users must run an external re-signing
proxy. The docs even ship a "Common Signature Headers by Service" table implying broad
support, but only header selection is actually supported.

## Change
Add a per-webhook **`signature_scheme`**:

- **`hmac_sha256_hex`** (default) — existing behavior, fully unchanged.
- **`standard_webhooks`** — verifies a `v1,<base64>` signature over
  `{webhook-id}.{webhook-timestamp}.{body}`, key = `base64decode(secret w/o "whsec_")`,
  and enforces a **timestamp freshness window** (default 300s) for replay protection —
  which also addresses the replay caveat noted in `event_router.py`.

Threaded through: `CustomWebhook` model, `WebhookConfig`,
`CustomWebhookCreate`/`Update`/`Response` schemas (with validation against the allowed
set), the event handler's verification branch, and a new Alembic migration.

## Usage
```bash
curl -X POST "$HOST/api/automation/v1/webhooks" -H "Authorization: Bearer $KEY" -d '{
  "name": "GitLab",
  "source": "gitlab",
  "event_key_expr": "object_kind",
  "signature_header": "webhook-signature",
  "signature_scheme": "standard_webhooks",
  "webhook_secret": "whsec_..."   # same value configured as GitLab signing token
}'
```
Then enable a **signing token** on the GitLab webhook. No proxy/middleware required.

## Files
- `openhands/automation/models.py` — `signature_scheme` column
- `migrations/versions/010_add_webhook_signature_scheme.py` — additive, `server_default='hmac_sha256_hex'`
- `openhands/automation/schemas.py` — field + validation on Create/Update/Response/WebhookConfig
- `openhands/automation/utils/webhook.py` — `verify_standard_webhooks()` + key derivation; config threading
- `openhands/automation/event_router.py` — scheme dispatch in the verify step
- `openhands/automation/webhook_router.py` — persist/return the field
- `tests/test_webhook_utils.py` — 10 new tests

## Testing
- `tests/test_webhook_utils.py`: **22 passed** (10 new — valid/invalid/expired/tampered/
  wrong-key/multi-sig/bad-timestamp/missing-headers, plus `get_webhook_config` threading
  for both schemes).
- `tests/test_webhook_router.py`: pass.
- `ruff check` + `ruff format --check`: clean.
- Migration `alembic upgrade head` / `downgrade -1` verified on SQLite (column added
  NOT NULL w/ default, dropped cleanly).
- Backward compatible: existing webhooks default to `hmac_sha256_hex`; no behavior change.

## Notes / follow-ups
- Stripe (`t=…,v1=…`) and Slack (`v0=…`) use yet other layouts; this PR adds the scheme
  dispatch point so they can follow as additional `signature_scheme` values.
