### PR TITLE
feat: set descriptive titles on automation-born conversations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,7 @@ Completion is handled asynchronously:
 | `SESSION_API_KEY` | From sandbox creation response | SDK reads for settings API auth |
 | `AUTOMATION_CALLBACK_URL` | Constructed by dispatcher | SDK posts completion status here |
 | `AUTOMATION_RUN_ID` | Run ID | Included in callback payload |
-| `AUTOMATION_EVENT_PAYLOAD` | Trigger context JSON | Available to user's script |
+| `AUTOMATION_EVENT_PAYLOAD` | Trigger context JSON | Available to user's script; preset scripts also use it to set a descriptive conversation title |
 
 The SDK's `OpenHandsCloudWorkspace(local_agent_server_mode=True)` reads `SANDBOX_ID`, `SESSION_API_KEY`, and `AGENT_SERVER_PORT` from env vars automatically.
 

--- a/openhands/automation/presets/plugin/sdk_main.py
+++ b/openhands/automation/presets/plugin/sdk_main.py
@@ -30,7 +30,7 @@ The script:
   7. Gets MCP config via workspace.get_mcp_config()
   8. Gets default agent with tools and condenser
   9. Loads plugins from plugins_config.json
-  10. Creates a RemoteConversation with all plugins
+  10. Creates a RemoteConversation with all plugins and sets a descriptive title
   11. Sends the prompt (with event context if available) and runs
   12. On context manager exit, the workspace sends a completion callback
 
@@ -70,6 +70,7 @@ import os
 import random
 import sys
 import time
+from datetime import datetime, timezone
 
 # Detect execution mode based on AGENT_SERVER_URL presence
 agent_server_url = os.environ.get("AGENT_SERVER_URL", "").rstrip("/")
@@ -157,6 +158,44 @@ def _normalize_mcp_config(raw_mcp_config):
     ):
         return raw_mcp_config["mcpServers"]
     return raw_mcp_config
+
+
+def _build_conversation_title(event_context) -> str | None:
+    """Build a descriptive conversation title from the automation event context.
+
+    Returns "{automation_name} — {repo}#{number}" for PR/issue events,
+    "{automation_name} — {timestamp}" otherwise, or None when no automation
+    name is available (keeps the agent-server's default autotitle behavior).
+    """
+    if not isinstance(event_context, dict):
+        return None
+    name = event_context.get("automation_name")
+    if not isinstance(name, str) or not name.strip():
+        return None
+    name = " ".join(name.split())
+
+    context = None
+    event = event_context.get("event")
+    if isinstance(event, dict):
+        repo = event.get("repository")
+        repo_name = repo.get("full_name") if isinstance(repo, dict) else None
+        number = None
+        for key in ("pull_request", "issue"):
+            obj = event.get(key)
+            if isinstance(obj, dict):
+                candidate = obj.get("number")
+                if isinstance(candidate, int) and not isinstance(candidate, bool):
+                    number = candidate
+                    break
+        if number is None:
+            candidate = event.get("number")
+            if isinstance(candidate, int) and not isinstance(candidate, bool):
+                number = candidate
+        if isinstance(repo_name, str) and repo_name and number is not None:
+            context = f"{repo_name.rsplit('/', 1)[-1]}#{number}"
+    if context is None:
+        context = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    return f"{name} — {context}"[:200]
 
 
 # Workspace base directory (for RemoteWorkspace working_dir)
@@ -413,6 +452,22 @@ This automation was triggered by a webhook event:
     print(f"  plugins loaded: {len(plugin_sources)}")
     if experiment_tags:
         print(f"  experiment tags: {experiment_tags}")
+
+    # Set a descriptive title so automation runs are distinguishable in the
+    # conversation panel — otherwise the agent-server's autotitle falls back
+    # to a truncated prompt prefix. Failure is non-fatal; the run continues.
+    conversation_title = _build_conversation_title(event_context)
+    if conversation_title:
+        try:
+            resp = workspace.client.patch(
+                f"/api/conversations/{conversation.id}",
+                json={"title": conversation_title},
+            )
+            resp.raise_for_status()
+            print(f"  title: {conversation_title}")
+        except Exception as e:
+            # Not a hard failure — autotitle fallback still applies
+            print(f"  set title failed (non-fatal): {e}")
 
     # Inject secrets into the conversation (auto-exported as env vars in bash)
     if secrets:

