### PR TITLE
fix: prevent watchdog stuck-RUNNING via telemetry datetime crash

### DIFF
--- a/openhands/automation/telemetry.py
+++ b/openhands/automation/telemetry.py
@@ -22,6 +22,7 @@ from openhands.automation.models import (
     AutomationRun,
     AutomationServiceMetadata,
 )
+from openhands.automation.utils.time import ensure_utc
 from openhands.automation.utils.version import get_server_version_info
 
 
@@ -374,7 +375,10 @@ def _base_properties(
         properties.setdefault("automation_id", str(run.automation_id))
         if run.started_at and run.completed_at:
             duration_ms = int(
-                (run.completed_at - run.started_at).total_seconds() * 1000
+                (
+                    ensure_utc(run.completed_at) - ensure_utc(run.started_at)
+                ).total_seconds()
+                * 1000
             )
             properties["duration_ms"] = duration_ms
 
@@ -394,6 +398,34 @@ async def capture_automation_event(
     session_factory: async_sessionmaker[AsyncSession] | None = None,
 ) -> None:
     """Capture a sanitized automation product event without affecting callers."""
+    try:
+        await _capture_automation_event(
+            event,
+            request=request,
+            request_context=request_context,
+            user=user,
+            automation=automation,
+            run=run,
+            properties=properties,
+            session=session,
+            session_factory=session_factory,
+        )
+    except Exception:
+        logger.debug("Failed to capture automation telemetry event", exc_info=True)
+
+
+async def _capture_automation_event(
+    event: str,
+    *,
+    request: Request | None = None,
+    request_context: TelemetryRequestContext | None = None,
+    user: AuthenticatedUser | None = None,
+    automation: Automation | None = None,
+    run: AutomationRun | None = None,
+    properties: dict[str, Any] | None = None,
+    session: AsyncSession | None = None,
+    session_factory: async_sessionmaker[AsyncSession] | None = None,
+) -> None:
     settings = get_config().service
     if not settings.posthog_api_key:
         return
@@ -451,12 +483,9 @@ async def capture_automation_event(
         "properties": event_properties,
     }
 
-    try:
-        async with httpx.AsyncClient(timeout=2.0) as client:
-            response = await client.post(
-                f"{settings.posthog_host.rstrip('/')}{POSTHOG_CAPTURE_PATH}",
-                json=payload,
-            )
-            response.raise_for_status()
-    except Exception:
-        logger.debug("Failed to capture automation telemetry event", exc_info=True)
+    async with httpx.AsyncClient(timeout=2.0) as client:
+        response = await client.post(
+            f"{settings.posthog_host.rstrip('/')}{POSTHOG_CAPTURE_PATH}",
+            json=payload,
+        )
+        response.raise_for_status()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import UTC, datetime, timedelta
 from typing import ClassVar
 
 import pytest
@@ -77,6 +78,49 @@ def _assert_server_version_properties(properties: dict) -> None:
     expected = get_server_version_info()
     assert properties["package_version"] == expected["package_version"]
     assert properties["sdk_version"] == expected["sdk_version"]
+
+
+def test_base_properties_normalizes_sqlite_run_timestamps(monkeypatch):
+    monkeypatch.setattr(
+        telemetry,
+        "get_server_version_info",
+        lambda **kwargs: {"package_version": "test", "sdk_version": "test"},
+    )
+    automation = _automation()
+    run = _run(automation)
+    run.started_at = datetime(2026, 8, 4, 12, 0)
+    run.completed_at = datetime(2026, 8, 4, 12, 0, tzinfo=UTC) + timedelta(seconds=2)
+
+    properties = telemetry._base_properties(
+        request_context=TelemetryRequestContext(),
+        user=None,
+        automation=automation,
+        run=run,
+        backend_distinct_id="automation-backend:test",
+    )
+
+    assert properties["duration_ms"] == 2000
+
+
+@pytest.mark.asyncio
+async def test_capture_contains_property_building_errors(monkeypatch):
+    monkeypatch.setenv("AUTOMATION_POSTHOG_API_KEY", "ph_test")
+    clear_config_cache()
+
+    async def backend_id(**kwargs):
+        return "automation-backend:test"
+
+    monkeypatch.setattr(telemetry, "get_automation_backend_distinct_id", backend_id)
+
+    def raise_property_error(**kwargs):
+        raise TypeError("invalid timestamp arithmetic")
+
+    monkeypatch.setattr(telemetry, "_base_properties", raise_property_error)
+
+    await telemetry.capture_automation_event(
+        "automation_run_failed",
+        automation=_automation(),
+    )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Problem

Automation runs were getting permanently stuck in `RUNNING` state. The "Graham Daily Workflow Prep" automation exhibited this for 7+ hours.

## Root cause

Two related issues:

### 1. Naive/aware datetime mismatch in telemetry (the trigger)

SQLite ignores `timezone=True` on `DateTime` columns and always returns **naive** `datetime` objects. When the watchdog reloads a run from SQLite and computes duration:

```python
(run.completed_at - run.started_at).total_seconds() * 1000
```

`run.completed_at` is naive (just set from a SQLite UPDATE), while `run.started_at` is still the in-memory **aware** value from dispatch time. Subtracting an aware datetime from a naive one (or vice versa) raises:

```
TypeError: can't subtract offset-naive and offset-aware datetimes
```

This happens inside `capture_automation_event`, which the watchdog calls **after** issuing the `UPDATE … SET status=COMPLETED` but **before** `session.commit()`. The exception propagates out, the `except Exception` in `mark_stale_runs` catches it and logs "Error processing stale run" — but the session never commits, so the status update is rolled back. The run stays `RUNNING` and the watchdog retries every 60s indefinitely.

### 2. Telemetry failure blocks status commit (the structural gap)

Even if the datetime bug were fixed differently, the deeper problem is that `capture_automation_event` is called *before* the transaction commits. Any telemetry exception — present or future — rolls back the run-status transition it is trying to report on. This turns any telemetry bug into a stuck run.

## Fix

**1. Normalize datetimes with `ensure_utc()`** before subtraction, matching the pattern already used in response schemas (`utils/time.py`). This handles both the SQLite-naive and in-memory-aware cases.

**2. Wrap the entire `capture_automation_event` body in `try/except`** so telemetry failures are logged but never propagate to the caller. Telemetry is best-effort observability; it must never block run-state transitions.

## Evidence

From the service logs (`~/.openhands/agent-canvas/logs/agent-canvas.2026-08-06.log`), repeating every 60s:

```
Processing stale run (timeout_at=2026-08-05 18:25:24, now=2026-08-06 00:01:53)
Verifying run status via backend
Verified run status: exit_code=0, success=True
Verified run completed successfully (exit_code=0), callback was missed
Error processing stale run
  File ".../watchdog.py", line 191, in _verify_and_mark_run
    await capture_automation_event(...)
  File ".../telemetry.py", line 377, in _base_properties
    (run.completed_at - run.started_at).total_seconds() * 1000
TypeError: can't subtract offset-naive and offset-aware datetimes
```

## Tests

- `test_base_properties_normalizes_sqlite_run_timestamps` — verifies that mixing a naive `started_at` with an aware `completed_at` (the SQLite reload scenario) produces a correct `duration_ms` instead of raising.
- `test_capture_contains_property_building_errors` — verifies that a `TypeError` (or any exception) inside `_base_properties` is swallowed by `capture_automation_event` and does not propagate to the caller.

## Impact

Without this fix, any automation run that misses its completion callback (so the watchdog must reconcile it) and has telemetry enabled will get permanently stuck in `RUNNING` on SQLite deployments.

---

_This PR was created by an AI agent (OpenHands) on behalf of @neubig._