### PR TITLE
feat: add automation server info endpoint

### DIFF
--- a/openhands/automation/app.py
+++ b/openhands/automation/app.py
@@ -12,6 +12,7 @@ from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy import text
 
+from openhands.automation import __version__
 from openhands.automation.auth import create_http_client
 from openhands.automation.config import get_config, get_settings
 from openhands.automation.db import (
@@ -260,6 +261,11 @@ async def readiness():
         )
 
 
+def _get_sdk_version() -> str:
+    """Return the installed OpenHands SDK package version."""
+    return importlib.metadata.version("openhands-sdk")
+
+
 @app.get("/sdk-version")
 @app.get(f"{_base_path}/sdk-version")
 async def sdk_version():
@@ -271,13 +277,30 @@ async def sdk_version():
     are available in the sandbox.
     """
     try:
-        version = importlib.metadata.version("openhands-sdk")
+        version = _get_sdk_version()
     except importlib.metadata.PackageNotFoundError:
         return JSONResponse(
             status_code=503,
             content={"error": "openhands-sdk package not found"},
         )
     return {"version": version}
+
+
+@app.get("/server_info")
+@app.get(f"{_base_path}/server_info")
+async def server_info():
+    """Return public metadata about the automation service."""
+    try:
+        sdk_version = _get_sdk_version()
+    except importlib.metadata.PackageNotFoundError:
+        return JSONResponse(
+            status_code=503,
+            content={"error": "openhands-sdk package not found"},
+        )
+    return {
+        "package_version": __version__,
+        "sdk_version": sdk_version,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,39 +1,77 @@
 """Tests for health check endpoints."""
 
 import importlib.metadata
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from openhands.automation import __version__
 from openhands.automation.app import app
+
+
+@pytest.fixture
+async def health_client():
+    """Create an async client for endpoints that do not require a real DB."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        yield client
+
+
+class _ReadyConnection:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def execute(self, statement):
+        pass
+
+
+class _ReadyEngine:
+    def connect(self):
+        return _ReadyConnection()
+
+
+class _UnavailableEngine:
+    def connect(self):
+        raise Exception("DB connection failed")
 
 
 class TestHealthEndpoints:
     """Tests for health and readiness endpoints."""
 
-    def test_health_endpoint(self, sync_client):
+    async def test_health_endpoint(self, health_client):
         """GET /health returns ok status."""
-        response = sync_client.get("/api/automation/health")
+        response = await health_client.get("/api/automation/health")
 
         assert response.status_code == 200
         assert response.json() == {"status": "ok"}
 
-    async def test_ready_endpoint_success(self, async_client):
+    async def test_ready_endpoint_success(self, health_client):
         """GET /ready returns ready status when DB is available."""
-        # async_client fixture sets up app.state.engine
-        response = await async_client.get("/api/automation/ready")
-
-        assert response.status_code == 200
-        assert response.json() == {"status": "ready"}
-
-    async def test_ready_endpoint_db_unavailable(self, async_client):
-        """GET /ready returns 503 when DB is unavailable."""
-        original_engine = app.state.engine
-
-        mock_engine = AsyncMock()
-        mock_engine.connect.side_effect = Exception("DB connection failed")
-        app.state.engine = mock_engine
+        original_engine = getattr(app.state, "engine", None)
+        app.state.engine = _ReadyEngine()
 
         try:
-            response = await async_client.get("/api/automation/ready")
+            response = await health_client.get("/api/automation/ready")
+
+            assert response.status_code == 200
+            assert response.json() == {"status": "ready"}
+        finally:
+            app.state.engine = original_engine
+
+    async def test_ready_endpoint_db_unavailable(self, health_client):
+        """GET /ready returns 503 when DB is unavailable."""
+        original_engine = getattr(app.state, "engine", None)
+
+        app.state.engine = _UnavailableEngine()
+
+        try:
+            response = await health_client.get("/api/automation/ready")
 
             assert response.status_code == 503
             data = response.json()
@@ -46,31 +84,65 @@ class TestHealthEndpoints:
 class TestSdkVersionEndpoint:
     """Tests for GET /sdk-version — called by setup.sh on every automation run."""
 
-    async def test_returns_installed_sdk_version(self, async_client):
+    async def test_returns_installed_sdk_version(self, health_client):
         """GET /sdk-version returns the currently installed openhands-sdk version."""
-        response = await async_client.get("/api/automation/sdk-version")
+        response = await health_client.get("/api/automation/sdk-version")
 
         assert response.status_code == 200
         data = response.json()
         assert "version" in data
         assert data["version"] == importlib.metadata.version("openhands-sdk")
 
-    async def test_no_auth_required(self, async_client):
+    async def test_no_auth_required(self, health_client):
         """GET /sdk-version is accessible without any authentication token."""
         # Use a raw client without the auth headers the fixture normally adds
-        response = await async_client.get(
+        response = await health_client.get(
             "/api/automation/sdk-version",
             headers={},
         )
         assert response.status_code == 200
 
-    async def test_returns_503_when_package_not_found(self, async_client):
+    async def test_returns_503_when_package_not_found(self, health_client):
         """GET /sdk-version returns 503 when openhands-sdk is not installed."""
         with patch(
             "openhands.automation.app.importlib.metadata.version",
             side_effect=importlib.metadata.PackageNotFoundError("openhands-sdk"),
         ):
-            response = await async_client.get("/api/automation/sdk-version")
+            response = await health_client.get("/api/automation/sdk-version")
+
+        assert response.status_code == 503
+        data = response.json()
+        assert "error" in data
+
+
+class TestServerInfoEndpoint:
+    """Tests for GET /server_info — public automation service metadata."""
+
+    async def test_returns_package_and_sdk_versions(self, health_client):
+        """GET /server_info returns automation package and SDK versions."""
+        response = await health_client.get("/api/automation/server_info")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "package_version": __version__,
+            "sdk_version": importlib.metadata.version("openhands-sdk"),
+        }
+
+    async def test_no_auth_required(self, health_client):
+        """GET /server_info is accessible without any authentication token."""
+        response = await health_client.get(
+            "/api/automation/server_info",
+            headers={},
+        )
+        assert response.status_code == 200
+
+    async def test_returns_503_when_sdk_package_not_found(self, health_client):
+        """GET /server_info returns 503 when openhands-sdk is not installed."""
+        with patch(
+            "openhands.automation.app.importlib.metadata.version",
+            side_effect=importlib.metadata.PackageNotFoundError("openhands-sdk"),
+        ):
+            response = await health_client.get("/api/automation/server_info")
 
         assert response.status_code == 503
         data = response.json()


### PR DESCRIPTION
## Summary
- Add unauthenticated `/server_info` and `/api/automation/server_info` endpoints exposing automation package and SDK versions.
- Share SDK version lookup between the existing `/sdk-version` endpoint and the new server metadata endpoint.
- Update health/version endpoint tests to avoid Docker-backed fixtures and cover the new endpoint.

## Testing
- `uv run ruff check openhands/automation/app.py tests/test_health.py`
- `uv run pytest tests/test_health.py -v`

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4b4d68dc-4849-4349-bfe5-b83b3bf86504)