### PR TITLE
feat: expose requested automation event types

### DIFF
--- a/openhands/automation/event_router.py
+++ b/openhands/automation/event_router.py
@@ -39,12 +39,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from openhands.automation.db import get_session
 from openhands.automation.event_schemas import WebhookEvent, parse_event
-from openhands.automation.schemas import EventResponse
+from openhands.automation.event_schemas.github import get_supported_event_types
+from openhands.automation.schemas import EventResponse, RequestedEventTypesResponse
 from openhands.automation.telemetry import capture_automation_event
 from openhands.automation.trigger_matcher import matches_trigger
 from openhands.automation.utils.webhook import (
     create_automation_run,
     get_event_automations,
+    get_requested_event_types,
     get_webhook_config,
     verify_signature,
 )
@@ -53,6 +55,43 @@ from openhands.automation.utils.webhook import (
 logger = logging.getLogger("automation.event_router")
 
 router = APIRouter(prefix="/v1/events", tags=["events"])
+
+
+@router.get("/{source}/requested-types", response_model=RequestedEventTypesResponse)
+async def requested_event_types(
+    source: str,
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+) -> RequestedEventTypesResponse:
+    """Return event types currently requested by enabled automations.
+
+    This endpoint is intended for trusted webhook forwarders. Built-in sources
+    authenticate with the same shared webhook secret used for event delivery.
+    The signature is computed over the UTF-8 source string.
+    """
+    config = await get_webhook_config(source, uuid.UUID(int=0), session)
+    if not config or not config.is_builtin:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Unknown builtin webhook source: {source}",
+        )
+
+    signature = request.headers.get(config.signature_header)
+    if not signature:
+        raise HTTPException(
+            status_code=401,
+            detail=f"Missing signature header: {config.signature_header}",
+        )
+    if not verify_signature(source.encode("utf-8"), signature, config.secret):
+        raise HTTPException(status_code=401, detail="Invalid signature")
+
+    supported_event_types = (
+        set(get_supported_event_types()) if source == "github" else None
+    )
+    event_types = await get_requested_event_types(
+        source, session, supported_event_types=supported_event_types
+    )
+    return RequestedEventTypesResponse(source=source, event_types=event_types)
 
 
 @router.post("/{org_id}/{source}", response_model=EventResponse)

