### PR TITLE
fix: trust ingress forwarded headers

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.12-slim-bookworm
 
 WORKDIR /app
 ENV PYTHONPATH='/app'
+# The service image runs behind an ingress. Direct deployments can override
+# this with their trusted proxy IPs or CIDRs.
+ENV FORWARDED_ALLOW_IPS='*'
 
 # Datadog labels
 LABEL com.datadoghq.tags.service="automation"


### PR DESCRIPTION
## Summary

- trust ingress proxy headers by default in the service container
- let Uvicorn honor `X-Forwarded-Proto: https` from in-cluster ingress addresses so canonical redirects keep the HTTPS scheme
- use the `FORWARDED_ALLOW_IPS` environment variable so direct deployments can override the default with specific trusted proxy IPs or CIDRs

## Validation

- confirmed Uvicorn resolves `Config.forwarded_allow_ips` to `*` from the container environment
- `git diff --check`

Fixes #245

Disclosure: This change was prepared with AI assistance. I reviewed the configuration and validated Uvicorn's environment handling.