### PR TITLE
chore: Add missing index on automation_runs.automation_id

### DIFF
--- a/migrations/versions/010_add_automation_id_index.py
+++ b/migrations/versions/010_add_automation_id_index.py
@@ -1,0 +1,36 @@
+"""Add index on automation_runs.automation_id.
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-07-21
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+
+revision: str = "010"
+down_revision: str = "009"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # automation_id is declared index=True on the AutomationRun model, but the
+    # index is absent in production, so queries that filter runs by automation_id
+    # (e.g. the list-runs count + fetch) sequentially scan the whole table.
+    op.create_index(
+        "ix_automation_runs_automation_id",
+        "automation_runs",
+        ["automation_id"],
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_automation_runs_automation_id",
+        table_name="automation_runs",
+        if_exists=True,
+    )


### PR DESCRIPTION
## Why
`AutomationRun.automation_id` is declared `index=True` on the model, but the index does not exist in production — so the list-runs queries that filter by `automation_id` (a `count(*)` and a `SELECT … ORDER BY created_at DESC`) sequentially scan the entire `automation_runs` table on every call. This migration creates the missing declared index (`ix_automation_runs_automation_id`), turning those filters into index scans. It is a single non-unique index matching the model's existing declaration, with `if_not_exists=True` so it is a no-op if the index is already present. Scoped to just this index: the composite polling indexes from #160 already exist; this is the still-missing single-column index tracked in #157.

## Validation
Confirmed against the production database (read-only) that `ix_automation_runs_automation_id` is currently absent and the `WHERE automation_id = $1` list-runs queries plan as sequential scans over the full table — the exact access pattern this index serves.
