### PR TITLE
feat: capture automation telemetry events

### DIFF
--- a/migrations/versions/011_add_service_metadata.py
+++ b/migrations/versions/011_add_service_metadata.py
@@ -1,0 +1,54 @@
+"""Add service metadata table.
+
+Revision ID: 011
+Revises: 010
+Create Date: 2026-07-23
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "011"
+down_revision: str = "010"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sqlite() -> bool:
+    return op.get_bind().dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "automation_service_metadata",
+        sa.Column("key", sa.String(255), primary_key=True),
+        sa.Column("value", sa.Text, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+    )
+
+    if _is_sqlite():
+        return
+
+    op.execute(
+        "COMMENT ON TABLE automation_service_metadata IS "
+        "'Service-level metadata shared across automation deployment modes. "
+        "Stores singleton values such as the PostHog backend distinct ID.'"
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("automation_service_metadata")

--- a/openhands/automation/app.py
+++ b/openhands/automation/app.py
@@ -32,6 +32,7 @@ from openhands.automation.middleware import (
 from openhands.automation.preset_router import router as preset_router
 from openhands.automation.router import router
 from openhands.automation.scheduler import scheduler_loop
+from openhands.automation.telemetry_router import router as telemetry_router
 from openhands.automation.uploads import router as uploads_router
 from openhands.automation.watchdog import watchdog_loop
 from openhands.automation.webhook_router import router as webhook_router
@@ -239,6 +240,8 @@ app.include_router(uploads_router, prefix=_base_path)
 app.include_router(preset_router, prefix=_base_path)
 app.include_router(event_router, prefix=_base_path)
 app.include_router(webhook_router, prefix=_base_path)
+app.include_router(telemetry_router, prefix=_base_path)
+
 app.include_router(kv_router, prefix=_base_path)
 app.include_router(router, prefix=_base_path)
 

--- a/openhands/automation/app.py
+++ b/openhands/automation/app.py
@@ -6,8 +6,9 @@ import logging
 import os
 from contextlib import asynccontextmanager
 from pathlib import Path
+from time import perf_counter
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy import text
@@ -31,6 +32,10 @@ from openhands.automation.middleware import (
 from openhands.automation.preset_router import router as preset_router
 from openhands.automation.router import router
 from openhands.automation.scheduler import scheduler_loop
+from openhands.automation.telemetry import (
+    capture_api_route_event,
+    should_capture_api_route,
+)
 from openhands.automation.uploads import router as uploads_router
 from openhands.automation.watchdog import watchdog_loop
 from openhands.automation.webhook_router import router as webhook_router
@@ -214,6 +219,33 @@ def _create_app() -> FastAPI:
 
 
 app = _create_app()
+
+
+@app.middleware("http")
+async def api_route_telemetry_middleware(request: Request, call_next):
+    should_capture = should_capture_api_route(request)
+    started_at = perf_counter()
+
+    try:
+        response = await call_next(request)
+    except Exception as exc:
+        if should_capture:
+            await capture_api_route_event(
+                request,
+                status_code=500,
+                duration_ms=int((perf_counter() - started_at) * 1000),
+                exception_type=type(exc).__name__,
+            )
+        raise
+
+    if should_capture:
+        await capture_api_route_event(
+            request,
+            status_code=response.status_code,
+            duration_ms=int((perf_counter() - started_at) * 1000),
+        )
+    return response
+
 
 app.add_middleware(TelemetryContextMiddleware)
 

--- a/openhands/automation/app.py
+++ b/openhands/automation/app.py
@@ -6,9 +6,8 @@ import logging
 import os
 from contextlib import asynccontextmanager
 from pathlib import Path
-from time import perf_counter
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy import text
@@ -28,14 +27,11 @@ from openhands.automation.logger import setup_all_loggers
 from openhands.automation.middleware import (
     ApiKeyAwareCORSMiddleware,
     TelemetryContextMiddleware,
+    api_route_telemetry_middleware,
 )
 from openhands.automation.preset_router import router as preset_router
 from openhands.automation.router import router
 from openhands.automation.scheduler import scheduler_loop
-from openhands.automation.telemetry import (
-    capture_api_route_event,
-    should_capture_api_route,
-)
 from openhands.automation.uploads import router as uploads_router
 from openhands.automation.watchdog import watchdog_loop
 from openhands.automation.webhook_router import router as webhook_router
@@ -221,30 +217,7 @@ def _create_app() -> FastAPI:
 app = _create_app()
 
 
-@app.middleware("http")
-async def api_route_telemetry_middleware(request: Request, call_next):
-    should_capture = should_capture_api_route(request)
-    started_at = perf_counter()
-
-    try:
-        response = await call_next(request)
-    except Exception as exc:
-        if should_capture:
-            await capture_api_route_event(
-                request,
-                status_code=500,
-                duration_ms=int((perf_counter() - started_at) * 1000),
-                exception_type=type(exc).__name__,
-            )
-        raise
-
-    if should_capture:
-        await capture_api_route_event(
-            request,
-            status_code=response.status_code,
-            duration_ms=int((perf_counter() - started_at) * 1000),
-        )
-    return response
+app.middleware("http")(api_route_telemetry_middleware)
 
 
 app.add_middleware(TelemetryContextMiddleware)

--- a/openhands/automation/app.py
+++ b/openhands/automation/app.py
@@ -24,7 +24,10 @@ from openhands.automation.dispatcher import dispatcher_loop
 from openhands.automation.event_router import router as event_router
 from openhands.automation.kv_router import router as kv_router
 from openhands.automation.logger import setup_all_loggers
-from openhands.automation.middleware import ApiKeyAwareCORSMiddleware
+from openhands.automation.middleware import (
+    ApiKeyAwareCORSMiddleware,
+    TelemetryContextMiddleware,
+)
 from openhands.automation.preset_router import router as preset_router
 from openhands.automation.router import router
 from openhands.automation.scheduler import scheduler_loop
@@ -211,6 +214,8 @@ def _create_app() -> FastAPI:
 
 
 app = _create_app()
+
+app.add_middleware(TelemetryContextMiddleware)
 
 # API-key requests (e.g. the local agent-server GUI calling directly from the
 # browser) get permissive CORS; cookie/session requests keep the strict

--- a/openhands/automation/auth.py
+++ b/openhands/automation/auth.py
@@ -107,6 +107,13 @@ class AuthenticatedUser:
     active_model_profile_name: str | None = None
 
 
+def _store_authenticated_user(
+    request: Request, user: AuthenticatedUser
+) -> AuthenticatedUser:
+    request.state.authenticated_user = user
+    return user
+
+
 class _LLMProfiles(BaseModel):
     """Consuming subset of the upstream ``LLMProfiles`` model.
 