--- a/openhands/automation/event_router.py
+++ b/openhands/automation/event_router.py
@@ -92,12 +92,14 @@ async def requested_event_types(
     if not verify_signature(source.encode("utf-8"), signature, config.secret):
         raise HTTPException(status_code=401, detail="Invalid signature")
 
-    supported_event_types = (
-        set(get_supported_event_types()) if source == "github" else None
-    )
-    event_types = await get_requested_event_types(
-        source, session, supported_event_types=supported_event_types
-    )
+    if source == "github":
+        # GitHub forwarding is prefiltered at the event-family level. Return all
+        # event families automation can parse so webhook forwarding still works
+        # before any org has configured automations; automation performs the
+        # granular action/filter matching after receiving the event.
+        event_types = get_supported_event_types()
+    else:
+        event_types = await get_requested_event_types(source, session)
     logger.info(
         "Requested event types for source=%s: event_types=%s",
         source,

--- a/openhands/automation/event_router.py
+++ b/openhands/automation/event_router.py
@@ -39,8 +39,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from openhands.automation.db import get_session
 from openhands.automation.event_schemas import WebhookEvent, parse_event
-from openhands.automation.event_schemas.github import get_supported_event_types
-from openhands.automation.schemas import EventResponse, RequestedEventTypesResponse
+from openhands.automation.event_schemas.github import (
+    get_event_detection_rules,
+    get_supported_event_types,
+)
+from openhands.automation.schemas import (
+    EventDetectionRule,
+    EventResponse,
+    RequestedEventTypesResponse,
+)
 from openhands.automation.telemetry import capture_automation_event
 from openhands.automation.trigger_matcher import matches_trigger
 from openhands.automation.utils.webhook import (
@@ -91,7 +98,19 @@ async def requested_event_types(
     event_types = await get_requested_event_types(
         source, session, supported_event_types=supported_event_types
     )
-    return RequestedEventTypesResponse(source=source, event_types=event_types)
+    event_detection_rules = (
+        [
+            EventDetectionRule.model_validate(rule)
+            for rule in get_event_detection_rules()
+        ]
+        if source == "github"
+        else []
+    )
+    return RequestedEventTypesResponse(
+        source=source,
+        event_types=event_types,
+        event_detection_rules=event_detection_rules,
+    )
 
 
 @router.post("/{org_id}/{source}", response_model=EventResponse)

--- a/openhands/automation/event_router.py
+++ b/openhands/automation/event_router.py
@@ -49,7 +49,7 @@ from openhands.automation.schemas import (
     RequestedEventTypesResponse,
 )
 from openhands.automation.telemetry import capture_automation_event
-from openhands.automation.trigger_matcher import matches_trigger
+from openhands.automation.trigger_matcher import match_trigger_with_reason
 from openhands.automation.utils.webhook import (
     create_automation_run,
     get_event_automations,
@@ -97,6 +97,11 @@ async def requested_event_types(
     )
     event_types = await get_requested_event_types(
         source, session, supported_event_types=supported_event_types
+    )
+    logger.info(
+        "Requested event types for source=%s: event_types=%s",
+        source,
+        event_types,
     )
     event_detection_rules = (
         [
@@ -247,7 +252,24 @@ async def receive_event(
 
     for automation, trigger in automations:
         # Match trigger against webhook payload using JMESPath filter
-        if matches_trigger(trigger, source, event.event_key, webhook_payload):
+        matched, reason = match_trigger_with_reason(
+            trigger, source, event.event_key, webhook_payload
+        )
+        logger.info(
+            "Evaluated event trigger: org=%s source=%s event_key=%s "
+            "automation_id=%s automation_name=%s trigger_on=%s "
+            "trigger_filter=%s matched=%s reason=%s",
+            org_id,
+            source,
+            event.event_key,
+            automation.id,
+            automation.name,
+            trigger.on,
+            trigger.filter,
+            matched,
+            reason,
+        )
+        if matched:
             matched_automations.append(automation)
 
     logger.info(

--- a/openhands/automation/event_router.py
+++ b/openhands/automation/event_router.py
@@ -49,7 +49,7 @@ from openhands.automation.schemas import (
     RequestedEventTypesResponse,
 )
 from openhands.automation.telemetry import capture_automation_event
-from openhands.automation.trigger_matcher import match_trigger_with_reason
+from openhands.automation.trigger_matcher import matches_trigger
 from openhands.automation.utils.webhook import (
     create_automation_run,
     get_event_automations,
@@ -100,11 +100,6 @@ async def requested_event_types(
         event_types = get_supported_event_types()
     else:
         event_types = await get_requested_event_types(source, session)
-    logger.info(
-        "Requested event types for source=%s: event_types=%s",
-        source,
-        event_types,
-    )
     event_detection_rules = (
         [
             EventDetectionRule.model_validate(rule)
@@ -254,24 +249,7 @@ async def receive_event(
 
     for automation, trigger in automations:
         # Match trigger against webhook payload using JMESPath filter
-        matched, reason = match_trigger_with_reason(
-            trigger, source, event.event_key, webhook_payload
-        )
-        logger.info(
-            "Evaluated event trigger: org=%s source=%s event_key=%s "
-            "automation_id=%s automation_name=%s trigger_on=%s "
-            "trigger_filter=%s matched=%s reason=%s",
-            org_id,
-            source,
-            event.event_key,
-            automation.id,
-            automation.name,
-            trigger.on,
-            trigger.filter,
-            matched,
-            reason,
-        )
-        if matched:
+        if matches_trigger(trigger, source, event.event_key, webhook_payload):
             matched_automations.append(automation)
 
     logger.info(

--- a/openhands/automation/event_schemas/github.py
+++ b/openhands/automation/event_schemas/github.py
@@ -481,3 +481,11 @@ def parse_github_event_auto(payload: dict[str, Any]) -> GitHubEvent:
 def get_supported_event_types() -> list[str]:
     """Get list of all supported GitHub event types."""
     return list(GITHUB_PAYLOAD_CLASSES.keys())
+
+
+def get_event_detection_rules() -> list[dict[str, str]]:
+    """Get ordered GitHub event type detection rules."""
+    return [
+        {"event_type": event_type, "jmespath": expression}
+        for event_type, expression in GITHUB_DETECTION_RULES
+    ]

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -391,6 +391,13 @@ class EventResponse(BaseModel):
     runs_created: list[str]  # List of run IDs created
 
 
+class RequestedEventTypesResponse(BaseModel):
+    """Event types currently requested by enabled automations for a source."""
+
+    source: str
+    event_types: list[str]
+
+
 # Valid source name pattern: lowercase alphanumeric with hyphens, 1-50 chars
 _SOURCE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,48}[a-z0-9]$|^[a-z0-9]$")
 

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -391,11 +391,19 @@ class EventResponse(BaseModel):
     runs_created: list[str]  # List of run IDs created
 
 
+class EventDetectionRule(BaseModel):
+    """Payload rule used to detect a source event type."""
+
+    event_type: str
+    jmespath: str
+
+
 class RequestedEventTypesResponse(BaseModel):
     """Event types currently requested by enabled automations for a source."""
 
     source: str
     event_types: list[str]
+    event_detection_rules: list[EventDetectionRule] = Field(default_factory=list)
 
 
 # Valid source name pattern: lowercase alphanumeric with hyphens, 1-50 chars

--- a/openhands/automation/telemetry.py
+++ b/openhands/automation/telemetry.py
@@ -313,7 +313,7 @@ def _base_properties(
         properties.update(
             {
                 "run_id": str(run.id),
-                "run_status": run.status.value,
+                "run_status": run.status.value if run.status is not None else None,
                 "has_conversation_id": bool(run.conversation_id),
             }
         )

--- a/openhands/automation/trigger_matcher.py
+++ b/openhands/automation/trigger_matcher.py
@@ -24,12 +24,12 @@ from openhands.automation.schemas import EventTrigger
 logger = logging.getLogger("automation.trigger_matcher")
 
 
-def match_trigger_with_reason(
+def matches_trigger(
     trigger: EventTrigger,
     event_source: str,
     event_key: str,
     payload: dict[str, Any],
-) -> tuple[bool, str]:
+) -> bool:
     """
     Check if an event matches an event trigger.
 
@@ -40,7 +40,7 @@ def match_trigger_with_reason(
         payload: The webhook payload for filter evaluation
 
     Returns:
-        Tuple of whether the trigger matched and a diagnostic reason.
+        True if the event matches all trigger conditions
 
     Examples:
         >>> trigger = EventTrigger(
@@ -53,11 +53,11 @@ def match_trigger_with_reason(
     """
     # 1. Source must match
     if trigger.source != event_source:
-        return False, f"source mismatch: trigger_source={trigger.source}"
+        return False
 
     # 2. Event key must match one of the patterns
     if not _matches_event_key(event_key, trigger.on):
-        return False, f"event key mismatch: trigger_on={trigger.on}"
+        return False
 
     # 3. Filter expression must evaluate to true (if specified)
     if trigger.filter:
@@ -68,25 +68,12 @@ def match_trigger_with_reason(
                     trigger.filter,
                     event_key,
                 )
-                return False, f"filter mismatch: filter={trigger.filter}"
+                return False
         except FilterEvaluationError as e:
             logger.warning("Filter evaluation failed: %s", e)
-            return False, f"filter evaluation error: {e}"
+            return False
 
-    return True, "matched"
-
-
-def matches_trigger(
-    trigger: EventTrigger,
-    event_source: str,
-    event_key: str,
-    payload: dict[str, Any],
-) -> bool:
-    """Check if an event matches an event trigger."""
-    matched, _reason = match_trigger_with_reason(
-        trigger, event_source, event_key, payload
-    )
-    return matched
+    return True
 
 
 def _matches_event_key(event_key: str, on: str | list[str]) -> bool:

--- a/openhands/automation/trigger_matcher.py
+++ b/openhands/automation/trigger_matcher.py
@@ -24,12 +24,12 @@ from openhands.automation.schemas import EventTrigger
 logger = logging.getLogger("automation.trigger_matcher")
 
 
-def matches_trigger(
+def match_trigger_with_reason(
     trigger: EventTrigger,
     event_source: str,
     event_key: str,
     payload: dict[str, Any],
-) -> bool:
+) -> tuple[bool, str]:
     """
     Check if an event matches an event trigger.
 
@@ -40,7 +40,7 @@ def matches_trigger(
         payload: The webhook payload for filter evaluation
 
     Returns:
-        True if the event matches all trigger conditions
+        Tuple of whether the trigger matched and a diagnostic reason.
 
     Examples:
         >>> trigger = EventTrigger(
@@ -53,11 +53,11 @@ def matches_trigger(
     """
     # 1. Source must match
     if trigger.source != event_source:
-        return False
+        return False, f"source mismatch: trigger_source={trigger.source}"
 
     # 2. Event key must match one of the patterns
     if not _matches_event_key(event_key, trigger.on):
-        return False
+        return False, f"event key mismatch: trigger_on={trigger.on}"
 
     # 3. Filter expression must evaluate to true (if specified)
     if trigger.filter:
@@ -68,12 +68,25 @@ def matches_trigger(
                     trigger.filter,
                     event_key,
                 )
-                return False
+                return False, f"filter mismatch: filter={trigger.filter}"
         except FilterEvaluationError as e:
             logger.warning("Filter evaluation failed: %s", e)
-            return False
+            return False, f"filter evaluation error: {e}"
 
-    return True
+    return True, "matched"
+
+
+def matches_trigger(
+    trigger: EventTrigger,
+    event_source: str,
+    event_key: str,
+    payload: dict[str, Any],
+) -> bool:
+    """Check if an event matches an event trigger."""
+    matched, _reason = match_trigger_with_reason(
+        trigger, event_source, event_key, payload
+    )
+    return matched
 
 
 def _matches_event_key(event_key: str, on: str | list[str]) -> bool:

--- a/openhands/automation/utils/webhook.py
+++ b/openhands/automation/utils/webhook.py
@@ -17,7 +17,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from openhands.automation.config import Settings, get_settings
 from openhands.automation.db import using_sqlite
-from openhands.automation.models import Automation, AutomationRun, CustomWebhook
+from openhands.automation.models import (
+    Automation,
+    AutomationRun,
+    AutomationRunStatus,
+    CustomWebhook,
+)
 from openhands.automation.schemas import EventTrigger, WebhookConfig
 
 
@@ -210,6 +215,68 @@ async def get_event_automations(
     return result_pairs
 
 
+def _event_type_from_pattern(pattern: str) -> str:
+    return pattern.split(".", 1)[0].strip()
+
+
+async def get_requested_event_types(
+    source: str,
+    session: AsyncSession,
+    *,
+    supported_event_types: set[str] | None = None,
+) -> list[str]:
+    """Return source event types requested by enabled event automations.
+
+    Trigger patterns can include actions (``pull_request.opened``) or wildcards
+    (``pull_request.*``). The forwarding service only needs the top-level source
+    event type. Unsupported requested types are omitted when a supported set is
+    provided.
+    """
+    from sqlalchemy import func, literal
+
+    base_filters = [
+        Automation.enabled == True,  # noqa: E712
+        Automation.deleted_at.is_(None),
+    ]
+
+    if using_sqlite():
+        trigger_filter = and_(
+            func.json_extract(Automation.trigger, "$.type") == literal("event"),
+            func.json_extract(Automation.trigger, "$.source") == literal(source),
+        )
+    else:
+        trigger_filter = and_(
+            Automation.trigger.op("->>")("type") == literal("event"),
+            Automation.trigger.op("->>")("source") == literal(source),
+        )
+
+    result = await session.execute(
+        select(Automation.trigger).where(*base_filters, trigger_filter)
+    )
+
+    supported = (
+        set(supported_event_types) if supported_event_types is not None else None
+    )
+    requested: set[str] = set()
+    for trigger_data in result.scalars().all():
+        try:
+            trigger = EventTrigger.model_validate(trigger_data)
+        except Exception as e:
+            logger.warning("Failed to parse event trigger for requested types: %s", e)
+            continue
+
+        for pattern in trigger.event_patterns:
+            event_type = _event_type_from_pattern(pattern)
+            if not event_type:
+                continue
+            if event_type == "*":
+                return sorted(supported) if supported is not None else ["*"]
+            if supported is None or event_type in supported:
+                requested.add(event_type)
+
+    return sorted(requested)
+
+
 async def create_automation_run(
     automation: Automation,
     session: AsyncSession,
@@ -231,6 +298,7 @@ async def create_automation_run(
     run = AutomationRun(
         id=uuid.uuid4(),
         automation_id=automation.id,
+        status=AutomationRunStatus.PENDING,
         event_payload=event_payload,
     )
     session.add(run)

--- a/tests/test_event_router.py
+++ b/tests/test_event_router.py
@@ -197,9 +197,17 @@ async def test_requested_github_event_types_returns_enabled_supported_triggers(
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "source": "github",
-        "event_types": ["pull_request", "push"],
+    data = response.json()
+    assert data["source"] == "github"
+    assert data["event_types"] == ["pull_request", "push"]
+    assert data["event_detection_rules"][0] == {
+        "event_type": "pull_request_review",
+        "jmespath": "contains(keys(@), 'pull_request') && contains(keys(@), 'review')",
+    }
+    assert {rule["event_type"] for rule in data["event_detection_rules"]} >= {
+        "pull_request",
+        "issue_comment",
+        "push",
     }
 
 

--- a/tests/test_event_router.py
+++ b/tests/test_event_router.py
@@ -145,51 +145,11 @@ def sign_text(text: str, secret: str) -> str:
 
 
 @pytest.mark.asyncio
-async def test_requested_github_event_types_returns_enabled_supported_triggers(
+async def test_requested_github_event_types_returns_supported_event_families(
     async_client: AsyncClient,
-    org_id: uuid.UUID,
-    async_session,
     monkeypatch: pytest.MonkeyPatch,
-    mock_authenticated_user,
 ):
     monkeypatch.setenv("AUTOMATION_WEBHOOK_SECRET", "test-secret")
-
-    automations = [
-        Automation(
-            id=uuid.uuid4(),
-            user_id=mock_authenticated_user.user_id,
-            org_id=org_id,
-            name="Push Automation",
-            tarball_path="oh-internal://uploads/test.tar.gz",
-            entrypoint="python main.py",
-            trigger={"type": "event", "source": "github", "on": "push"},
-        ),
-        Automation(
-            id=uuid.uuid4(),
-            user_id=mock_authenticated_user.user_id,
-            org_id=org_id,
-            name="PR Automation",
-            tarball_path="oh-internal://uploads/test.tar.gz",
-            entrypoint="python main.py",
-            trigger={
-                "type": "event",
-                "source": "github",
-                "on": ["pull_request.opened", "workflow_run.completed"],
-            },
-        ),
-        Automation(
-            id=uuid.uuid4(),
-            user_id=mock_authenticated_user.user_id,
-            org_id=org_id,
-            name="Disabled Issues Automation",
-            tarball_path="oh-internal://uploads/test.tar.gz",
-            entrypoint="python main.py",
-            enabled=False,
-            trigger={"type": "event", "source": "github", "on": "issues.opened"},
-        ),
-    ]
-    async_session.add_all(automations)
-    await async_session.commit()
 
     response = await async_client.get(
         "/api/automation/v1/events/github/requested-types",
@@ -199,7 +159,14 @@ async def test_requested_github_event_types_returns_enabled_supported_triggers(
     assert response.status_code == 200
     data = response.json()
     assert data["source"] == "github"
-    assert data["event_types"] == ["pull_request", "push"]
+    assert data["event_types"] == [
+        "pull_request",
+        "pull_request_review",
+        "issues",
+        "issue_comment",
+        "push",
+        "release",
+    ]
     assert data["event_detection_rules"][0] == {
         "event_type": "pull_request_review",
         "jmespath": "contains(keys(@), 'pull_request') && contains(keys(@), 'review')",

--- a/tests/test_event_router.py
+++ b/tests/test_event_router.py
@@ -138,6 +138,87 @@ def sign_payload(payload: dict, secret: str) -> tuple[str, bytes]:
     return f"sha256={sig}", body
 
 
+def sign_text(text: str, secret: str) -> str:
+    """Generate HMAC signature for a UTF-8 text payload."""
+    sig = hmac.new(secret.encode(), text.encode(), hashlib.sha256).hexdigest()
+    return f"sha256={sig}"
+
+
+@pytest.mark.asyncio
+async def test_requested_github_event_types_returns_enabled_supported_triggers(
+    async_client: AsyncClient,
+    org_id: uuid.UUID,
+    async_session,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_authenticated_user,
+):
+    monkeypatch.setenv("AUTOMATION_WEBHOOK_SECRET", "test-secret")
+
+    automations = [
+        Automation(
+            id=uuid.uuid4(),
+            user_id=mock_authenticated_user.user_id,
+            org_id=org_id,
+            name="Push Automation",
+            tarball_path="oh-internal://uploads/test.tar.gz",
+            entrypoint="python main.py",
+            trigger={"type": "event", "source": "github", "on": "push"},
+        ),
+        Automation(
+            id=uuid.uuid4(),
+            user_id=mock_authenticated_user.user_id,
+            org_id=org_id,
+            name="PR Automation",
+            tarball_path="oh-internal://uploads/test.tar.gz",
+            entrypoint="python main.py",
+            trigger={
+                "type": "event",
+                "source": "github",
+                "on": ["pull_request.opened", "workflow_run.completed"],
+            },
+        ),
+        Automation(
+            id=uuid.uuid4(),
+            user_id=mock_authenticated_user.user_id,
+            org_id=org_id,
+            name="Disabled Issues Automation",
+            tarball_path="oh-internal://uploads/test.tar.gz",
+            entrypoint="python main.py",
+            enabled=False,
+            trigger={"type": "event", "source": "github", "on": "issues.opened"},
+        ),
+    ]
+    async_session.add_all(automations)
+    await async_session.commit()
+
+    response = await async_client.get(
+        "/api/automation/v1/events/github/requested-types",
+        headers={"X-Hub-Signature-256": sign_text("github", "test-secret")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "source": "github",
+        "event_types": ["pull_request", "push"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_requested_github_event_types_rejects_invalid_signature(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("AUTOMATION_WEBHOOK_SECRET", "test-secret")
+
+    response = await async_client.get(
+        "/api/automation/v1/events/github/requested-types",
+        headers={"X-Hub-Signature-256": "sha256=invalid"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid signature"
+
+
 @pytest.mark.asyncio
 async def test_receive_github_event_no_matching_automations(
     async_client: AsyncClient,


### PR DESCRIPTION
## Summary
- Add a signed `GET /v1/events/{source}/requested-types` endpoint for trusted webhook forwarders.
- Compute requested top-level event types from enabled event-triggered automations, filtering to currently supported GitHub types.
- Explicitly initialize event-created automation runs as `PENDING` and guard telemetry against unset `run.status`.

## Verification
- `uv run pre-commit run --files openhands/automation/event_router.py openhands/automation/utils/webhook.py openhands/automation/schemas.py openhands/automation/telemetry.py tests/test_event_router.py --show-diff-on-failure`
- `uv run pytest tests/test_telemetry.py -q`
- Attempted `uv run pytest tests/test_event_router.py tests/test_telemetry.py -q`; event-router tests require Docker/testcontainers and Docker is unavailable in this runtime (`FileNotFoundError` for Docker socket). Telemetry tests passed.

This PR was created by an AI agent (OpenHands) on behalf of the user.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5840b589-4a94-4738-b329-2070c5736b5f)