--- a/openhands/automation/presets/prompt/sdk_main.py
+++ b/openhands/automation/presets/prompt/sdk_main.py
@@ -34,7 +34,7 @@ The script:
   6. Gets secrets via workspace.get_secrets()
   7. Gets MCP config via workspace.get_mcp_config()
   8. Gets default agent with tools and condenser
-  9. Creates a RemoteConversation and injects secrets
+  9. Creates a RemoteConversation, sets a descriptive title, and injects secrets
   10. Sends the user's prompt (with event context if available) and runs
   11. On context manager exit, the workspace sends a completion callback
 
@@ -73,6 +73,7 @@ import json
 import os
 import sys
 import time
+from datetime import datetime, timezone
 
 # Detect execution mode based on AGENT_SERVER_URL presence
 agent_server_url = os.environ.get("AGENT_SERVER_URL", "").rstrip("/")
@@ -160,6 +161,44 @@ def _normalize_mcp_config(raw_mcp_config):
     ):
         return raw_mcp_config["mcpServers"]
     return raw_mcp_config
+
+
+def _build_conversation_title(event_context) -> str | None:
+    """Build a descriptive conversation title from the automation event context.
+
+    Returns "{automation_name} — {repo}#{number}" for PR/issue events,
+    "{automation_name} — {timestamp}" otherwise, or None when no automation
+    name is available (keeps the agent-server's default autotitle behavior).
+    """
+    if not isinstance(event_context, dict):
+        return None
+    name = event_context.get("automation_name")
+    if not isinstance(name, str) or not name.strip():
+        return None
+    name = " ".join(name.split())
+
+    context = None
+    event = event_context.get("event")
+    if isinstance(event, dict):
+        repo = event.get("repository")
+        repo_name = repo.get("full_name") if isinstance(repo, dict) else None
+        number = None
+        for key in ("pull_request", "issue"):
+            obj = event.get(key)
+            if isinstance(obj, dict):
+                candidate = obj.get("number")
+                if isinstance(candidate, int) and not isinstance(candidate, bool):
+                    number = candidate
+                    break
+        if number is None:
+            candidate = event.get("number")
+            if isinstance(candidate, int) and not isinstance(candidate, bool):
+                number = candidate
+        if isinstance(repo_name, str) and repo_name and number is not None:
+            context = f"{repo_name.rsplit('/', 1)[-1]}#{number}"
+    if context is None:
+        context = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    return f"{name} — {context}"[:200]
 
 
 # Workspace base directory (for RemoteWorkspace working_dir).
@@ -362,6 +401,22 @@ This automation was triggered by a webhook event:
     conversation = Conversation(**conversation_kwargs)
     assert isinstance(conversation, RemoteConversation)
     print(f"  conversation created: {type(conversation).__name__}")
+
+    # Set a descriptive title so automation runs are distinguishable in the
+    # conversation panel — otherwise the agent-server's autotitle falls back
+    # to a truncated prompt prefix. Failure is non-fatal; the run continues.
+    conversation_title = _build_conversation_title(event_context)
+    if conversation_title:
+        try:
+            resp = workspace.client.patch(
+                f"/api/conversations/{conversation.id}",
+                json={"title": conversation_title},
+            )
+            resp.raise_for_status()
+            print(f"  title: {conversation_title}")
+        except Exception as e:
+            # Not a hard failure — autotitle fallback still applies
+            print(f"  set title failed (non-fatal): {e}")
 
     # Inject secrets into the conversation (auto-exported as env vars in bash)
     if secrets:

--- a/tests/test_preset_router.py
+++ b/tests/test_preset_router.py
@@ -3,10 +3,12 @@
 import ast
 import io
 import json
+import re
 import socket
 import tarfile
 import uuid
 from collections.abc import Callable
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import MagicMock
@@ -72,6 +74,26 @@ def _load_preset_mcp_normalizer(
         namespace,
     )
     return cast(Callable[[Any], Any], namespace["_normalize_mcp_config"])
+
+
+def _load_preset_title_builder(preset_name: str) -> Callable[[Any], str | None]:
+    source_path = PRESETS_DIR / preset_name / "sdk_main.py"
+    module = ast.parse(source_path.read_text(), filename=str(source_path))
+    function_node = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_build_conversation_title"
+    )
+    namespace: dict[str, Any] = {"datetime": datetime, "timezone": timezone}
+    ast.fix_missing_locations(function_node)
+    exec(
+        compile(
+            ast.Module(body=[function_node], type_ignores=[]), str(source_path), "exec"
+        ),
+        namespace,
+    )
+    return cast(Callable[[Any], str | None], namespace["_build_conversation_title"])
 
 
 class TestPresetFileSyntax:
