### PR TITLE
fix: add server versions to telemetry

### DIFF
--- a/openhands/automation/app.py
+++ b/openhands/automation/app.py
@@ -1,10 +1,10 @@
 """FastAPI application entrypoint."""
 
 import asyncio
-import importlib.metadata
 import logging
 import os
 from contextlib import asynccontextmanager
+from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -12,7 +12,6 @@ from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy import text
 
-from openhands.automation import __version__
 from openhands.automation.auth import create_http_client
 from openhands.automation.config import get_config, get_settings
 from openhands.automation.db import (
@@ -34,6 +33,7 @@ from openhands.automation.router import router
 from openhands.automation.scheduler import scheduler_loop
 from openhands.automation.telemetry_router import router as telemetry_router
 from openhands.automation.uploads import router as uploads_router
+from openhands.automation.utils.version import get_sdk_version, get_server_version_info
 from openhands.automation.watchdog import watchdog_loop
 from openhands.automation.webhook_router import router as webhook_router
 
@@ -274,11 +274,6 @@ async def readiness():
         )
 
 
-def _get_sdk_version() -> str:
-    """Return the installed OpenHands SDK package version."""
-    return importlib.metadata.version("openhands-sdk")
-
-
 @app.get("/sdk-version")
 @app.get(f"{_base_path}/sdk-version")
 async def sdk_version():
