### PR TITLE
perf: reuse telemetry HTTP client

### DIFF
--- a/openhands/automation/app.py
+++ b/openhands/automation/app.py
@@ -30,6 +30,10 @@ from openhands.automation.middleware import (
 from openhands.automation.preset_router import router as preset_router
 from openhands.automation.router import router
 from openhands.automation.scheduler import scheduler_loop
+from openhands.automation.telemetry import (
+    close_telemetry_http_client,
+    get_telemetry_http_client,
+)
 from openhands.automation.telemetry_router import router as telemetry_router
 from openhands.automation.uploads import router as uploads_router
 from openhands.automation.utils.version import get_sdk_version, get_server_version_info
@@ -65,6 +69,7 @@ async def lifespan(app: FastAPI):
 
     # Create shared httpx client for auth (stored in app.state for DI)
     app.state.http_client = create_http_client()
+    get_telemetry_http_client()
 
     # Create engine and session factory, store in app.state
     engine_result = await create_engine(settings)
@@ -183,6 +188,7 @@ async def lifespan(app: FastAPI):
                 pass
 
     await app.state.http_client.aclose()
+    await close_telemetry_http_client()
     await app.state.engine_result.dispose()
     logger.info("Automations service shut down")
 

--- a/openhands/automation/telemetry.py
+++ b/openhands/automation/telemetry.py
@@ -26,6 +26,7 @@ from openhands.automation.utils.version import get_server_version_info
 
 
 logger = logging.getLogger("automation.telemetry")
+_telemetry_http_client: httpx.AsyncClient | None = None
 AUTOMATION_BACKEND_ID_PROPERTY = "automation_backend_id"
 FRONTEND_DISTINCT_ID_PROPERTY = "frontend_distinct_id"
 POSTHOG_CAPTURE_PATH = "/capture/"
@@ -34,6 +35,23 @@ TELEMETRY_CONSENT_ANONYMOUS_ID = "__anonymous__"
 
 API_EVENT_PREFIX = "automation_api"
 TELEMETRY_BACKEND_DISTINCT_ID_KEY = "posthog_backend_distinct_id"
+
+
+def get_telemetry_http_client() -> httpx.AsyncClient:
+    """Return the process-wide client used for PostHog capture requests."""
+    global _telemetry_http_client
+    if _telemetry_http_client is None:
+        _telemetry_http_client = httpx.AsyncClient(timeout=2.0)
+    return _telemetry_http_client
+
+
+async def close_telemetry_http_client() -> None:
+    """Close the shared telemetry client and clear it for future lifespans."""
+    global _telemetry_http_client
+    client = _telemetry_http_client
+    _telemetry_http_client = None
+    if client is not None:
+        await client.aclose()
 
 
 async def _get_or_create_backend_distinct_id(session: AsyncSession) -> str:
@@ -452,11 +470,10 @@ async def capture_automation_event(
     }
 
     try:
-        async with httpx.AsyncClient(timeout=2.0) as client:
-            response = await client.post(
-                f"{settings.posthog_host.rstrip('/')}{POSTHOG_CAPTURE_PATH}",
-                json=payload,
-            )
-            response.raise_for_status()
+        response = await get_telemetry_http_client().post(
+            f"{settings.posthog_host.rstrip('/')}{POSTHOG_CAPTURE_PATH}",
+            json=payload,
+        )
+        response.raise_for_status()
     except Exception:
         logger.debug("Failed to capture automation telemetry event", exc_info=True)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -34,9 +34,11 @@ class _Response:
 
 class _MockAsyncClient:
     posts: ClassVar[list[tuple[str, dict]]] = []
+    instances: ClassVar[list["_MockAsyncClient"]] = []
 
     def __init__(self, *args, **kwargs) -> None:
-        pass
+        self.closed = False
+        self.instances.append(self)
 
     async def __aenter__(self):
         return self
@@ -47,6 +49,9 @@ class _MockAsyncClient:
     async def post(self, url: str, json: dict) -> _Response:
         self.posts.append((url, json))
         return _Response()
+
+    async def aclose(self) -> None:
+        self.closed = True
 
 
 def _automation(telemetry_distinct_id: str | None = None) -> Automation:
@@ -89,8 +94,40 @@ def _reset_config(monkeypatch):
         monkeypatch.delenv(name, raising=False)
     clear_config_cache()
     _MockAsyncClient.posts.clear()
+    _MockAsyncClient.instances.clear()
+    monkeypatch.setattr(telemetry, "_telemetry_http_client", None)
     yield
     clear_config_cache()
+
+
+@pytest.mark.asyncio
+async def test_capture_reuses_shared_http_client(monkeypatch):
+    monkeypatch.setenv("AUTOMATION_POSTHOG_API_KEY", "ph_test")
+    clear_config_cache()
+    monkeypatch.setattr(telemetry.httpx, "AsyncClient", _MockAsyncClient)
+
+    async def backend_id(**kwargs):
+        return "automation-backend:test"
+
+    monkeypatch.setattr(telemetry, "get_automation_backend_distinct_id", backend_id)
+
+    await telemetry.capture_automation_event("automation_created")
+    await telemetry.capture_automation_event("automation_event_received")
+
+    assert len(_MockAsyncClient.instances) == 1
+    assert len(_MockAsyncClient.posts) == 2
+
+
+@pytest.mark.asyncio
+async def test_close_telemetry_http_client_allows_clean_restart(monkeypatch):
+    monkeypatch.setattr(telemetry.httpx, "AsyncClient", _MockAsyncClient)
+    first_client = telemetry.get_telemetry_http_client()
+
+    await telemetry.close_telemetry_http_client()
+
+    assert first_client.closed is True
+    second_client = telemetry.get_telemetry_http_client()
+    assert second_client is not first_client
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- reuse one process-wide `httpx.AsyncClient` for PostHog capture requests so telemetry benefits from connection pooling and keep-alive
- initialize the client during application startup and close/reset it during shutdown
- add regression coverage for multi-event reuse and clean client recreation after shutdown

## Testing

- `ruff check openhands/automation/telemetry.py openhands/automation/app.py tests/test_telemetry.py`
- `ruff format --check openhands/automation/telemetry.py openhands/automation/app.py tests/test_telemetry.py`
- 16 focused telemetry tests passed in an isolated Python 3.12 environment
- full dependency sync was unavailable locally because LiteLLM 1.93's Windows build requires the MSVC linker; upstream Linux CI should run the complete suite

Fixes #288

Disclosure: This change was prepared with AI assistance. I reviewed the implementation and ran the checks listed above.