### PR TITLE
feat: report the configured automation timeout cap

### DIFF
--- a/openhands/automation/capabilities_router.py
+++ b/openhands/automation/capabilities_router.py
@@ -93,6 +93,7 @@ async def get_capabilities(
     if not (config.service.is_local_mode or config.service.service_key):
         return CapabilitiesResponse(
             ready=False,
+            max_automation_timeout_seconds=config.sandbox.max_run_duration,
             trigger_kinds=[],
             event_sources=[],
             event_types=[],
@@ -113,6 +114,7 @@ async def get_capabilities(
 
     return CapabilitiesResponse(
         ready=True,
+        max_automation_timeout_seconds=config.sandbox.max_run_duration,
         trigger_kinds=["cron", "event"] if event_sources else ["cron"],
         event_sources=event_sources,
         event_types=(

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -722,6 +722,10 @@ class CapabilitiesResponse(_SetupContractModel):
     """What this deployment supports, discovered before a setup form renders."""
 
     ready: bool = Field(..., description="Whether the service can accept new work")
+    max_automation_timeout_seconds: int = Field(
+        ...,
+        description="Maximum timeout the service accepts for an automation run",
+    )
     trigger_kinds: list[str]
     event_sources: list[str]
     event_types: list[str] = Field(

--- a/tests/test_capabilities_router.py
+++ b/tests/test_capabilities_router.py
@@ -131,6 +131,18 @@ class TestGetCapabilities:
         assert "webhookDelivery" in body["features"]
         assert "kvStore" in body["features"]
 
+    async def test_advertises_the_configured_timeout_ceiling(
+        self, async_client, ready_deployment, monkeypatch
+    ):
+        """The setup client learns the same maximum the API enforces."""
+        monkeypatch.setenv("AUTOMATION_MAX_RUN_DURATION", "900")
+        clear_config_cache()
+
+        response = await async_client.get(CAPABILITIES_URL)
+
+        assert response.status_code == 200
+        assert response.json()["maxAutomationTimeoutSeconds"] == 900
+
     async def test_deployment_without_webhook_secret_withdraws_event_support(
         self, async_client, ready_deployment, monkeypatch
     ):


### PR DESCRIPTION
## Summary

- expose the configured `max_run_duration` as `maxAutomationTimeoutSeconds` in capability discovery
- return the same runtime-derived value for ready and unavailable deployments
- cover an overridden deployment configuration

## Testing

- `uv run pytest tests/test_capabilities_router.py -q`

This provides the server-authoritative ceiling for Agent Canvas, rather than requiring clients to duplicate the default.