@@ -290,8 +285,8 @@ async def sdk_version():
     are available in the sandbox.
     """
     try:
-        version = _get_sdk_version()
-    except importlib.metadata.PackageNotFoundError:
+        version = get_sdk_version()
+    except PackageNotFoundError:
         return JSONResponse(
             status_code=503,
             content={"error": "openhands-sdk package not found"},
@@ -304,16 +299,12 @@ async def sdk_version():
 async def server_info():
     """Return public metadata about the automation service."""
     try:
-        sdk_version = _get_sdk_version()
-    except importlib.metadata.PackageNotFoundError:
+        return get_server_version_info()
+    except PackageNotFoundError:
         return JSONResponse(
             status_code=503,
             content={"error": "openhands-sdk package not found"},
         )
-    return {
-        "package_version": __version__,
-        "sdk_version": sdk_version,
-    }
 
 
 # ---------------------------------------------------------------------------

--- a/openhands/automation/telemetry.py
+++ b/openhands/automation/telemetry.py
@@ -22,6 +22,7 @@ from openhands.automation.models import (
     AutomationRun,
     AutomationServiceMetadata,
 )
+from openhands.automation.utils.version import get_server_version_info
 
 
 logger = logging.getLogger("automation.telemetry")
@@ -269,6 +270,7 @@ def _base_properties(
     properties: dict[str, Any] = {
         "deployment_mode": "local" if settings.is_local_mode else "cloud",
         "automation_service": "openhands_automation",
+        **get_server_version_info(missing_sdk_version="unknown"),
     }
 
     properties[AUTOMATION_BACKEND_ID_PROPERTY] = backend_distinct_id

--- a/openhands/automation/utils/version.py
+++ b/openhands/automation/utils/version.py
@@ -1,0 +1,30 @@
+"""Version metadata helpers for the automation service."""
+
+import importlib.metadata
+from typing import TypedDict
+
+from openhands.automation import __version__
+
+
+SDK_PACKAGE_NAME = "openhands-sdk"
+
+
+class ServerVersionInfo(TypedDict):
+    package_version: str
+    sdk_version: str
+
+
+def get_sdk_version() -> str:
+    return importlib.metadata.version(SDK_PACKAGE_NAME)
+
+
+def get_server_version_info(
+    *, missing_sdk_version: str | None = None
+) -> ServerVersionInfo:
+    try:
+        sdk_version = get_sdk_version()
+    except importlib.metadata.PackageNotFoundError:
+        if missing_sdk_version is None:
+            raise
+        sdk_version = missing_sdk_version
+    return {"package_version": __version__, "sdk_version": sdk_version}

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -105,7 +105,7 @@ class TestSdkVersionEndpoint:
     async def test_returns_503_when_package_not_found(self, health_client):
         """GET /sdk-version returns 503 when openhands-sdk is not installed."""
         with patch(
-            "openhands.automation.app.importlib.metadata.version",
+            "openhands.automation.utils.version.importlib.metadata.version",
             side_effect=importlib.metadata.PackageNotFoundError("openhands-sdk"),
         ):
             response = await health_client.get("/api/automation/sdk-version")
@@ -139,7 +139,7 @@ class TestServerInfoEndpoint:
     async def test_returns_503_when_sdk_package_not_found(self, health_client):
         """GET /server_info returns 503 when openhands-sdk is not installed."""
         with patch(
-            "openhands.automation.app.importlib.metadata.version",
+            "openhands.automation.utils.version.importlib.metadata.version",
             side_effect=importlib.metadata.PackageNotFoundError("openhands-sdk"),
         ):
             response = await health_client.get("/api/automation/server_info")

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -22,6 +22,7 @@ from openhands.automation.models import (
 )
 from openhands.automation.schemas import TelemetryConsentRequest
 from openhands.automation.telemetry_router import set_telemetry_consent
+from openhands.automation.utils.version import get_server_version_info
 
 
 class _Response:
@@ -67,6 +68,12 @@ def _run(automation: Automation) -> AutomationRun:
         automation=automation,
         status=AutomationRunStatus.COMPLETED,
     )
+
+
+def _assert_server_version_properties(properties: dict) -> None:
+    expected = get_server_version_info()
+    assert properties["package_version"] == expected["package_version"]
+    assert properties["sdk_version"] == expected["sdk_version"]
 
 
 @pytest.fixture(autouse=True)
@@ -123,6 +130,8 @@ async def test_local_capture_uses_backend_id_and_frontend_property(monkeypatch):
     assert payload["event"] == "automation_run_completed"
     assert payload["distinct_id"] == "automation-backend:test"
     properties = payload["properties"]
+    _assert_server_version_properties(properties)
+
     assert properties["automation_backend_id"] == "automation-backend:test"
     assert properties["frontend_distinct_id"] == "ph-fe-123"
     assert properties["client_source"] == "agent_canvas"
@@ -511,6 +520,8 @@ async def test_capture_api_route_event_uses_endpoint_name_and_route_template(
     assert properties["route_path"] == "/api/automation/v1/{automation_id}"
     assert properties["route_operation"] == "get_automation"
     assert properties["status_code"] == 200
+    _assert_server_version_properties(properties)
+
     assert properties["deployment_mode"] == "cloud"
     assert properties["cloud_user_id"] == str(user.user_id)
     assert properties["cloud_org_id"] == str(user.org_id)


### PR DESCRIPTION
## Summary
- Add automation package version and installed SDK version to the shared PostHog telemetry base properties.
- Deduplicate version metadata lookup through `openhands.automation.utils.version` and reuse it for `/sdk-version`, `/server_info`, and telemetry.
- Reuse the existing public server-info property names: `package_version` and `sdk_version`.
- Cover lifecycle, API route telemetry, and health endpoint payloads in tests.

## Verification
- `uv run pytest tests/test_health.py tests/test_telemetry.py -q`
- `uv run ruff check openhands/automation/app.py openhands/automation/telemetry.py openhands/automation/utils/version.py tests/test_health.py tests/test_telemetry.py`
- `uv run ruff format openhands/automation/app.py openhands/automation/telemetry.py openhands/automation/utils/version.py tests/test_health.py tests/test_telemetry.py`
- `uv run pre-commit run --files openhands/automation/app.py openhands/automation/telemetry.py openhands/automation/utils/version.py tests/test_health.py tests/test_telemetry.py --show-diff-on-failure`

Note: I also attempted `uv run pytest tests/ -q --ignore=tests/integration`, but this environment has no Docker daemon, so Docker/testcontainers-backed tests failed during setup.

_This PR was updated by an AI agent (OpenHands) on behalf of the user._