@@ -431,7 +438,7 @@ async def authenticate_request(
     if api_key and settings.is_local_mode and settings.local_api_key:
         if secrets.compare_digest(api_key, settings.local_api_key):
             logger.debug("Authenticated via local API key")
-            return _get_local_user()
+            return _store_authenticated_user(request, _get_local_user())
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid API key",
@@ -446,7 +453,7 @@ async def authenticate_request(
     cached_user = auth_cache.get(cache_key)
     if cached_user is not None:
         logger.debug("Auth cache hit for user %s", cached_user.user_id)
-        return cached_user
+        return _store_authenticated_user(request, cached_user)
 
     # --- Validate against OpenHands API ---
     logger.debug("Auth cache miss, validating with OpenHands API")
@@ -494,4 +501,4 @@ async def authenticate_request(
     # --- Build user and cache ---
     user = _parse_users_me(resp.json(), auth_method, credential)
     auth_cache[cache_key] = user
-    return user
+    return _store_authenticated_user(request, user)

--- a/openhands/automation/config.py
+++ b/openhands/automation/config.py
@@ -352,8 +352,6 @@ class ServiceSettings(BaseSettings):
         # Product telemetry (optional)
         AUTOMATION_POSTHOG_API_KEY: PostHog project key. Empty disables capture.
         AUTOMATION_POSTHOG_HOST: PostHog capture host (default: https://us.i.posthog.com)
-        AUTOMATION_TELEMETRY_BACKEND_ID_PATH: Local-mode persistent backend ID path
-            (default: ~/.openhands/automation/telemetry-backend-id)
     """
 
     # Database (PostgreSQL - Cloud mode)
@@ -456,7 +454,6 @@ class ServiceSettings(BaseSettings):
     # project key is configured by the deployment.
     posthog_api_key: str = ""
     posthog_host: str = "https://us.i.posthog.com"
-    telemetry_backend_id_path: str = ""
 
     model_config = {"env_prefix": "AUTOMATION_"}
 

--- a/openhands/automation/config.py
+++ b/openhands/automation/config.py
@@ -348,6 +348,12 @@ class ServiceSettings(BaseSettings):
         AUTOMATION_SERVICE_KEY: Service key for SaaS API (required in cloud mode)
         AUTOMATION_WEBHOOK_SECRET: Webhook signature secret (optional)
         AUTOMATION_OPENHANDS_API_BASE_URL: OpenHands API URL (default: https://app.all-hands.dev)
+
+        # Product telemetry (optional)
+        AUTOMATION_POSTHOG_API_KEY: PostHog project key. Empty disables capture.
+        AUTOMATION_POSTHOG_HOST: PostHog capture host (default: https://us.i.posthog.com)
+        AUTOMATION_TELEMETRY_BACKEND_ID_PATH: Local-mode persistent backend ID path
+            (default: ~/.openhands/automation/telemetry-backend-id)
     """
 
     # Database (PostgreSQL - Cloud mode)
@@ -445,6 +451,12 @@ class ServiceSettings(BaseSettings):
     # Event-based triggers: Shared secret for verifying webhook signatures
     # Used by the OpenHands server when forwarding GitHub events
     webhook_secret: str = ""
+
+    # Optional PostHog product telemetry. Capture remains disabled unless a
+    # project key is configured by the deployment.
+    posthog_api_key: str = ""
+    posthog_host: str = "https://us.i.posthog.com"
+    telemetry_backend_id_path: str = ""
 
     model_config = {"env_prefix": "AUTOMATION_"}
 

--- a/openhands/automation/dispatcher.py
+++ b/openhands/automation/dispatcher.py
@@ -192,6 +192,7 @@ async def _execute_run(
             "automation_run_failed",
             automation=automation,
             run=run,
+            session_factory=session_factory,
             properties={
                 "trigger_source": "dispatcher",
                 "failure_kind": "dispatch_error",
@@ -220,6 +221,7 @@ async def _execute_run(
             "automation_run_skipped",
             automation=automation,
             run=run,
+            session_factory=session_factory,
             properties={
                 "trigger_source": "dispatcher",
                 "skip_reason": "concurrency_limit",
@@ -413,6 +415,7 @@ async def dispatch_pending_runs(
                     automation=run.automation,
                     run=run,
                     properties={"trigger_source": "dispatcher"},
+                    session=session,
                 )
 
         await session.commit()
@@ -423,12 +426,14 @@ async def dispatch_pending_runs(
                 automation=run.automation,
                 run=run,
                 properties={"trigger_source": "dispatcher"},
+                session_factory=session_factory,
             )
             await capture_automation_event(
                 "automation_run_started",
                 automation=run.automation,
                 run=run,
                 properties={"trigger_source": "dispatcher"},
+                session_factory=session_factory,
             )
             asyncio.create_task(
                 _execute_run_safe(run, settings, session_factory, client),

--- a/openhands/automation/dispatcher.py
+++ b/openhands/automation/dispatcher.py
@@ -428,13 +428,6 @@ async def dispatch_pending_runs(
                 properties={"trigger_source": "dispatcher"},
                 session_factory=session_factory,
             )
-            await capture_automation_event(
-                "automation_run_started",
-                automation=run.automation,
-                run=run,
-                properties={"trigger_source": "dispatcher"},
-                session_factory=session_factory,
-            )
             asyncio.create_task(
                 _execute_run_safe(run, settings, session_factory, client),
                 name=f"execute-run-{run.id}",

--- a/openhands/automation/dispatcher.py
+++ b/openhands/automation/dispatcher.py
@@ -408,10 +408,22 @@ async def dispatch_pending_runs(
                 dispatched_runs.append(run)
             except Exception:
                 logger.exception("Failed to dispatch run", extra=extra)
+                await capture_automation_event(
+                    "automation_run_dispatch_failed",
+                    automation=run.automation,
+                    run=run,
+                    properties={"trigger_source": "dispatcher"},
+                )
 
         await session.commit()
 
         for run in dispatched_runs:
+            await capture_automation_event(
+                "automation_run_dispatched",
+                automation=run.automation,
+                run=run,
+                properties={"trigger_source": "dispatcher"},
+            )
             await capture_automation_event(
                 "automation_run_started",
                 automation=run.automation,

--- a/openhands/automation/dispatcher.py
+++ b/openhands/automation/dispatcher.py
@@ -41,6 +41,7 @@ from openhands.automation.models import (
     AutomationRunStatus,
     TarballUpload,
 )
+from openhands.automation.telemetry import capture_automation_event
 from openhands.automation.utils import log_extra
 from openhands.automation.utils.api_key import APIKeyError
 from openhands.automation.utils.kv import create_kv_token
@@ -187,6 +188,16 @@ async def _execute_run(
     async def _fail(error: str, disable: bool = False) -> None:
         """Mark run as failed and optionally disable the automation."""
         await mark_run_terminal(session_factory, run, AutomationRunStatus.FAILED, error)
+        await capture_automation_event(
+            "automation_run_failed",
+            automation=automation,
+            run=run,
+            properties={
+                "trigger_source": "dispatcher",
+                "failure_kind": "dispatch_error",
+                "automation_disabled": disable,
+            },
+        )
         if disable:
             await disable_automation(session_factory, automation.id, error)
 
@@ -205,6 +216,15 @@ async def _execute_run(
             extra=_log_ctx(),
         )
         await mark_run_terminal(session_factory, run, AutomationRunStatus.SKIPPED)
+        await capture_automation_event(
+            "automation_run_skipped",
+            automation=automation,
+            run=run,
+            properties={
+                "trigger_source": "dispatcher",
+                "skip_reason": "concurrency_limit",
+            },
+        )
         return
     except Exception:
         logger.exception("Failed to get execution context", extra=_log_ctx())
@@ -392,6 +412,12 @@ async def dispatch_pending_runs(
         await session.commit()
 
         for run in dispatched_runs:
+            await capture_automation_event(
+                "automation_run_started",
+                automation=run.automation,
+                run=run,
+                properties={"trigger_source": "dispatcher"},
+            )
             asyncio.create_task(
                 _execute_run_safe(run, settings, session_factory, client),
                 name=f"execute-run-{run.id}",

--- a/openhands/automation/event_router.py
+++ b/openhands/automation/event_router.py
@@ -152,6 +152,15 @@ async def receive_event(
             org_id,
             e,
         )
+        await capture_automation_event(
+            "automation_event_ignored",
+            request=request,
+            properties={
+                "event_source": source,
+                "org_id": str(org_id),
+                "ignore_reason": "unrecognized_event",
+            },
+        )
         return EventResponse(received=True, matched=0, runs_created=[])
     except Exception as e:
         logger.warning("Failed to parse event: %s", e)
@@ -162,6 +171,16 @@ async def receive_event(
         source,
         event.event_key,
         org_id,
+    )
+    await capture_automation_event(
+        "automation_event_received",
+        request=request,
+        properties={
+            "event_source": source,
+            "event_key": event.event_key,
+            "org_id": str(org_id),
+            "webhook_builtin": config.is_builtin,
+        },
     )
 
     # 6. Find matching automations
@@ -179,6 +198,17 @@ async def receive_event(
         len(automations),
         org_id,
     )
+    await capture_automation_event(
+        "automation_event_matched",
+        request=request,
+        properties={
+            "event_source": source,
+            "event_key": event.event_key,
+            "org_id": str(org_id),
+            "candidate_count": len(automations),
+            "matched_count": len(matched_automations),
+        },
+    )
 
     # 7. Create PENDING runs for matched automations
     # For Pydantic-parsed events (GitHub), use model_dump() for typed fields
@@ -195,11 +225,24 @@ async def receive_event(
             automation, session, event_payload=event_payload
         )
         run_ids.append(str(run.id))
+        run_properties = {
+            "trigger_source": "event",
+            "event_source": source,
+            "event_key": event.event_key,
+        }
         await capture_automation_event(
-            "automation_run_created",
+            "automation_run_scheduled",
+            request=request,
             automation=automation,
             run=run,
-            properties={"trigger_source": "event", "event_source": source},
+            properties=run_properties,
+        )
+        await capture_automation_event(
+            "automation_run_created",
+            request=request,
+            automation=automation,
+            run=run,
+            properties=run_properties,
         )
 
     await session.commit()

--- a/openhands/automation/event_router.py
+++ b/openhands/automation/event_router.py
@@ -40,6 +40,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from openhands.automation.db import get_session
 from openhands.automation.event_schemas import WebhookEvent, parse_event
 from openhands.automation.schemas import EventResponse
+from openhands.automation.telemetry import capture_automation_event
 from openhands.automation.trigger_matcher import matches_trigger
 from openhands.automation.utils.webhook import (
     create_automation_run,
@@ -194,6 +195,12 @@ async def receive_event(
             automation, session, event_payload=event_payload
         )
         run_ids.append(str(run.id))
+        await capture_automation_event(
+            "automation_run_created",
+            automation=automation,
+            run=run,
+            properties={"trigger_source": "event", "event_source": source},
+        )
 
     await session.commit()
 

--- a/openhands/automation/middleware.py
+++ b/openhands/automation/middleware.py
@@ -1,7 +1,9 @@
 """ASGI middleware for the automations service."""
 
 from dataclasses import dataclass
+from time import perf_counter
 
+from fastapi import Request
 from starlette.middleware.cors import CORSMiddleware
 from starlette.types import ASGIApp, Receive, Scope, Send
 
@@ -54,6 +56,36 @@ class TelemetryContextMiddleware:
                 build_telemetry_request_context(scope)
             )
         await self.app(scope, receive, send)
+
+
+async def api_route_telemetry_middleware(request: Request, call_next):
+    from openhands.automation.telemetry import (
+        capture_api_route_event,
+        should_capture_api_route,
+    )
+
+    should_capture = should_capture_api_route(request)
+    started_at = perf_counter()
+
+    try:
+        response = await call_next(request)
+    except Exception as exc:
+        if should_capture:
+            await capture_api_route_event(
+                request,
+                status_code=500,
+                duration_ms=int((perf_counter() - started_at) * 1000),
+                exception_type=type(exc).__name__,
+            )
+        raise
+
+    if should_capture:
+        await capture_api_route_event(
+            request,
+            status_code=response.status_code,
+            duration_ms=int((perf_counter() - started_at) * 1000),
+        )
+    return response
 
 
 # Header names (lowercase) that carry an explicit API key. Cookie auth is

--- a/openhands/automation/middleware.py
+++ b/openhands/automation/middleware.py
@@ -1,7 +1,59 @@
 """ASGI middleware for the automations service."""
 
+from dataclasses import dataclass
+
 from starlette.middleware.cors import CORSMiddleware
 from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+TELEMETRY_DISTINCT_ID_HEADER = "x-openhands-telemetry-distinct-id"
+CLIENT_SOURCE_HEADER = "x-openhands-client"
+CLIENT_VERSION_HEADER = "x-openhands-client-version"
+
+
+@dataclass(frozen=True)
+class TelemetryRequestContext:
+    frontend_distinct_id: str | None = None
+    client_source: str | None = None
+    client_version: str | None = None
+
+
+def _clean_header(value: bytes | None, max_length: int = 256) -> str | None:
+    if value is None:
+        return None
+    decoded = value.decode("latin-1").strip()
+    if not decoded:
+        return None
+    return decoded[:max_length]
+
+
+def build_telemetry_request_context(scope: Scope) -> TelemetryRequestContext:
+    headers = dict(scope.get("headers") or [])
+    return TelemetryRequestContext(
+        frontend_distinct_id=_clean_header(
+            headers.get(TELEMETRY_DISTINCT_ID_HEADER.encode("latin-1"))
+        ),
+        client_source=_clean_header(
+            headers.get(CLIENT_SOURCE_HEADER.encode("latin-1"))
+        ),
+        client_version=_clean_header(
+            headers.get(CLIENT_VERSION_HEADER.encode("latin-1"))
+        ),
+    )
+
+
+class TelemetryContextMiddleware:
+    """Extract best-effort frontend telemetry context from request headers."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http":
+            scope.setdefault("state", {})["telemetry_context"] = (
+                build_telemetry_request_context(scope)
+            )
+        await self.app(scope, receive, send)
 
 
 # Header names (lowercase) that carry an explicit API key. Cookie auth is

--- a/openhands/automation/models.py
+++ b/openhands/automation/models.py
@@ -329,6 +329,26 @@ class CustomWebhook(Base):
     )
 
 
+class AutomationServiceMetadata(Base):
+    """Service-level metadata shared by all automation deployment modes."""
+
+    __tablename__ = "automation_service_metadata"
+
+    key: Mapped[str] = mapped_column(String(255), primary_key=True)
+    value: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=text("CURRENT_TIMESTAMP"),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=text("CURRENT_TIMESTAMP"),
+        onupdate=utcnow,
+        nullable=False,
+    )
+
+
 class AutomationKV(Base):
     """Single-document state store for automation persistence.
 

--- a/openhands/automation/preset_router.py
+++ b/openhands/automation/preset_router.py
@@ -19,7 +19,7 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -30,6 +30,7 @@ from openhands.automation.db import get_session
 from openhands.automation.models import Automation, TarballUpload, UploadStatus
 from openhands.automation.schemas import AutomationResponse, Trigger
 from openhands.automation.storage import FileStore, get_file_store
+from openhands.automation.telemetry import capture_automation_event
 from openhands.automation.utils import utcnow
 from openhands.automation.utils.model_profiles import resolve_model_profile_for_user
 from openhands.automation.utils.tarball_validation import (
@@ -384,6 +385,7 @@ async def regenerate_preset_prompt_tarball(
 @router.post("/prompt", status_code=status.HTTP_201_CREATED)
 async def create_automation_from_prompt(
     body: CreatePromptAutomationRequest,
+    request: Request,
     user: AuthenticatedUser = Depends(authenticate_request),
     session: AsyncSession = Depends(get_session),
     file_store: FileStore = Depends(get_file_store),
@@ -484,6 +486,13 @@ async def create_automation_from_prompt(
             "upload_id": str(upload_id),
             "prompt_length": len(body.prompt),
         },
+    )
+    await capture_automation_event(
+        "automation_created",
+        request=request,
+        user=user,
+        automation=automation,
+        properties={"creation_path": "prompt_preset"},
     )
 
     return AutomationResponse.model_validate(automation)
@@ -731,6 +740,7 @@ def _format_plugin_sources_for_description(plugins: list[PluginSource]) -> str:
 @router.post("/plugin", status_code=status.HTTP_201_CREATED)
 async def create_automation_from_plugin(
     body: CreatePluginAutomationRequest,
+    request: Request,
     user: AuthenticatedUser = Depends(authenticate_request),
     session: AsyncSession = Depends(get_session),
     file_store: FileStore = Depends(get_file_store),
@@ -862,5 +872,15 @@ async def create_automation_from_plugin(
         log_extra["plugin_count"] = len(body.plugins)
 
     logger.info("Created automation from plugin", extra=log_extra)
+    await capture_automation_event(
+        "automation_created",
+        request=request,
+        user=user,
+        automation=automation,
+        properties={
+            "creation_path": "plugin_preset",
+            "plugin_count": len(body.plugins or []),
+        },
+    )
 
     return AutomationResponse.model_validate(automation)

--- a/openhands/automation/router.py
+++ b/openhands/automation/router.py
@@ -5,7 +5,7 @@ import logging
 import re
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.responses import RedirectResponse
 from sqlalchemy import func, select, update
 from sqlalchemy.engine import CursorResult
@@ -31,6 +31,7 @@ from openhands.automation.schemas import (
     UpdateAutomationRequest,
 )
 from openhands.automation.storage import FileStore, get_file_store
+from openhands.automation.telemetry import capture_automation_event
 from openhands.automation.utils import utcnow
 from openhands.automation.utils.api_key import (
     APIKeyError,
@@ -60,6 +61,7 @@ _require_manage_automations = require_permission("manage_automations")
 @router.post("", status_code=status.HTTP_201_CREATED)
 async def create_automation(
     body: CreateAutomationRequest,
+    request: Request,
     user: AuthenticatedUser = Depends(_require_manage_automations),
     session: AsyncSession = Depends(get_session),
 ) -> AutomationResponse:
@@ -93,6 +95,13 @@ async def create_automation(
     session.add(auto)
     await session.flush()
     await session.refresh(auto)
+    await capture_automation_event(
+        "automation_created",
+        request=request,
+        user=user,
+        automation=auto,
+        properties={"creation_path": "raw"},
+    )
     return AutomationResponse.model_validate(auto)
 
 
@@ -141,6 +150,7 @@ async def get_automation(
 async def update_automation(
     automation_id: uuid.UUID,
     body: UpdateAutomationRequest,
+    request: Request,
     user: AuthenticatedUser = Depends(_require_manage_automations),
     session: AsyncSession = Depends(get_session),
 ) -> AutomationResponse:
@@ -178,12 +188,20 @@ async def update_automation(
     # Note: updated_at is handled automatically by the model's onupdate=utcnow
     await session.flush()
     await session.refresh(auto)
+    await capture_automation_event(
+        "automation_updated",
+        request=request,
+        user=user,
+        automation=auto,
+        properties={"updated_fields": sorted(update_data.keys())},
+    )
     return AutomationResponse.model_validate(auto)
 
 
 @router.delete("/{automation_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_automation(
     automation_id: uuid.UUID,
+    request: Request,
     user: AuthenticatedUser = Depends(_require_manage_automations),
     session: AsyncSession = Depends(get_session),
 ) -> None:
@@ -192,6 +210,12 @@ async def delete_automation(
     auto.enabled = False
     auto.deleted_at = utcnow()
     await session.flush()
+    await capture_automation_event(
+        "automation_deleted",
+        request=request,
+        user=user,
+        automation=auto,
+    )
 
 
 @router.get("/{automation_id}/tarball")
@@ -267,6 +291,7 @@ async def download_automation_tarball(
 @router.post("/{automation_id}/dispatch", status_code=status.HTTP_201_CREATED)
 async def dispatch_automation(
     automation_id: uuid.UUID,
+    request: Request,
     user: AuthenticatedUser = Depends(_require_manage_automations),
     session: AsyncSession = Depends(get_session),
 ) -> AutomationRunResponse:
@@ -279,6 +304,14 @@ async def dispatch_automation(
     run = await create_pending_run(session, auto)
     await session.flush()
     await session.refresh(run)
+    await capture_automation_event(
+        "automation_run_created",
+        request=request,
+        user=user,
+        automation=auto,
+        run=run,
+        properties={"trigger_source": "manual"},
+    )
     return AutomationRunResponse.model_validate(run)
 
 
@@ -326,6 +359,7 @@ async def list_automation_runs(
 async def complete_run(
     run_id: uuid.UUID,
     body: RunCompleteRequest,
+    request: Request,
     user: AuthenticatedUser = Depends(_require_manage_automations),
     session: AsyncSession = Depends(get_session),
 ) -> AutomationRunResponse:
@@ -393,6 +427,16 @@ async def complete_run(
 
     await session.refresh(run)
     logger.info("Run %s → %s", run_id, new_status.value)
+    await capture_automation_event(
+        "automation_run_completed"
+        if new_status == AutomationRunStatus.COMPLETED
+        else "automation_run_failed",
+        request=request,
+        user=user,
+        automation=automation,
+        run=run,
+        properties={"trigger_source": "callback"},
+    )
 
     # Clean up immediately when this automation owns explicit cleanup. Once
     # post-run callbacks exist, this path should run them before deleting.
@@ -434,6 +478,7 @@ async def complete_run(
 @router.post("/runs/{run_id}/cancel")
 async def cancel_run(
     run_id: uuid.UUID,
+    request: Request,
     user: AuthenticatedUser = Depends(_require_manage_automations),
     session: AsyncSession = Depends(get_session),
 ) -> AutomationRunResponse:
@@ -491,6 +536,14 @@ async def cancel_run(
 
     await session.refresh(run)
     logger.info("Run %s cancelled by user", run_id)
+    await capture_automation_event(
+        "automation_run_cancelled",
+        request=request,
+        user=user,
+        automation=automation,
+        run=run,
+        properties={"trigger_source": "manual"},
+    )
 
     # Clean up sandbox for runs that were RUNNING
     if run.sandbox_id:

--- a/openhands/automation/scheduler.py
+++ b/openhands/automation/scheduler.py
@@ -194,11 +194,23 @@ async def poll_and_schedule(
             try:
                 run = await create_pending_run(session, automation)
                 created_runs.append(run)
+                schedule_properties = {
+                    "trigger_source": "cron",
+                    "schedule": automation.trigger.get("schedule")
+                    if isinstance(automation.trigger, dict)
+                    else None,
+                }
+                await capture_automation_event(
+                    "automation_run_scheduled",
+                    automation=automation,
+                    run=run,
+                    properties=schedule_properties,
+                )
                 await capture_automation_event(
                     "automation_run_created",
                     automation=automation,
                     run=run,
-                    properties={"trigger_source": "cron"},
+                    properties=schedule_properties,
                 )
                 logger.info(
                     "Created pending run: run_id=%s automation_id=%s "

--- a/openhands/automation/scheduler.py
+++ b/openhands/automation/scheduler.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from openhands.automation.db import using_sqlite
 from openhands.automation.models import Automation, AutomationRun
+from openhands.automation.telemetry import capture_automation_event
 from openhands.automation.utils import get_next_fire_time, is_automation_due, utcnow
 from openhands.automation.utils.run import create_pending_run
 
@@ -193,6 +194,12 @@ async def poll_and_schedule(
             try:
                 run = await create_pending_run(session, automation)
                 created_runs.append(run)
+                await capture_automation_event(
+                    "automation_run_created",
+                    automation=automation,
+                    run=run,
+                    properties={"trigger_source": "cron"},
+                )
                 logger.info(
                     "Created pending run: run_id=%s automation_id=%s "
                     "name=%s schedule=%s",

--- a/openhands/automation/scheduler.py
+++ b/openhands/automation/scheduler.py
@@ -205,12 +205,14 @@ async def poll_and_schedule(
                     automation=automation,
                     run=run,
                     properties=schedule_properties,
+                    session=session,
                 )
                 await capture_automation_event(
                     "automation_run_created",
                     automation=automation,
                     run=run,
                     properties=schedule_properties,
+                    session=session,
                 )
                 logger.info(
                     "Created pending run: run_id=%s automation_id=%s "

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -578,6 +578,21 @@ class CustomWebhookListResponse(BaseModel):
     total: int
 
 
+class TelemetryConsentRequest(BaseModel):
+    """Frontend telemetry consent state for local automation telemetry."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    consent_granted: bool
+    frontend_distinct_id: str | None = Field(default=None, max_length=256)
+
+
+class TelemetryConsentResponse(BaseModel):
+    """Stored aggregate telemetry consent for this automation service."""
+
+    consent_granted: bool
+
+
 # --- Responses ---
 
 

--- a/openhands/automation/telemetry.py
+++ b/openhands/automation/telemetry.py
@@ -3,11 +3,12 @@
 import logging
 import re
 import uuid
-from pathlib import Path
 from typing import Any
 
 import httpx
 from fastapi import Request
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from openhands.automation.auth import AuthenticatedUser
 from openhands.automation.config import get_config
@@ -15,7 +16,11 @@ from openhands.automation.middleware import (
     TelemetryRequestContext,
     build_telemetry_request_context,
 )
-from openhands.automation.models import Automation, AutomationRun
+from openhands.automation.models import (
+    Automation,
+    AutomationRun,
+    AutomationServiceMetadata,
+)
 
 
 logger = logging.getLogger("automation.telemetry")
@@ -23,41 +28,64 @@ AUTOMATION_BACKEND_ID_PROPERTY = "automation_backend_id"
 FRONTEND_DISTINCT_ID_PROPERTY = "frontend_distinct_id"
 POSTHOG_CAPTURE_PATH = "/capture/"
 API_EVENT_PREFIX = "automation_api"
+TELEMETRY_BACKEND_DISTINCT_ID_KEY = "posthog_backend_distinct_id"
 _PUBLIC_API_ROUTE_PATHS = frozenset(
     {"/health", "/ready", "/sdk-version", "/server_info"}
 )
 
 
-def _default_backend_id_path() -> Path:
-    return Path.home() / ".openhands" / "automation" / "telemetry-backend-id"
+async def _get_or_create_backend_distinct_id(session: AsyncSession) -> str:
+    existing = await session.scalar(
+        select(AutomationServiceMetadata.value).where(
+            AutomationServiceMetadata.key == TELEMETRY_BACKEND_DISTINCT_ID_KEY
+        )
+    )
+    if existing:
+        return existing
 
-
-def get_local_backend_distinct_id() -> str:
-    """Return a stable local-mode backend telemetry distinct ID."""
-    settings = get_config().service
-    path = (
-        Path(settings.telemetry_backend_id_path).expanduser()
-        if settings.telemetry_backend_id_path
-        else _default_backend_id_path()
+    generated = f"automation-backend:{uuid.uuid4()}"
+    await session.execute(
+        text(
+            "INSERT INTO automation_service_metadata (key, value) "
+            "VALUES (:key, :value) ON CONFLICT (key) DO NOTHING"
+        ),
+        {"key": TELEMETRY_BACKEND_DISTINCT_ID_KEY, "value": generated},
+    )
+    return (
+        await session.scalar(
+            select(AutomationServiceMetadata.value).where(
+                AutomationServiceMetadata.key == TELEMETRY_BACKEND_DISTINCT_ID_KEY
+            )
+        )
+        or generated
     )
 
-    try:
-        existing = path.read_text().strip()
-        if existing:
-            return existing
-    except FileNotFoundError:
-        pass
-    except Exception:
-        logger.exception("Failed to read automation telemetry backend ID")
 
-    generated = f"automation-local:{uuid.uuid4()}"
+async def get_automation_backend_distinct_id(
+    *,
+    request: Request | None = None,
+    session: AsyncSession | None = None,
+    session_factory: async_sessionmaker[AsyncSession] | None = None,
+) -> str | None:
+    """Return the DB-backed automation backend PostHog distinct ID."""
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(f"{generated}\n")
-        path.chmod(0o600)
+        if session is not None:
+            return await _get_or_create_backend_distinct_id(session)
+
+        if session_factory is None and request is not None:
+            session_factory = getattr(request.app.state, "session_factory", None)
+
+        if session_factory is None:
+            logger.debug("No database session available for automation telemetry ID")
+            return None
+
+        async with session_factory() as new_session:
+            distinct_id = await _get_or_create_backend_distinct_id(new_session)
+            await new_session.commit()
+            return distinct_id
     except Exception:
-        logger.exception("Failed to persist automation telemetry backend ID")
-    return generated
+        logger.debug("Failed to load automation telemetry backend ID", exc_info=True)
+        return None
 
 
 def get_request_telemetry_context(request: Request | None) -> TelemetryRequestContext:
@@ -136,13 +164,8 @@ def _trigger_type(automation: Automation | None) -> str | None:
     return str(trigger) if trigger is not None else None
 
 
-def _resolve_distinct_id(
-    *,
-    request_context: TelemetryRequestContext,
-) -> str:
-    if request_context.frontend_distinct_id:
-        return request_context.frontend_distinct_id
-    return get_local_backend_distinct_id()
+def _resolve_distinct_id(*, backend_distinct_id: str) -> str:
+    return backend_distinct_id
 
 
 def _base_properties(
@@ -151,6 +174,7 @@ def _base_properties(
     user: AuthenticatedUser | None,
     automation: Automation | None,
     run: AutomationRun | None,
+    backend_distinct_id: str,
 ) -> dict[str, Any]:
     settings = get_config().service
     properties: dict[str, Any] = {
@@ -158,7 +182,7 @@ def _base_properties(
         "automation_service": "openhands_automation",
     }
 
-    properties[AUTOMATION_BACKEND_ID_PROPERTY] = get_local_backend_distinct_id()
+    properties[AUTOMATION_BACKEND_ID_PROPERTY] = backend_distinct_id
 
     if request_context.frontend_distinct_id:
         properties[FRONTEND_DISTINCT_ID_PROPERTY] = request_context.frontend_distinct_id
@@ -222,6 +246,8 @@ async def capture_automation_event(
     automation: Automation | None = None,
     run: AutomationRun | None = None,
     properties: dict[str, Any] | None = None,
+    session: AsyncSession | None = None,
+    session_factory: async_sessionmaker[AsyncSession] | None = None,
 ) -> None:
     """Capture a sanitized automation product event without affecting callers."""
     settings = get_config().service
@@ -229,11 +255,20 @@ async def capture_automation_event(
         return
 
     context = request_context or get_request_telemetry_context(request)
+    backend_distinct_id = await get_automation_backend_distinct_id(
+        request=request,
+        session=session,
+        session_factory=session_factory,
+    )
+    if backend_distinct_id is None:
+        return
+
     event_properties = _base_properties(
         request_context=context,
         user=user,
         automation=automation,
         run=run,
+        backend_distinct_id=backend_distinct_id,
     )
     if properties:
         event_properties.update(properties)
@@ -241,7 +276,7 @@ async def capture_automation_event(
     payload = {
         "api_key": settings.posthog_api_key,
         "event": event,
-        "distinct_id": _resolve_distinct_id(request_context=context),
+        "distinct_id": _resolve_distinct_id(backend_distinct_id=backend_distinct_id),
         "properties": event_properties,
     }
 

--- a/openhands/automation/telemetry.py
+++ b/openhands/automation/telemetry.py
@@ -33,7 +33,6 @@ TELEMETRY_CONSENT_ANONYMOUS_ID = "__anonymous__"
 
 API_EVENT_PREFIX = "automation_api"
 TELEMETRY_BACKEND_DISTINCT_ID_KEY = "posthog_backend_distinct_id"
-_PUBLIC_API_ROUTE_PATHS = frozenset({"/health", "/ready", "/server_info"})
 
 
 async def _get_or_create_backend_distinct_id(session: AsyncSession) -> str:
@@ -218,13 +217,8 @@ def should_capture_api_route(request: Request) -> bool:
     path = request.url.path
     settings = get_config().service
     base_path = settings.base_path.rstrip("/")
-    base_public_paths = {f"{base_path}{route}" for route in _PUBLIC_API_ROUTE_PATHS}
 
-    return (
-        path.startswith(f"{base_path}/v1")
-        or path in _PUBLIC_API_ROUTE_PATHS
-        or path in base_public_paths
-    )
+    return path.startswith(f"{base_path}/v1")
 
 
 async def capture_api_route_event(

--- a/openhands/automation/telemetry.py
+++ b/openhands/automation/telemetry.py
@@ -1,6 +1,7 @@
 """Best-effort PostHog product telemetry for automation lifecycle events."""
 
 import logging
+import re
 import uuid
 from pathlib import Path
 from typing import Any
@@ -21,6 +22,10 @@ logger = logging.getLogger("automation.telemetry")
 AUTOMATION_BACKEND_ID_PROPERTY = "automation_backend_id"
 FRONTEND_DISTINCT_ID_PROPERTY = "frontend_distinct_id"
 POSTHOG_CAPTURE_PATH = "/capture/"
+API_EVENT_PREFIX = "automation_api"
+_PUBLIC_API_ROUTE_PATHS = frozenset(
+    {"/health", "/ready", "/sdk-version", "/server_info"}
+)
 
 
 def _default_backend_id_path() -> Path:
@@ -62,6 +67,65 @@ def get_request_telemetry_context(request: Request | None) -> TelemetryRequestCo
     if isinstance(context, TelemetryRequestContext):
         return context
     return build_telemetry_request_context(request.scope)
+
+
+def _clean_event_suffix(value: str | None) -> str:
+    cleaned = re.sub(r"[^a-zA-Z0-9_]+", "_", value or "unknown").strip("_")
+    return cleaned.lower() or "unknown"
+
+
+def _route_template(request: Request) -> str:
+    route = request.scope.get("route")
+    route_path = getattr(route, "path", None)
+    if isinstance(route_path, str) and route_path:
+        return route_path
+    return request.url.path
+
+
+def _route_operation(request: Request) -> str:
+    endpoint = request.scope.get("endpoint")
+    endpoint_name = getattr(endpoint, "__name__", None)
+    if isinstance(endpoint_name, str) and endpoint_name:
+        return endpoint_name
+    route = request.scope.get("route")
+    route_name = getattr(route, "name", None)
+    return route_name if isinstance(route_name, str) else "unknown"
+
+
+def should_capture_api_route(request: Request) -> bool:
+    path = request.url.path
+    settings = get_config().service
+    base_path = settings.base_path.rstrip("/")
+    base_public_paths = {f"{base_path}{route}" for route in _PUBLIC_API_ROUTE_PATHS}
+
+    return (
+        path.startswith(f"{base_path}/v1")
+        or path in _PUBLIC_API_ROUTE_PATHS
+        or path in base_public_paths
+    )
+
+
+async def capture_api_route_event(
+    request: Request,
+    *,
+    status_code: int,
+    duration_ms: int,
+    exception_type: str | None = None,
+) -> None:
+    operation = _clean_event_suffix(_route_operation(request))
+    await capture_automation_event(
+        f"{API_EVENT_PREFIX}_{operation}",
+        request=request,
+        properties={
+            "http_method": request.method,
+            "route_path": _route_template(request),
+            "route_operation": operation,
+            "status_code": status_code,
+            "success": status_code < 400,
+            "duration_ms": duration_ms,
+            **({"exception_type": exception_type} if exception_type else {}),
+        },
+    )
 
 
 def _trigger_type(automation: Automation | None) -> str | None:

--- a/openhands/automation/telemetry.py
+++ b/openhands/automation/telemetry.py
@@ -1,5 +1,6 @@
 """Best-effort PostHog product telemetry for automation lifecycle events."""
 
+import json
 import logging
 import re
 import uuid
@@ -27,6 +28,9 @@ logger = logging.getLogger("automation.telemetry")
 AUTOMATION_BACKEND_ID_PROPERTY = "automation_backend_id"
 FRONTEND_DISTINCT_ID_PROPERTY = "frontend_distinct_id"
 POSTHOG_CAPTURE_PATH = "/capture/"
+TELEMETRY_CONSENT_METADATA_KEY = "posthog_frontend_consent_by_distinct_id"
+TELEMETRY_CONSENT_ANONYMOUS_ID = "__anonymous__"
+
 API_EVENT_PREFIX = "automation_api"
 TELEMETRY_BACKEND_DISTINCT_ID_KEY = "posthog_backend_distinct_id"
 _PUBLIC_API_ROUTE_PATHS = frozenset(
@@ -86,6 +90,93 @@ async def get_automation_backend_distinct_id(
     except Exception:
         logger.debug("Failed to load automation telemetry backend ID", exc_info=True)
         return None
+
+
+def _normalize_frontend_distinct_id(frontend_distinct_id: str | None) -> str:
+    normalized = (frontend_distinct_id or "").strip()
+    return normalized[:256] or TELEMETRY_CONSENT_ANONYMOUS_ID
+
+
+def _parse_telemetry_consent_map(raw_value: str | None) -> dict[str, bool]:
+    if not raw_value:
+        return {}
+    try:
+        parsed = json.loads(raw_value)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {
+        str(frontend_id): consent
+        for frontend_id, consent in parsed.items()
+        if isinstance(consent, bool)
+    }
+
+
+async def _load_telemetry_consent_map(session: AsyncSession) -> dict[str, bool]:
+    raw_value = await session.scalar(
+        select(AutomationServiceMetadata.value).where(
+            AutomationServiceMetadata.key == TELEMETRY_CONSENT_METADATA_KEY
+        )
+    )
+    return _parse_telemetry_consent_map(raw_value)
+
+
+def has_granted_telemetry_consent(consents: dict[str, bool]) -> bool:
+    return any(consents.values())
+
+
+async def set_stored_telemetry_consent(
+    session: AsyncSession,
+    *,
+    consent_granted: bool,
+    frontend_distinct_id: str | None,
+) -> bool:
+    """Store frontend telemetry consent and return aggregate consent state."""
+    consents = await _load_telemetry_consent_map(session)
+    consents[_normalize_frontend_distinct_id(frontend_distinct_id)] = consent_granted
+    serialized = json.dumps(consents, sort_keys=True)
+    await session.execute(
+        text(
+            "INSERT INTO automation_service_metadata (key, value) "
+            "VALUES (:key, :value) "
+            "ON CONFLICT (key) DO UPDATE SET "
+            "value = :value, updated_at = CURRENT_TIMESTAMP"
+        ),
+        {"key": TELEMETRY_CONSENT_METADATA_KEY, "value": serialized},
+    )
+    return has_granted_telemetry_consent(consents)
+
+
+async def get_stored_telemetry_consent(
+    *,
+    request: Request | None = None,
+    session: AsyncSession | None = None,
+    session_factory: async_sessionmaker[AsyncSession] | None = None,
+) -> bool:
+    """Return whether any known frontend identity granted telemetry consent."""
+    try:
+        if session is not None:
+            return has_granted_telemetry_consent(
+                await _load_telemetry_consent_map(session)
+            )
+
+        if session_factory is None and request is not None:
+            session_factory = getattr(request.app.state, "session_factory", None)
+
+        if session_factory is None:
+            logger.debug(
+                "No database session available for automation telemetry consent"
+            )
+            return False
+
+        async with session_factory() as new_session:
+            return has_granted_telemetry_consent(
+                await _load_telemetry_consent_map(new_session)
+            )
+    except Exception:
+        logger.debug("Failed to load automation telemetry consent", exc_info=True)
+        return False
 
 
 def get_request_telemetry_context(request: Request | None) -> TelemetryRequestContext:
@@ -260,7 +351,11 @@ async def capture_automation_event(
         return
 
     context = request_context or get_request_telemetry_context(request)
-    if settings.is_local_mode and not context.frontend_distinct_id:
+    if settings.is_local_mode and not await get_stored_telemetry_consent(
+        request=request,
+        session=session,
+        session_factory=session_factory,
+    ):
         return
 
     backend_distinct_id = await get_automation_backend_distinct_id(

--- a/openhands/automation/telemetry.py
+++ b/openhands/automation/telemetry.py
@@ -33,9 +33,7 @@ TELEMETRY_CONSENT_ANONYMOUS_ID = "__anonymous__"
 
 API_EVENT_PREFIX = "automation_api"
 TELEMETRY_BACKEND_DISTINCT_ID_KEY = "posthog_backend_distinct_id"
-_PUBLIC_API_ROUTE_PATHS = frozenset(
-    {"/health", "/ready", "/sdk-version", "/server_info"}
-)
+_PUBLIC_API_ROUTE_PATHS = frozenset({"/health", "/ready", "/server_info"})
 
 
 async def _get_or_create_backend_distinct_id(session: AsyncSession) -> str:

--- a/openhands/automation/telemetry.py
+++ b/openhands/automation/telemetry.py
@@ -97,6 +97,11 @@ def get_request_telemetry_context(request: Request | None) -> TelemetryRequestCo
     return build_telemetry_request_context(request.scope)
 
 
+def get_request_authenticated_user(request: Request) -> AuthenticatedUser | None:
+    user = getattr(request.state, "authenticated_user", None)
+    return user if isinstance(user, AuthenticatedUser) else None
+
+
 def _clean_event_suffix(value: str | None) -> str:
     cleaned = re.sub(r"[^a-zA-Z0-9_]+", "_", value or "unknown").strip("_")
     return cleaned.lower() or "unknown"
@@ -144,6 +149,7 @@ async def capture_api_route_event(
     await capture_automation_event(
         f"{API_EVENT_PREFIX}_{operation}",
         request=request,
+        user=get_request_authenticated_user(request),
         properties={
             "http_method": request.method,
             "route_path": _route_template(request),

--- a/openhands/automation/telemetry.py
+++ b/openhands/automation/telemetry.py
@@ -228,6 +228,7 @@ def _base_properties(
                 "has_conversation_id": bool(run.conversation_id),
             }
         )
+        properties.setdefault("automation_id", str(run.automation_id))
         if run.started_at and run.completed_at:
             duration_ms = int(
                 (run.completed_at - run.started_at).total_seconds() * 1000

--- a/openhands/automation/telemetry.py
+++ b/openhands/automation/telemetry.py
@@ -211,7 +211,6 @@ def _base_properties(
                 {
                     "cloud_user_id": str(automation.user_id),
                     "cloud_org_id": str(automation.org_id),
-                    "org_id": str(automation.org_id),
                     "$groups": {"org": str(automation.org_id)},
                 }
             )
@@ -221,7 +220,6 @@ def _base_properties(
             {
                 "cloud_user_id": str(user.user_id),
                 "cloud_org_id": str(user.org_id),
-                "org_id": str(user.org_id),
                 "$groups": {"org": str(user.org_id)},
             }
         )

--- a/openhands/automation/telemetry.py
+++ b/openhands/automation/telemetry.py
@@ -1,0 +1,192 @@
+"""Best-effort PostHog product telemetry for automation lifecycle events."""
+
+import logging
+import uuid
+from pathlib import Path
+from typing import Any
+
+import httpx
+from fastapi import Request
+
+from openhands.automation.auth import AuthenticatedUser
+from openhands.automation.config import get_config
+from openhands.automation.middleware import (
+    TelemetryRequestContext,
+    build_telemetry_request_context,
+)
+from openhands.automation.models import Automation, AutomationRun
+
+
+logger = logging.getLogger("automation.telemetry")
+AUTOMATION_BACKEND_ID_PROPERTY = "automation_backend_id"
+FRONTEND_DISTINCT_ID_PROPERTY = "frontend_distinct_id"
+POSTHOG_CAPTURE_PATH = "/capture/"
+
+
+def _default_backend_id_path() -> Path:
+    return Path.home() / ".openhands" / "automation" / "telemetry-backend-id"
+
+
+def get_local_backend_distinct_id() -> str:
+    """Return a stable local-mode backend telemetry distinct ID."""
+    settings = get_config().service
+    path = (
+        Path(settings.telemetry_backend_id_path).expanduser()
+        if settings.telemetry_backend_id_path
+        else _default_backend_id_path()
+    )
+
+    try:
+        existing = path.read_text().strip()
+        if existing:
+            return existing
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.exception("Failed to read automation telemetry backend ID")
+
+    generated = f"automation-local:{uuid.uuid4()}"
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"{generated}\n")
+        path.chmod(0o600)
+    except Exception:
+        logger.exception("Failed to persist automation telemetry backend ID")
+    return generated
+
+
+def get_request_telemetry_context(request: Request | None) -> TelemetryRequestContext:
+    if request is None:
+        return TelemetryRequestContext()
+    context = getattr(request.state, "telemetry_context", None)
+    if isinstance(context, TelemetryRequestContext):
+        return context
+    return build_telemetry_request_context(request.scope)
+
+
+def _trigger_type(automation: Automation | None) -> str | None:
+    trigger = automation.trigger if automation is not None else None
+    if isinstance(trigger, dict):
+        value = trigger.get("type")
+        return str(value) if value is not None else None
+    return str(trigger) if trigger is not None else None
+
+
+def _resolve_distinct_id(
+    *,
+    request_context: TelemetryRequestContext,
+) -> str:
+    if request_context.frontend_distinct_id:
+        return request_context.frontend_distinct_id
+    return get_local_backend_distinct_id()
+
+
+def _base_properties(
+    *,
+    request_context: TelemetryRequestContext,
+    user: AuthenticatedUser | None,
+    automation: Automation | None,
+    run: AutomationRun | None,
+) -> dict[str, Any]:
+    settings = get_config().service
+    properties: dict[str, Any] = {
+        "deployment_mode": "local" if settings.is_local_mode else "cloud",
+        "automation_service": "openhands_automation",
+    }
+
+    properties[AUTOMATION_BACKEND_ID_PROPERTY] = get_local_backend_distinct_id()
+
+    if request_context.frontend_distinct_id:
+        properties[FRONTEND_DISTINCT_ID_PROPERTY] = request_context.frontend_distinct_id
+    if request_context.client_source:
+        properties["client_source"] = request_context.client_source
+    if request_context.client_version:
+        properties["client_version"] = request_context.client_version
+
+    if automation is not None:
+        properties.update(
+            {
+                "automation_id": str(automation.id),
+                "automation_enabled": automation.enabled,
+                "trigger_type": _trigger_type(automation),
+                "timeout_seconds": automation.timeout,
+            }
+        )
+        if not settings.is_local_mode:
+            properties.update(
+                {
+                    "cloud_user_id": str(automation.user_id),
+                    "cloud_org_id": str(automation.org_id),
+                    "org_id": str(automation.org_id),
+                    "$groups": {"org": str(automation.org_id)},
+                }
+            )
+
+    if user is not None and not settings.is_local_mode:
+        properties.update(
+            {
+                "cloud_user_id": str(user.user_id),
+                "cloud_org_id": str(user.org_id),
+                "org_id": str(user.org_id),
+                "$groups": {"org": str(user.org_id)},
+            }
+        )
+
+    if run is not None:
+        properties.update(
+            {
+                "run_id": str(run.id),
+                "run_status": run.status.value,
+                "has_conversation_id": bool(run.conversation_id),
+            }
+        )
+        if run.started_at and run.completed_at:
+            duration_ms = int(
+                (run.completed_at - run.started_at).total_seconds() * 1000
+            )
+            properties["duration_ms"] = duration_ms
+
+    return properties
+
+
+async def capture_automation_event(
+    event: str,
+    *,
+    request: Request | None = None,
+    request_context: TelemetryRequestContext | None = None,
+    user: AuthenticatedUser | None = None,
+    automation: Automation | None = None,
+    run: AutomationRun | None = None,
+    properties: dict[str, Any] | None = None,
+) -> None:
+    """Capture a sanitized automation product event without affecting callers."""
+    settings = get_config().service
+    if not settings.posthog_api_key:
+        return
+
+    context = request_context or get_request_telemetry_context(request)
+    event_properties = _base_properties(
+        request_context=context,
+        user=user,
+        automation=automation,
+        run=run,
+    )
+    if properties:
+        event_properties.update(properties)
+
+    payload = {
+        "api_key": settings.posthog_api_key,
+        "event": event,
+        "distinct_id": _resolve_distinct_id(request_context=context),
+        "properties": event_properties,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=2.0) as client:
+            response = await client.post(
+                f"{settings.posthog_host.rstrip('/')}{POSTHOG_CAPTURE_PATH}",
+                json=payload,
+            )
+            response.raise_for_status()
+    except Exception:
+        logger.debug("Failed to capture automation telemetry event", exc_info=True)

--- a/openhands/automation/telemetry.py
+++ b/openhands/automation/telemetry.py
@@ -260,6 +260,9 @@ async def capture_automation_event(
         return
 
     context = request_context or get_request_telemetry_context(request)
+    if settings.is_local_mode and not context.frontend_distinct_id:
+        return
+
     backend_distinct_id = await get_automation_backend_distinct_id(
         request=request,
         session=session,

--- a/openhands/automation/telemetry_router.py
+++ b/openhands/automation/telemetry_router.py
@@ -1,0 +1,55 @@
+"""Telemetry configuration endpoints for the automation service."""
+
+from fastapi import APIRouter, Depends, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from openhands.automation.auth import AuthenticatedUser, require_permission
+from openhands.automation.db import get_session
+from openhands.automation.middleware import TelemetryRequestContext
+from openhands.automation.schemas import (
+    TelemetryConsentRequest,
+    TelemetryConsentResponse,
+)
+from openhands.automation.telemetry import (
+    capture_automation_event,
+    get_request_telemetry_context,
+    set_stored_telemetry_consent,
+)
+
+
+router = APIRouter(prefix="/v1/telemetry", tags=["Telemetry"])
+
+_require_manage_automations = require_permission("manage_automations")
+
+
+@router.post("/consent")
+async def set_telemetry_consent(
+    body: TelemetryConsentRequest,
+    request: Request,
+    user: AuthenticatedUser = Depends(_require_manage_automations),
+    session: AsyncSession = Depends(get_session),
+) -> TelemetryConsentResponse:
+    """Persist frontend telemetry consent for local backend capture decisions."""
+    consent_granted = await set_stored_telemetry_consent(
+        session,
+        consent_granted=body.consent_granted,
+        frontend_distinct_id=body.frontend_distinct_id,
+    )
+
+    if body.consent_granted:
+        request_context = get_request_telemetry_context(request)
+        await capture_automation_event(
+            "automation_telemetry_consent_granted",
+            request=request,
+            user=user,
+            properties={"consent_source": "agent_canvas"},
+            request_context=TelemetryRequestContext(
+                frontend_distinct_id=body.frontend_distinct_id,
+                client_source=request_context.client_source,
+                client_version=request_context.client_version,
+            ),
+            session=session,
+        )
+
+    await session.commit()
+    return TelemetryConsentResponse(consent_granted=consent_granted)

--- a/openhands/automation/telemetry_router.py
+++ b/openhands/automation/telemetry_router.py
@@ -1,9 +1,10 @@
 """Telemetry configuration endpoints for the automation service."""
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from openhands.automation.auth import AuthenticatedUser, require_permission
+from openhands.automation.config import get_config
 from openhands.automation.db import get_session
 from openhands.automation.middleware import TelemetryRequestContext
 from openhands.automation.schemas import (
@@ -18,6 +19,10 @@ from openhands.automation.telemetry import (
 
 
 router = APIRouter(prefix="/v1/telemetry", tags=["Telemetry"])
+CLOUD_MODE_CONSENT_ERROR = (
+    "Telemetry consent is managed by the main OpenHands app in cloud mode."
+)
+
 
 _require_manage_automations = require_permission("manage_automations")
 
@@ -30,6 +35,12 @@ async def set_telemetry_consent(
     session: AsyncSession = Depends(get_session),
 ) -> TelemetryConsentResponse:
     """Persist frontend telemetry consent for local backend capture decisions."""
+    if not get_config().service.is_local_mode:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=CLOUD_MODE_CONSENT_ERROR,
+        )
+
     consent_granted = await set_stored_telemetry_consent(
         session,
         consent_granted=body.consent_granted,

--- a/openhands/automation/watchdog.py
+++ b/openhands/automation/watchdog.py
@@ -26,6 +26,7 @@ from openhands.automation.models import (
     AutomationRun,
     AutomationRunStatus,
 )
+from openhands.automation.telemetry import capture_automation_event
 from openhands.automation.utils import log_extra
 from openhands.automation.utils.time import utcnow
 
@@ -91,6 +92,16 @@ async def _verify_and_mark_run(
             )
         )
         result: CursorResult = await session.execute(stmt)  # type: ignore[assignment]
+        if result.rowcount > 0:
+            await capture_automation_event(
+                "automation_run_failed",
+                automation=run.automation,
+                run=run,
+                properties={
+                    "trigger_source": "watchdog",
+                    "failure_kind": "verification_failed",
+                },
+            )
         return result.rowcount > 0
 
     if verification.verified:
@@ -168,6 +179,18 @@ async def _verify_and_mark_run(
             )
 
         result = await session.execute(stmt)  # type: ignore[assignment]
+        if result.rowcount > 0:
+            await capture_automation_event(
+                "automation_run_completed"
+                if exit_code == 0
+                else "automation_run_failed",
+                automation=run.automation,
+                run=run,
+                properties={
+                    "trigger_source": "watchdog",
+                    "verification_exit_code": exit_code,
+                },
+            )
         if result.rowcount > 0 and _should_cleanup_sandbox_after_terminal(
             run, keep_alive
         ):
@@ -219,6 +242,16 @@ async def _verify_and_mark_run(
         )
     )
     result = await session.execute(stmt)  # type: ignore[assignment]
+    if result.rowcount > 0:
+        await capture_automation_event(
+            "automation_run_failed",
+            automation=run.automation,
+            run=run,
+            properties={
+                "trigger_source": "watchdog",
+                "failure_kind": "timeout",
+            },
+        )
     return result.rowcount > 0
 
 

--- a/openhands/automation/watchdog.py
+++ b/openhands/automation/watchdog.py
@@ -46,6 +46,13 @@ async def _get_automation_keep_alive(
     )
 
 
+def _loaded_automation(run: AutomationRun) -> Automation | None:
+    """Return the parent automation only when it is already loaded."""
+    if "automation" in inspect(run).unloaded:
+        return None
+    return run.automation
+
+
 def _should_cleanup_sandbox_after_terminal(
     run: AutomationRun, keep_alive: bool | None
 ) -> bool:
@@ -95,7 +102,7 @@ async def _verify_and_mark_run(
         if result.rowcount > 0:
             await capture_automation_event(
                 "automation_run_failed",
-                automation=run.automation,
+                automation=_loaded_automation(run),
                 run=run,
                 session=session,
                 properties={
@@ -185,7 +192,7 @@ async def _verify_and_mark_run(
                 "automation_run_completed"
                 if exit_code == 0
                 else "automation_run_failed",
-                automation=run.automation,
+                automation=_loaded_automation(run),
                 run=run,
                 session=session,
                 properties={
@@ -247,7 +254,7 @@ async def _verify_and_mark_run(
     if result.rowcount > 0:
         await capture_automation_event(
             "automation_run_failed",
-            automation=run.automation,
+            automation=_loaded_automation(run),
             run=run,
             session=session,
             properties={

--- a/openhands/automation/watchdog.py
+++ b/openhands/automation/watchdog.py
@@ -97,6 +97,7 @@ async def _verify_and_mark_run(
                 "automation_run_failed",
                 automation=run.automation,
                 run=run,
+                session=session,
                 properties={
                     "trigger_source": "watchdog",
                     "failure_kind": "verification_failed",
@@ -186,6 +187,7 @@ async def _verify_and_mark_run(
                 else "automation_run_failed",
                 automation=run.automation,
                 run=run,
+                session=session,
                 properties={
                     "trigger_source": "watchdog",
                     "verification_exit_code": exit_code,
@@ -247,6 +249,7 @@ async def _verify_and_mark_run(
             "automation_run_failed",
             automation=run.automation,
             run=run,
+            session=session,
             properties={
                 "trigger_source": "watchdog",
                 "failure_kind": "timeout",

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -254,6 +254,45 @@ class TestDispatchPendingRuns:
             updated = result.scalars().first()
             assert updated.status == AutomationRunStatus.RUNNING
 
+    @patch(
+        "openhands.automation.dispatcher.capture_automation_event",
+        new_callable=AsyncMock,
+    )
+    @patch("openhands.automation.dispatcher._execute_run_safe", new_callable=AsyncMock)
+    async def test_dispatch_emits_single_run_lifecycle_event(
+        self,
+        mock_execute,
+        mock_capture_event,
+        async_session_factory,
+        mock_settings,
+        mock_client,
+    ):
+        """Dispatch is the canonical telemetry event for a run starting."""
+        async with async_session_factory() as session:
+            automation = Automation(
+                user_id=TEST_USER_ID,
+                org_id=TEST_ORG_ID,
+                name="Test",
+                trigger={"type": "cron", "schedule": "* * * * *", "timezone": "UTC"},
+                tarball_path="s3://bucket/code.tar.gz",
+                entrypoint="uv run main.py",
+                enabled=True,
+            )
+            session.add(automation)
+            await session.commit()
+
+            run = AutomationRun(
+                automation_id=automation.id,
+                status=AutomationRunStatus.PENDING,
+            )
+            session.add(run)
+            await session.commit()
+
+        await dispatch_pending_runs(async_session_factory, mock_settings, mock_client)
+
+        emitted_events = [call.args[0] for call in mock_capture_event.await_args_list]
+        assert emitted_events == ["automation_run_dispatched"]
+
     @patch("openhands.automation.dispatcher._execute_run_safe", new_callable=AsyncMock)
     async def test_ignores_running_runs(
         self, mock_execute, async_session_factory, mock_settings, mock_client

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -120,6 +120,13 @@ async def test_local_capture_uses_backend_id_and_frontend_property(monkeypatch):
     assert properties["client_source"] == "agent_canvas"
     assert properties["automation_id"] == str(automation.id)
     assert properties["run_id"] == str(run.id)
+    assert properties["deployment_mode"] == "local"
+    assert "cloud_user_id" not in properties
+    assert "cloud_org_id" not in properties
+    assert "org_id" not in properties
+
+    assert "$groups" not in properties
+
     assert properties["trigger_source"] == "callback"
 
 
@@ -150,6 +157,8 @@ async def test_cloud_capture_uses_backend_id_and_org_properties(monkeypatch):
     assert properties["cloud_user_id"] == str(automation.user_id)
     assert properties["cloud_org_id"] == str(automation.org_id)
     assert properties["$groups"] == {"org": str(automation.org_id)}
+    assert "org_id" not in properties
+
     assert properties["creation_path"] == "prompt_preset"
     assert properties["frontend_distinct_id"] == "ph-fe-123"
     assert properties["automation_backend_id"] == "automation-backend:cloud"
@@ -263,6 +272,50 @@ async def test_capture_api_route_event_uses_endpoint_name_and_route_template(
     assert properties["cloud_user_id"] == str(user.user_id)
     assert properties["cloud_org_id"] == str(user.org_id)
     assert properties["$groups"] == {"org": str(user.org_id)}
+    assert "org_id" not in properties
+    assert properties["success"] is True
+    assert properties["duration_ms"] == 12
+
+
+@pytest.mark.asyncio
+async def test_capture_api_route_event_in_local_mode_omits_cloud_identity(
+    monkeypatch,
+):
+    monkeypatch.setenv("AUTOMATION_POSTHOG_API_KEY", "ph_test")
+    monkeypatch.setenv("AUTOMATION_AGENT_SERVER_URL", "http://localhost:3000")
+    clear_config_cache()
+    monkeypatch.setattr(telemetry.httpx, "AsyncClient", _MockAsyncClient)
+
+    async def backend_id(**kwargs):
+        return "automation-backend:local-api"
+
+    monkeypatch.setattr(telemetry, "get_automation_backend_distinct_id", backend_id)
+
+    request = _request("/api/automation/v1/123", endpoint_name="get_automation")
+    request.state.authenticated_user = AuthenticatedUser(
+        user_id=uuid.uuid4(),
+        org_id=uuid.uuid4(),
+        email="local@example.com",
+        role="admin",
+        permissions=["manage_automations"],
+        auth_method=AuthMethod.LOCAL_API_KEY,
+    )
+
+    await telemetry.capture_api_route_event(
+        request,
+        status_code=200,
+        duration_ms=12,
+    )
+
+    _, payload = _MockAsyncClient.posts[0]
+    properties = payload["properties"]
+    assert payload["distinct_id"] == "automation-backend:local-api"
+    assert properties["deployment_mode"] == "local"
+    assert properties["automation_backend_id"] == "automation-backend:local-api"
+    assert "cloud_user_id" not in properties
+    assert "cloud_org_id" not in properties
+    assert "org_id" not in properties
+    assert "$groups" not in properties
 
     assert properties["success"] is True
     assert properties["duration_ms"] == 12

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -458,8 +458,11 @@ def _request(path: str, *, endpoint_name: str = "list_automations"):
 
 def test_should_capture_api_route_for_v1_and_public_paths():
     assert telemetry.should_capture_api_route(_request("/api/automation/v1"))
-    assert telemetry.should_capture_api_route(_request("/sdk-version"))
     assert telemetry.should_capture_api_route(_request("/api/automation/server_info"))
+    assert not telemetry.should_capture_api_route(_request("/sdk-version"))
+    assert not telemetry.should_capture_api_route(
+        _request("/api/automation/sdk-version")
+    )
     assert not telemetry.should_capture_api_route(_request("/docs"))
     assert not telemetry.should_capture_api_route(_request("/automations"))
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -175,3 +175,65 @@ def test_build_telemetry_request_context_extracts_canvas_headers():
         client_source="agent_canvas",
         client_version="1.2.3",
     )
+
+
+class _Route:
+    path = "/api/automation/v1/{automation_id}"
+
+
+def _request(path: str, *, endpoint_name: str = "list_automations"):
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    def endpoint():
+        return None
+
+    endpoint.__name__ = endpoint_name
+    return telemetry.Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": path,
+            "headers": [],
+            "query_string": b"",
+            "server": ("testserver", 80),
+            "scheme": "http",
+            "client": ("testclient", 50000),
+            "endpoint": endpoint,
+            "route": _Route(),
+        },
+        receive,
+    )
+
+
+def test_should_capture_api_route_for_v1_and_public_paths():
+    assert telemetry.should_capture_api_route(_request("/api/automation/v1"))
+    assert telemetry.should_capture_api_route(_request("/sdk-version"))
+    assert telemetry.should_capture_api_route(_request("/api/automation/server_info"))
+    assert not telemetry.should_capture_api_route(_request("/docs"))
+    assert not telemetry.should_capture_api_route(_request("/automations"))
+
+
+@pytest.mark.asyncio
+async def test_capture_api_route_event_uses_endpoint_name_and_route_template(
+    monkeypatch,
+):
+    monkeypatch.setenv("AUTOMATION_POSTHOG_API_KEY", "ph_test")
+    clear_config_cache()
+    monkeypatch.setattr(telemetry.httpx, "AsyncClient", _MockAsyncClient)
+
+    await telemetry.capture_api_route_event(
+        _request("/api/automation/v1/123", endpoint_name="get_automation"),
+        status_code=200,
+        duration_ms=12,
+    )
+
+    _, payload = _MockAsyncClient.posts[0]
+    assert payload["event"] == "automation_api_get_automation"
+    properties = payload["properties"]
+    assert properties["http_method"] == "GET"
+    assert properties["route_path"] == "/api/automation/v1/{automation_id}"
+    assert properties["route_operation"] == "get_automation"
+    assert properties["status_code"] == 200
+    assert properties["success"] is True
+    assert properties["duration_ms"] == 12

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -2,6 +2,7 @@ import uuid
 from typing import ClassVar
 
 import pytest
+from fastapi import HTTPException
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
@@ -353,6 +354,57 @@ async def test_telemetry_consent_route_stores_consent_and_emits_link_event(
         assert properties["frontend_distinct_id"] == "ph-fe-link"
         assert properties["client_source"] == "agent_canvas"
         assert properties["client_version"] == "1.2.3"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_telemetry_consent_route_rejects_cloud_mode(monkeypatch):
+    monkeypatch.delenv("AUTOMATION_AGENT_SERVER_URL", raising=False)
+    monkeypatch.setenv("AUTOMATION_POSTHOG_API_KEY", "ph_test")
+    clear_config_cache()
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        request = _request(
+            "/api/automation/v1/telemetry/consent",
+            endpoint_name="set_telemetry_consent",
+        )
+        user = AuthenticatedUser(
+            user_id=uuid.uuid4(),
+            org_id=uuid.uuid4(),
+            email="cloud@example.com",
+            role="admin",
+            permissions=["manage_automations"],
+            auth_method=AuthMethod.API_KEY,
+        )
+
+        async with session_factory() as session:
+            with pytest.raises(HTTPException) as exc_info:
+                await set_telemetry_consent(
+                    TelemetryConsentRequest(
+                        consent_granted=True,
+                        frontend_distinct_id="ph-fe-cloud",
+                    ),
+                    request,
+                    user,
+                    session,
+                )
+
+            assert exc_info.value.status_code == 400
+            assert "cloud mode" in str(exc_info.value.detail)
+            stored = await session.scalar(
+                select(AutomationServiceMetadata.value).where(
+                    AutomationServiceMetadata.key
+                    == telemetry.TELEMETRY_CONSENT_METADATA_KEY
+                )
+            )
+            assert stored is None
+            assert _MockAsyncClient.posts == []
     finally:
         await engine.dispose()
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -262,7 +262,6 @@ async def test_capture_api_route_event_uses_endpoint_name_and_route_template(
     assert properties["deployment_mode"] == "cloud"
     assert properties["cloud_user_id"] == str(user.user_id)
     assert properties["cloud_org_id"] == str(user.org_id)
-    assert properties["org_id"] == str(user.org_id)
     assert properties["$groups"] == {"org": str(user.org_id)}
 
     assert properties["success"] is True

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,177 @@
+import uuid
+from typing import ClassVar
+
+import pytest
+
+from openhands.automation import telemetry
+from openhands.automation.config import clear_config_cache
+from openhands.automation.middleware import (
+    TelemetryRequestContext,
+    build_telemetry_request_context,
+)
+from openhands.automation.models import Automation, AutomationRun, AutomationRunStatus
+
+
+class _Response:
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _MockAsyncClient:
+    posts: ClassVar[list[tuple[str, dict]]] = []
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def post(self, url: str, json: dict) -> _Response:
+        self.posts.append((url, json))
+        return _Response()
+
+
+def _automation() -> Automation:
+    return Automation(
+        id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        org_id=uuid.uuid4(),
+        name="Daily report",
+        trigger={"type": "cron", "schedule": "0 9 * * *"},
+        tarball_path="https://example.com/a.tar",
+        entrypoint="python main.py",
+        enabled=True,
+        timeout=300,
+    )
+
+
+def _run(automation: Automation) -> AutomationRun:
+    return AutomationRun(
+        id=uuid.uuid4(),
+        automation_id=automation.id,
+        automation=automation,
+        status=AutomationRunStatus.COMPLETED,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_config(monkeypatch):
+    for name in (
+        "AUTOMATION_POSTHOG_API_KEY",
+        "AUTOMATION_POSTHOG_HOST",
+        "AUTOMATION_AGENT_SERVER_URL",
+        "AUTOMATION_TELEMETRY_BACKEND_ID_PATH",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    clear_config_cache()
+    _MockAsyncClient.posts.clear()
+    yield
+    clear_config_cache()
+
+
+@pytest.mark.asyncio
+async def test_local_capture_uses_persistent_backend_id_and_frontend_property(
+    monkeypatch, tmp_path
+):
+    backend_id_path = tmp_path / "backend-id"
+    monkeypatch.setenv("AUTOMATION_POSTHOG_API_KEY", "ph_test")
+    monkeypatch.setenv("AUTOMATION_POSTHOG_HOST", "https://posthog.example")
+    monkeypatch.setenv("AUTOMATION_AGENT_SERVER_URL", "http://localhost:3000")
+    monkeypatch.setenv("AUTOMATION_TELEMETRY_BACKEND_ID_PATH", str(backend_id_path))
+    clear_config_cache()
+    monkeypatch.setattr(telemetry.httpx, "AsyncClient", _MockAsyncClient)
+
+    automation = _automation()
+    run = _run(automation)
+    context = TelemetryRequestContext(
+        frontend_distinct_id="ph-fe-123",
+        client_source="agent_canvas",
+        client_version="1.2.3",
+    )
+
+    await telemetry.capture_automation_event(
+        "automation_run_completed",
+        request_context=context,
+        automation=automation,
+        run=run,
+        properties={"trigger_source": "callback"},
+    )
+
+    assert len(_MockAsyncClient.posts) == 1
+    url, payload = _MockAsyncClient.posts[0]
+    assert url == "https://posthog.example/capture/"
+    assert payload["event"] == "automation_run_completed"
+    assert payload["distinct_id"] == "ph-fe-123"
+    properties = payload["properties"]
+    assert properties["automation_backend_id"].startswith("automation-local:")
+    assert backend_id_path.read_text().strip() == properties["automation_backend_id"]
+    assert properties["frontend_distinct_id"] == "ph-fe-123"
+    assert properties["client_source"] == "agent_canvas"
+    assert properties["automation_id"] == str(automation.id)
+    assert properties["run_id"] == str(run.id)
+    assert properties["trigger_source"] == "callback"
+
+
+@pytest.mark.asyncio
+async def test_cloud_capture_uses_frontend_distinct_id_and_org_properties(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("AUTOMATION_POSTHOG_API_KEY", "ph_test")
+    monkeypatch.setenv(
+        "AUTOMATION_TELEMETRY_BACKEND_ID_PATH", str(tmp_path / "backend-id")
+    )
+    clear_config_cache()
+    monkeypatch.setattr(telemetry.httpx, "AsyncClient", _MockAsyncClient)
+
+    automation = _automation()
+
+    await telemetry.capture_automation_event(
+        "automation_created",
+        request_context=TelemetryRequestContext(frontend_distinct_id="ph-fe-123"),
+        automation=automation,
+        properties={"creation_path": "prompt_preset"},
+    )
+
+    _, payload = _MockAsyncClient.posts[0]
+    assert payload["distinct_id"] == "ph-fe-123"
+    properties = payload["properties"]
+    assert properties["deployment_mode"] == "cloud"
+    assert properties["cloud_user_id"] == str(automation.user_id)
+    assert properties["cloud_org_id"] == str(automation.org_id)
+    assert properties["$groups"] == {"org": str(automation.org_id)}
+    assert properties["creation_path"] == "prompt_preset"
+    assert properties["frontend_distinct_id"] == "ph-fe-123"
+    assert properties["automation_backend_id"].startswith("automation-local:")
+
+
+@pytest.mark.asyncio
+async def test_capture_is_disabled_without_posthog_key(monkeypatch):
+    monkeypatch.setattr(telemetry.httpx, "AsyncClient", _MockAsyncClient)
+
+    await telemetry.capture_automation_event(
+        "automation_created",
+        automation=_automation(),
+    )
+
+    assert _MockAsyncClient.posts == []
+
+
+def test_build_telemetry_request_context_extracts_canvas_headers():
+    scope = {
+        "headers": [
+            (b"x-openhands-telemetry-distinct-id", b" ph-fe-123 "),
+            (b"x-openhands-client", b"agent_canvas"),
+            (b"x-openhands-client-version", b"1.2.3"),
+        ]
+    }
+
+    context = build_telemetry_request_context(scope)
+
+    assert context == TelemetryRequestContext(
+        frontend_distinct_id="ph-fe-123",
+        client_source="agent_canvas",
+        client_version="1.2.3",
+    )

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -19,6 +19,8 @@ from openhands.automation.models import (
     AutomationServiceMetadata,
     Base,
 )
+from openhands.automation.schemas import TelemetryConsentRequest
+from openhands.automation.telemetry_router import set_telemetry_consent
 
 
 class _Response:
@@ -92,6 +94,11 @@ async def test_local_capture_uses_backend_id_and_frontend_property(monkeypatch):
         return "automation-backend:test"
 
     monkeypatch.setattr(telemetry, "get_automation_backend_distinct_id", backend_id)
+
+    async def stored_consent(**kwargs):
+        return True
+
+    monkeypatch.setattr(telemetry, "get_stored_telemetry_consent", stored_consent)
 
     automation = _automation()
     run = _run(automation)
@@ -177,7 +184,7 @@ async def test_capture_is_disabled_without_posthog_key(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_local_capture_requires_consented_frontend_distinct_id(monkeypatch):
+async def test_local_capture_requires_stored_telemetry_consent(monkeypatch):
     monkeypatch.setenv("AUTOMATION_POSTHOG_API_KEY", "ph_test")
     monkeypatch.setenv("AUTOMATION_AGENT_SERVER_URL", "http://localhost:3000")
     clear_config_cache()
@@ -217,6 +224,137 @@ async def test_cloud_capture_does_not_require_frontend_distinct_id(monkeypatch):
     _, payload = _MockAsyncClient.posts[0]
     assert payload["distinct_id"] == "automation-backend:cloud"
     assert payload["properties"]["deployment_mode"] == "cloud"
+
+
+@pytest.mark.asyncio
+async def test_local_capture_uses_stored_consent_without_request_id(monkeypatch):
+    monkeypatch.setenv("AUTOMATION_POSTHOG_API_KEY", "ph_test")
+    monkeypatch.setenv("AUTOMATION_AGENT_SERVER_URL", "http://localhost:3000")
+    clear_config_cache()
+    monkeypatch.setattr(telemetry.httpx, "AsyncClient", _MockAsyncClient)
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        async with session_factory() as session:
+            await telemetry.set_stored_telemetry_consent(
+                session,
+                consent_granted=True,
+                frontend_distinct_id="ph-fe-consented",
+            )
+            await session.commit()
+
+        await telemetry.capture_automation_event(
+            "automation_run_dispatched",
+            automation=_automation(),
+            session_factory=session_factory,
+        )
+
+        assert len(_MockAsyncClient.posts) == 1
+        _, payload = _MockAsyncClient.posts[0]
+        assert payload["event"] == "automation_run_dispatched"
+        assert payload["properties"]["deployment_mode"] == "local"
+        assert "frontend_distinct_id" not in payload["properties"]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_stored_telemetry_consent_tracks_any_granted_frontend_id():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        async with session_factory() as session:
+            assert not await telemetry.set_stored_telemetry_consent(
+                session,
+                consent_granted=False,
+                frontend_distinct_id="ph-fe-a",
+            )
+            assert await telemetry.set_stored_telemetry_consent(
+                session,
+                consent_granted=True,
+                frontend_distinct_id="ph-fe-b",
+            )
+            assert await telemetry.get_stored_telemetry_consent(session=session)
+
+            assert await telemetry.set_stored_telemetry_consent(
+                session,
+                consent_granted=False,
+                frontend_distinct_id="ph-fe-a",
+            )
+            assert (
+                await telemetry.set_stored_telemetry_consent(
+                    session,
+                    consent_granted=False,
+                    frontend_distinct_id="ph-fe-b",
+                )
+                is False
+            )
+            assert not await telemetry.get_stored_telemetry_consent(session=session)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_telemetry_consent_route_stores_consent_and_emits_link_event(
+    monkeypatch,
+):
+    monkeypatch.setenv("AUTOMATION_POSTHOG_API_KEY", "ph_test")
+    monkeypatch.setenv("AUTOMATION_AGENT_SERVER_URL", "http://localhost:3000")
+    clear_config_cache()
+    monkeypatch.setattr(telemetry.httpx, "AsyncClient", _MockAsyncClient)
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        request = _request(
+            "/api/automation/v1/telemetry/consent",
+            endpoint_name="set_telemetry_consent",
+        )
+        request.state.telemetry_context = TelemetryRequestContext(
+            client_source="agent_canvas",
+            client_version="1.2.3",
+        )
+        user = AuthenticatedUser(
+            user_id=uuid.uuid4(),
+            org_id=uuid.uuid4(),
+            email="local@example.com",
+            role="admin",
+            permissions=["manage_automations"],
+            auth_method=AuthMethod.LOCAL_API_KEY,
+        )
+
+        async with session_factory() as session:
+            response = await set_telemetry_consent(
+                TelemetryConsentRequest(
+                    consent_granted=True,
+                    frontend_distinct_id="ph-fe-link",
+                ),
+                request,
+                user,
+                session,
+            )
+
+        assert response.consent_granted is True
+        assert len(_MockAsyncClient.posts) == 1
+        _, payload = _MockAsyncClient.posts[0]
+        properties = payload["properties"]
+        assert payload["event"] == "automation_telemetry_consent_granted"
+        assert payload["distinct_id"].startswith("automation-backend:")
+        assert properties["frontend_distinct_id"] == "ph-fe-link"
+        assert properties["client_source"] == "agent_canvas"
+        assert properties["client_version"] == "1.2.3"
+    finally:
+        await engine.dispose()
 
 
 def test_build_telemetry_request_context_extracts_canvas_headers():
@@ -333,6 +471,11 @@ async def test_capture_api_route_event_in_local_mode_omits_cloud_identity(
         return "automation-backend:local-api"
 
     monkeypatch.setattr(telemetry, "get_automation_backend_distinct_id", backend_id)
+
+    async def stored_consent(**kwargs):
+        return True
+
+    monkeypatch.setattr(telemetry, "get_stored_telemetry_consent", stored_consent)
 
     request = _request("/api/automation/v1/123", endpoint_name="get_automation")
     request.state.telemetry_context = TelemetryRequestContext(

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -176,6 +176,49 @@ async def test_capture_is_disabled_without_posthog_key(monkeypatch):
     assert _MockAsyncClient.posts == []
 
 
+@pytest.mark.asyncio
+async def test_local_capture_requires_consented_frontend_distinct_id(monkeypatch):
+    monkeypatch.setenv("AUTOMATION_POSTHOG_API_KEY", "ph_test")
+    monkeypatch.setenv("AUTOMATION_AGENT_SERVER_URL", "http://localhost:3000")
+    clear_config_cache()
+    monkeypatch.setattr(telemetry.httpx, "AsyncClient", _MockAsyncClient)
+
+    async def backend_id(**kwargs):
+        return "automation-backend:local"
+
+    monkeypatch.setattr(telemetry, "get_automation_backend_distinct_id", backend_id)
+
+    await telemetry.capture_automation_event(
+        "automation_created",
+        automation=_automation(),
+        request_context=TelemetryRequestContext(client_source="agent_canvas"),
+    )
+
+    assert _MockAsyncClient.posts == []
+
+
+@pytest.mark.asyncio
+async def test_cloud_capture_does_not_require_frontend_distinct_id(monkeypatch):
+    monkeypatch.setenv("AUTOMATION_POSTHOG_API_KEY", "ph_test")
+    clear_config_cache()
+    monkeypatch.setattr(telemetry.httpx, "AsyncClient", _MockAsyncClient)
+
+    async def backend_id(**kwargs):
+        return "automation-backend:cloud"
+
+    monkeypatch.setattr(telemetry, "get_automation_backend_distinct_id", backend_id)
+
+    await telemetry.capture_automation_event(
+        "automation_created",
+        automation=_automation(),
+    )
+
+    assert len(_MockAsyncClient.posts) == 1
+    _, payload = _MockAsyncClient.posts[0]
+    assert payload["distinct_id"] == "automation-backend:cloud"
+    assert payload["properties"]["deployment_mode"] == "cloud"
+
+
 def test_build_telemetry_request_context_extracts_canvas_headers():
     scope = {
         "headers": [
@@ -292,6 +335,9 @@ async def test_capture_api_route_event_in_local_mode_omits_cloud_identity(
     monkeypatch.setattr(telemetry, "get_automation_backend_distinct_id", backend_id)
 
     request = _request("/api/automation/v1/123", endpoint_name="get_automation")
+    request.state.telemetry_context = TelemetryRequestContext(
+        frontend_distinct_id="ph-fe-local"
+    )
     request.state.authenticated_user = AuthenticatedUser(
         user_id=uuid.uuid4(),
         org_id=uuid.uuid4(),

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -2,6 +2,8 @@ import uuid
 from typing import ClassVar
 
 import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from openhands.automation import telemetry
 from openhands.automation.config import clear_config_cache
@@ -9,7 +11,13 @@ from openhands.automation.middleware import (
     TelemetryRequestContext,
     build_telemetry_request_context,
 )
-from openhands.automation.models import Automation, AutomationRun, AutomationRunStatus
+from openhands.automation.models import (
+    Automation,
+    AutomationRun,
+    AutomationRunStatus,
+    AutomationServiceMetadata,
+    Base,
+)
 
 
 class _Response:
@@ -63,7 +71,6 @@ def _reset_config(monkeypatch):
         "AUTOMATION_POSTHOG_API_KEY",
         "AUTOMATION_POSTHOG_HOST",
         "AUTOMATION_AGENT_SERVER_URL",
-        "AUTOMATION_TELEMETRY_BACKEND_ID_PATH",
     ):
         monkeypatch.delenv(name, raising=False)
     clear_config_cache()
@@ -73,16 +80,17 @@ def _reset_config(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_local_capture_uses_persistent_backend_id_and_frontend_property(
-    monkeypatch, tmp_path
-):
-    backend_id_path = tmp_path / "backend-id"
+async def test_local_capture_uses_backend_id_and_frontend_property(monkeypatch):
     monkeypatch.setenv("AUTOMATION_POSTHOG_API_KEY", "ph_test")
     monkeypatch.setenv("AUTOMATION_POSTHOG_HOST", "https://posthog.example")
     monkeypatch.setenv("AUTOMATION_AGENT_SERVER_URL", "http://localhost:3000")
-    monkeypatch.setenv("AUTOMATION_TELEMETRY_BACKEND_ID_PATH", str(backend_id_path))
     clear_config_cache()
     monkeypatch.setattr(telemetry.httpx, "AsyncClient", _MockAsyncClient)
+
+    async def backend_id(**kwargs):
+        return "automation-backend:test"
+
+    monkeypatch.setattr(telemetry, "get_automation_backend_distinct_id", backend_id)
 
     automation = _automation()
     run = _run(automation)
@@ -104,10 +112,9 @@ async def test_local_capture_uses_persistent_backend_id_and_frontend_property(
     url, payload = _MockAsyncClient.posts[0]
     assert url == "https://posthog.example/capture/"
     assert payload["event"] == "automation_run_completed"
-    assert payload["distinct_id"] == "ph-fe-123"
+    assert payload["distinct_id"] == "automation-backend:test"
     properties = payload["properties"]
-    assert properties["automation_backend_id"].startswith("automation-local:")
-    assert backend_id_path.read_text().strip() == properties["automation_backend_id"]
+    assert properties["automation_backend_id"] == "automation-backend:test"
     assert properties["frontend_distinct_id"] == "ph-fe-123"
     assert properties["client_source"] == "agent_canvas"
     assert properties["automation_id"] == str(automation.id)
@@ -116,15 +123,15 @@ async def test_local_capture_uses_persistent_backend_id_and_frontend_property(
 
 
 @pytest.mark.asyncio
-async def test_cloud_capture_uses_frontend_distinct_id_and_org_properties(
-    monkeypatch, tmp_path
-):
+async def test_cloud_capture_uses_backend_id_and_org_properties(monkeypatch):
     monkeypatch.setenv("AUTOMATION_POSTHOG_API_KEY", "ph_test")
-    monkeypatch.setenv(
-        "AUTOMATION_TELEMETRY_BACKEND_ID_PATH", str(tmp_path / "backend-id")
-    )
     clear_config_cache()
     monkeypatch.setattr(telemetry.httpx, "AsyncClient", _MockAsyncClient)
+
+    async def backend_id(**kwargs):
+        return "automation-backend:cloud"
+
+    monkeypatch.setattr(telemetry, "get_automation_backend_distinct_id", backend_id)
 
     automation = _automation()
 
@@ -136,7 +143,7 @@ async def test_cloud_capture_uses_frontend_distinct_id_and_org_properties(
     )
 
     _, payload = _MockAsyncClient.posts[0]
-    assert payload["distinct_id"] == "ph-fe-123"
+    assert payload["distinct_id"] == "automation-backend:cloud"
     properties = payload["properties"]
     assert properties["deployment_mode"] == "cloud"
     assert properties["cloud_user_id"] == str(automation.user_id)
@@ -144,7 +151,7 @@ async def test_cloud_capture_uses_frontend_distinct_id_and_org_properties(
     assert properties["$groups"] == {"org": str(automation.org_id)}
     assert properties["creation_path"] == "prompt_preset"
     assert properties["frontend_distinct_id"] == "ph-fe-123"
-    assert properties["automation_backend_id"].startswith("automation-local:")
+    assert properties["automation_backend_id"] == "automation-backend:cloud"
 
 
 @pytest.mark.asyncio
@@ -222,6 +229,11 @@ async def test_capture_api_route_event_uses_endpoint_name_and_route_template(
     clear_config_cache()
     monkeypatch.setattr(telemetry.httpx, "AsyncClient", _MockAsyncClient)
 
+    async def backend_id(**kwargs):
+        return "automation-backend:api"
+
+    monkeypatch.setattr(telemetry, "get_automation_backend_distinct_id", backend_id)
+
     await telemetry.capture_api_route_event(
         _request("/api/automation/v1/123", endpoint_name="get_automation"),
         status_code=200,
@@ -237,3 +249,39 @@ async def test_capture_api_route_event_uses_endpoint_name_and_route_template(
     assert properties["status_code"] == 200
     assert properties["success"] is True
     assert properties["duration_ms"] == 12
+
+
+@pytest.mark.asyncio
+async def test_backend_distinct_id_is_db_backed_and_stable():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        first = await telemetry.get_automation_backend_distinct_id(
+            session_factory=session_factory
+        )
+        second = await telemetry.get_automation_backend_distinct_id(
+            session_factory=session_factory
+        )
+
+        assert first is not None
+        assert first.startswith("automation-backend:")
+        assert second == first
+
+        async with session_factory() as session:
+            row_count = await session.scalar(
+                select(func.count()).select_from(AutomationServiceMetadata)
+            )
+            stored = await session.scalar(
+                select(AutomationServiceMetadata.value).where(
+                    AutomationServiceMetadata.key
+                    == telemetry.TELEMETRY_BACKEND_DISTINCT_ID_KEY
+                )
+            )
+
+        assert row_count == 1
+        assert stored == first
+    finally:
+        await engine.dispose()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -456,9 +456,16 @@ def _request(path: str, *, endpoint_name: str = "list_automations"):
     )
 
 
-def test_should_capture_api_route_for_v1_and_public_paths():
+def test_should_capture_api_route_for_v1_routes_only():
     assert telemetry.should_capture_api_route(_request("/api/automation/v1"))
-    assert telemetry.should_capture_api_route(_request("/api/automation/server_info"))
+    assert not telemetry.should_capture_api_route(_request("/health"))
+    assert not telemetry.should_capture_api_route(_request("/api/automation/health"))
+    assert not telemetry.should_capture_api_route(_request("/ready"))
+    assert not telemetry.should_capture_api_route(_request("/api/automation/ready"))
+    assert not telemetry.should_capture_api_route(_request("/server_info"))
+    assert not telemetry.should_capture_api_route(
+        _request("/api/automation/server_info")
+    )
     assert not telemetry.should_capture_api_route(_request("/sdk-version"))
     assert not telemetry.should_capture_api_route(
         _request("/api/automation/sdk-version")

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -6,6 +6,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from openhands.automation import telemetry
+from openhands.automation.auth import AuthenticatedUser, AuthMethod
 from openhands.automation.config import clear_config_cache
 from openhands.automation.middleware import (
     TelemetryRequestContext,
@@ -234,8 +235,19 @@ async def test_capture_api_route_event_uses_endpoint_name_and_route_template(
 
     monkeypatch.setattr(telemetry, "get_automation_backend_distinct_id", backend_id)
 
+    request = _request("/api/automation/v1/123", endpoint_name="get_automation")
+    user = AuthenticatedUser(
+        user_id=uuid.uuid4(),
+        org_id=uuid.uuid4(),
+        email="user@example.com",
+        role="admin",
+        permissions=["manage_automations"],
+        auth_method=AuthMethod.API_KEY,
+    )
+    request.state.authenticated_user = user
+
     await telemetry.capture_api_route_event(
-        _request("/api/automation/v1/123", endpoint_name="get_automation"),
+        request,
         status_code=200,
         duration_ms=12,
     )
@@ -247,6 +259,12 @@ async def test_capture_api_route_event_uses_endpoint_name_and_route_template(
     assert properties["route_path"] == "/api/automation/v1/{automation_id}"
     assert properties["route_operation"] == "get_automation"
     assert properties["status_code"] == 200
+    assert properties["deployment_mode"] == "cloud"
+    assert properties["cloud_user_id"] == str(user.user_id)
+    assert properties["cloud_org_id"] == str(user.org_id)
+    assert properties["org_id"] == str(user.org_id)
+    assert properties["$groups"] == {"org": str(user.org_id)}
+
     assert properties["success"] is True
     assert properties["duration_ms"] == 12
 


### PR DESCRIPTION
## Summary
- Add optional PostHog capture for automation lifecycle events without persisting frontend distinct IDs on automation records.
- Use the automation backend distinct ID as the canonical PostHog `distinct_id`; frontend PostHog IDs are correlation properties only.
- Emit automation created/updated/deleted and run dispatched/completed/failed/skipped/cancelled events with cloud/local-safe correlation properties.
- Persist explicit local telemetry consent in `AutomationServiceMetadata`; reject consent-route calls in cloud mode because the main OpenHands app owns ToS and consent there.

## Architecture

```mermaid
flowchart TB
  subgraph Local[Local mode]
    AC[Agent Canvas<br/>PostHog frontend ID]
    Toggle[Analytics toggle]
    ConsentAPI[Automation API<br/>POST /v1/telemetry/consent]
    Meta[(AutomationServiceMetadata<br/>frontend consent map<br/>backend distinct ID)]
    LocalEvents[automation_* events]
    PH[(PostHog)]

    Toggle --> AC
    AC -- consent_granted + frontend_distinct_id --> ConsentAPI
    ConsentAPI --> Meta
    Meta -- any frontend consent is true --> LocalEvents
    LocalEvents -- distinct_id = automation backend ID<br/>props: deployment_mode=local<br/>optional frontend_distinct_id<br/>no cloud user/org/groups --> PH
  end

  subgraph Cloud[Cloud mode]
    App[Main OpenHands app<br/>ToS + consent gate]
    CloudAPI[Automation API<br/>POST /v1/telemetry/consent]
    CloudMeta[(AutomationServiceMetadata<br/>backend distinct ID)]
    CloudEvents[automation_* events]
    PH2[(PostHog)]

    App -. manages consent outside automation .-> CloudAPI
    CloudAPI -- 400: consent managed by main app --> App
    CloudMeta --> CloudEvents
    CloudEvents -- distinct_id = automation backend ID<br/>props: deployment_mode=cloud<br/>cloud_user_id + cloud_org_id<br/>PostHog org group metadata --> PH2
  end
```

ID rules:
- PostHog `distinct_id`: always the automation backend distinct ID.
- `automation_backend_id`: repeated as an event property for querying.
- `frontend_distinct_id`: optional event property from Agent Canvas requests or the local consent-link event; never used as PostHog `distinct_id`.
- Cloud identity: `cloud_user_id`, `cloud_org_id`, and PostHog org grouping are cloud-only.

## Validation
- `uv run ruff check openhands/automation/telemetry_router.py tests/test_telemetry.py`
- `uv run pytest tests/test_telemetry.py -q`
- `uv run pyright openhands/automation/telemetry_router.py tests/test_telemetry.py`
- Previous broader validation from this PR: telemetry, config, router, scheduler, dispatcher, and event-router checks listed in earlier commits.

Note: Docker-backed router tests could not run in this sandbox because Docker is unavailable (`docker.errors.DockerException: Error while fetching server API version`).

This PR was updated by an AI agent (OpenHands) on behalf of the user.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/df8d52e7-213b-4143-87d8-5ce651fc7e14)