@@ -202,6 +224,106 @@ def test_preset_mcp_normalizer_unwraps_without_sdk_coercer(preset_name):
     assert normalize(wrapped_config) == native_config
     assert normalize(native_config) == native_config
     assert normalize(None) == {}
+
+
+_UTC_TIMESTAMP_RE = re.compile(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC")
+
+
+@pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
+@pytest.mark.parametrize(
+    ("event", "expected_context"),
+    [
+        (
+            {
+                "repository": {"full_name": "OpenHands/software-agent-sdk"},
+                "number": 1234,
+                "pull_request": {"number": 1234, "title": "Fix bug"},
+            },
+            "software-agent-sdk#1234",
+        ),
+        (
+            {
+                "repository": {"full_name": "OpenHands/automation"},
+                "issue": {"number": 274},
+            },
+            "automation#274",
+        ),
+        ({"repository": {"full_name": "org/repo"}, "number": 7}, "repo#7"),
+    ],
+)
+def test_preset_title_builder_uses_repo_and_number_for_numbered_events(
+    preset_name, event, expected_context
+):
+    build_title = _load_preset_title_builder(preset_name)
+    event_context = {"automation_name": "PR review", "event": event}
+
+    title = build_title(event_context)
+
+    assert title == f"PR review — {expected_context}"
+
+
+@pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
+@pytest.mark.parametrize(
+    "event_context",
+    [
+        {"automation_name": "Issue triage", "trigger": "cron"},
+        {
+            "automation_name": "Issue triage",
+            "event": {
+                "repository": {"full_name": "org/repo"},
+                "ref": "refs/heads/main",
+            },
+        },
+        {"automation_name": "Issue triage", "event": {"issue": {"number": 7}}},
+        {
+            "automation_name": "Issue triage",
+            "event": {"number": True, "repository": "junk", "pull_request": [1]},
+        },
+    ],
+)
+def test_preset_title_builder_falls_back_to_utc_timestamp(preset_name, event_context):
+    build_title = _load_preset_title_builder(preset_name)
+
+    title = build_title(event_context)
+
+    assert title is not None
+    name, separator, context = title.partition(" — ")
+    assert (name, separator) == ("Issue triage", " — ")
+    assert _UTC_TIMESTAMP_RE.fullmatch(context)
+
+
+@pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
+@pytest.mark.parametrize(
+    "event_context",
+    [None, "not a dict", {}, {"automation_name": "   "}, {"automation_name": 42}],
+)
+def test_preset_title_builder_skips_runs_without_an_automation_name(
+    preset_name, event_context
+):
+    build_title = _load_preset_title_builder(preset_name)
+
+    assert build_title(event_context) is None
+
+
+@pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
+def test_preset_title_builder_collapses_automation_name_whitespace(preset_name):
+    build_title = _load_preset_title_builder(preset_name)
+
+    title = build_title({"automation_name": "  Nightly\n\ntriage  "})
+
+    assert title is not None
+    assert title.startswith("Nightly triage — ")
+
+
+@pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
+def test_preset_title_builder_caps_titles_at_the_conversation_api_limit(preset_name):
+    # The agent-server's UpdateConversationRequest enforces title max_length=200
+    build_title = _load_preset_title_builder(preset_name)
+
+    title = build_title({"automation_name": "x" * 500})
+
+    assert title is not None
+    assert len(title) == 200
 
 
 class TestGenerateTarball:


### PR DESCRIPTION
### Summary

Gives every automation-born conversation a meaningful, distinguishable title at creation time, instead of the truncated prompt prefix.

Resolves https://github.com/OpenHands/automation/issues/274

<img width="1440" height="831" alt="image" src="https://github.com/user-attachments/assets/a3f21ee8-fed7-4294-b2f5-ee9bc162f074" />

### Problem

Conversations created by automation runs show up in the conversation panel titled with the first ~50 characters of the automation's prompt:

```
✓ You are an issue triage bot for Op…   11h   gpt-5.6-sol
✓ You are an issue triage bot for Op…   11h   gpt-5.6-sol
✓ You are an issue triage bot for Op…   15h   gpt-5.6-sol

```

Root cause: the SDK conversation-creation path (`Conversation(...)` → `StartConversationRequest`) has no title parameter, so automation conversations start untitled. The agent-server's `autotitle` (default on) then generates a title from the first user message — the automation prompt — and its silent fallback truncates the prompt to 50 chars. Every run of the same automation gets the same title; nothing in the pipeline that knows the automation context (name, trigger, event) ever sets one.

### Solution

Both preset scripts (`presets/prompt/sdk_main.py`, `presets/plugin/sdk_main.py`) now:

1. Build a title from the already-parsed `AUTOMATION_EVENT_PAYLOAD` context via a new `_build_conversation_title()` helper:

- Event with a PR/issue number → `PR review — software-agent-sdk#1234`
- Cron / manual / payloads without a usable number → `Issue triage — 2026-08-06 09:41:07 UTC` (seconds keep same-minute event runs distinct)
- No automation name (e.g. hand-run script) → helper returns `None`, existing autotitle behavior is kept

2. Set it with `PATCH /api/conversations/{conversation.id}` through `workspace.client` immediately after the conversation is created and **before** `send_message` — the `AutoTitleSubscriber` skips whenever a title is already set, so this deterministically wins the race. The PATCH also fires the conversation webhook, so the cloud app-server picks the title up unchanged.
3. Treat any failure as non-fatal: a warning is printed and the run continues with today's behavior as the fallback.

The helper is defensively typed throughout (`isinstance` guards; the `repo#number` form requires both a `repository.full_name` string and a real int) because custom webhook sources deliver arbitrary JSON. Titles are whitespace-normalized and capped at 200 chars (the agent-server's `UpdateConversationRequest.title` limit).

Works identically for the local backend (script talks to the local agent-server; the GUI renders the agent-server title verbatim) and the cloud backend (`OpenHandsCloudWorkspace(local_agent_server_mode=True)` points the same client at the sandbox's own agent-server; the app-server copies the title via `SetTitleCallbackProcessor`).

The helper is duplicated between the two preset scripts by design: they are standalone templates baked into tarballs and executed in sandboxes where the `openhands.automation` package is not installed (same pattern as `_conversation_supports_user_id` / `_normalize_mcp_config`).

### Scope / limitations

- Applies to **newly created automations** only: preset tarballs bake `main.py` at creation time, and prompt edits intentionally swap only `prompt.txt`. Existing automations keep prompt-prefix titles until recreated. A tarball-refresh mechanism was considered and deliberately left to a follow-up.
- `scripts/test_tarball/main.py` (developer smoke-test) is intentionally untouched.

### Changes

- `openhands/automation/presets/prompt/sdk_main.py` — `_build_conversation_title()` helper + title PATCH after conversation creation; docstring step updated
- `openhands/automation/presets/plugin/sdk_main.py` — same changes at the plugin preset's corresponding locations
- `tests/test_preset_router.py` — behavioral tests for the title builder, AST-extracted from both preset files (same technique as the existing MCP-normalizer tests), parametrized over both presets so the two copies cannot drift
- `AGENTS.md` — noted that preset scripts also use `AUTOMATION_EVENT_PAYLOAD` to set the conversation title

### Testing

- `uv run pytest tests/test_preset_router.py -q` → **127 passed** (28 new test runs: repo#number titles for PR/issue/bare-number payloads, UTC-timestamp fallback incl. junk-typed payloads, skip-without-name, whitespace normalization, 200-char cap — each verified against **both** preset files)
- Red/green verified: `_build_conversation_title` does not exist at the parent commit, so every new test fails there and passes with this change
- `uv run pytest tests/test_ab_testing_integration.py -q` → 17 passed (regression)
- `uv run python -m py_compile` on both preset scripts (mirrors `TestPresetFileSyntax`)
- `uv run ruff check` / `ruff format --check` clean on the test file (presets are lint-exempt)
- Manual verification recipe: deploy, create a **fresh** prompt automation, trigger a run, and confirm (a) the run log prints `  title: <Name — …>`, (b) the conversation panel shows `Name — <timestamp>` / `Name — repo#N` instead of the prompt prefix. Event path without a real webhook: run `main.py` with `AGENT_SERVER_URL` set and `AUTOMATION_EVENT_PAYLOAD='{"trigger":"event","automation_name":"Test bot","automation_id":"x","trigger_payload":{},"event":{"repository":{"full_name":"o/r"},"issue":{"number":7}}}'` → expect title `Test bot — r#7`.