### PR TITLE
perf: cache SDK version metadata

### DIFF
--- a/openhands/automation/utils/version.py
+++ b/openhands/automation/utils/version.py
@@ -1,6 +1,7 @@
 """Version metadata helpers for the automation service."""
 
 import importlib.metadata
+from functools import lru_cache
 from typing import TypedDict
 
 from openhands.automation import __version__
@@ -14,6 +15,7 @@ class ServerVersionInfo(TypedDict):
     sdk_version: str
 
 
+@lru_cache(maxsize=1)
 def get_sdk_version() -> str:
     return importlib.metadata.version(SDK_PACKAGE_NAME)
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,22 @@
+import importlib.metadata
+
+from openhands.automation.utils.version import SDK_PACKAGE_NAME, get_sdk_version
+
+
+def test_get_sdk_version_caches_package_metadata_lookup(monkeypatch):
+    calls = 0
+
+    def package_version(name: str) -> str:
+        nonlocal calls
+        calls += 1
+        assert name == SDK_PACKAGE_NAME
+        return "1.2.3"
+
+    monkeypatch.setattr(importlib.metadata, "version", package_version)
+    get_sdk_version.cache_clear()
+    try:
+        assert get_sdk_version() == "1.2.3"
+        assert get_sdk_version() == "1.2.3"
+        assert calls == 1
+    finally:
+        get_sdk_version.cache_clear()


### PR DESCRIPTION
## Summary

- cache the installed OpenHands SDK version for the process lifetime
- avoid repeated synchronous package-metadata filesystem lookups on every telemetry event
- add a regression test that verifies repeated reads perform one metadata lookup

## Testing

- `pytest tests/test_version.py --noconftest -q`
- `ruff check openhands/automation/utils/version.py tests/test_version.py`
- `ruff format --check openhands/automation/utils/version.py tests/test_version.py`

Fixes #289

Disclosure: This change was prepared with AI assistance. I reviewed the implementation and ran the checks listed above.