### PR TITLE
feat: add generic preset metadata field to Automation model

### DIFF
--- a/migrations/versions/013_add_preset_metadata.py
+++ b/migrations/versions/013_add_preset_metadata.py
@@ -1,0 +1,30 @@
+"""Add preset_metadata column to automations table.
+
+This migration adds a nullable preset_metadata JSON column to the automations
+table so preset endpoints can record the configuration used to build the
+automation (preset type, prompt, plugins, repos) for the UI to consume.
+Custom SDK automations leave it NULL.
+
+Revision ID: 013
+Revises: 012
+Create Date: 2026-08-01
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "013"
+down_revision: str = "012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("automations", sa.Column("preset_metadata", sa.JSON, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("automations", "preset_metadata")

--- a/migrations/versions/014_add_preset_metadata.py
+++ b/migrations/versions/014_add_preset_metadata.py
@@ -5,8 +5,8 @@ table so preset endpoints can record the configuration used to build the
 automation (preset type, prompt, plugins, repos) for the UI to consume.
 Custom SDK automations leave it NULL.
 
-Revision ID: 013
-Revises: 012
+Revision ID: 014
+Revises: 013
 Create Date: 2026-08-01
 """
 
@@ -16,8 +16,8 @@ import sqlalchemy as sa
 from alembic import op
 
 
-revision: str = "013"
-down_revision: str = "012"
+revision: str = "014"
+down_revision: str = "013"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/openhands/automation/models.py
+++ b/openhands/automation/models.py
@@ -61,6 +61,11 @@ class Automation(Base):
     # Optional prompt (set when created via preset endpoints)
     prompt: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # Preset-specific metadata (populated by preset endpoints; NULL for custom
+    # SDK automations).
+    # Uses generic JSON type for cross-database compatibility (PostgreSQL + SQLite)
+    preset_metadata: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+
     # Model profile name to use for automation runs.
     # None is only used for legacy/local fallback.
     model: Mapped[str | None] = mapped_column(String(64), nullable=True)

--- a/openhands/automation/preset_router.py
+++ b/openhands/automation/preset_router.py
@@ -454,12 +454,20 @@ async def create_automation_from_prompt(
     # 3. Create the automation referencing the internal upload
     tarball_path = build_internal_url(upload_id)
 
+    preset_metadata: dict[str, Any] = {
+        "preset_type": "prompt",
+        "prompt": body.prompt,
+    }
+    if body.repos:
+        preset_metadata["repos"] = [r.model_dump(exclude_none=True) for r in body.repos]
+
     try:
         automation = Automation(
             user_id=user.user_id,
             org_id=user.org_id,
             name=body.name,
             prompt=body.prompt,
+            preset_metadata=preset_metadata,
             model=model,
             trigger=body.trigger.model_dump(),
             tarball_path=tarball_path,
@@ -838,12 +846,24 @@ async def create_automation_from_plugin(
     # 3. Create the automation referencing the internal upload
     tarball_path = build_internal_url(upload_id)
 
+    preset_metadata: dict[str, Any] = {
+        "preset_type": "plugin",
+        "prompt": body.prompt,
+    }
+    if body.plugins:
+        preset_metadata["plugins"] = [
+            p.model_dump(exclude_none=True) for p in body.plugins
+        ]
+    if body.repos:
+        preset_metadata["repos"] = [r.model_dump(exclude_none=True) for r in body.repos]
+
     try:
         automation = Automation(
             user_id=user.user_id,
             org_id=user.org_id,
             name=body.name,
             prompt=body.prompt,
+            preset_metadata=preset_metadata,
             model=model,
             trigger=body.trigger.model_dump(),
             tarball_path=tarball_path,

--- a/openhands/automation/router.py
+++ b/openhands/automation/router.py
@@ -190,6 +190,10 @@ async def update_automation(
         )
         if new_tarball_path is not None:
             auto.tarball_path = new_tarball_path
+        # Keep preset metadata in sync with the edited prompt. Reassign the
+        # whole dict: in-place mutation of a JSON column is not change-tracked.
+        if auto.preset_metadata is not None:
+            auto.preset_metadata = {**auto.preset_metadata, "prompt": auto.prompt}
 
     # Note: updated_at is handled automatically by the model's onupdate=utcnow
     await session.flush()

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -620,6 +620,7 @@ class AutomationResponse(BaseModel):
 
     name: str
     prompt: str | None
+    preset_metadata: dict | None = None
     trigger: dict
     tarball_path: str
     setup_script_path: str | None

--- a/tests/test_ab_testing_integration.py
+++ b/tests/test_ab_testing_integration.py
@@ -226,6 +226,21 @@ class TestABTestAutomationCreation:
         assert data["tarball_path"].startswith("oh-internal://uploads/")
         assert data["enabled"] is True
 
+    async def test_ab_automation_preset_metadata_omits_plugins(
+        self, client, mock_file_store
+    ):
+        """Variant-based automations record preset metadata without a plugins list."""
+        resp = await client.post(
+            "/api/automation/v1/preset/plugin",
+            json=self.AB_PAYLOAD,
+        )
+
+        assert resp.status_code == 201
+        assert resp.json()["preset_metadata"] == {
+            "preset_type": "plugin",
+            "prompt": self.AB_PAYLOAD["prompt"],
+        }
+
     async def test_tarball_contains_experiment_config(self, client, mock_file_store):
         """Generated tarball has experiment_config.json, not plugins_config.json."""
         resp = await client.post(

--- a/tests/test_preset_router.py
+++ b/tests/test_preset_router.py
@@ -546,6 +546,53 @@ class TestCreateAutomationFromPrompt:
             assert prompt_file is not None
             assert prompt_file.read().decode() == test_prompt
 
+    async def test_create_from_prompt_stores_preset_metadata(self, async_client):
+        """Prompt preset records preset metadata without repos when none given."""
+        test_prompt = "Summarize open PRs"
+        payload = {
+            "name": "Metadata Test",
+            "prompt": test_prompt,
+            "trigger": {"type": "cron", "schedule": "0 9 * * 1"},
+        }
+
+        response = await async_client.post(
+            "/api/automation/v1/preset/prompt", json=payload
+        )
+
+        assert response.status_code == 201
+        assert response.json()["preset_metadata"] == {
+            "preset_type": "prompt",
+            "prompt": test_prompt,
+        }
+
+    async def test_create_from_prompt_stores_repos_in_preset_metadata(
+        self, async_client
+    ):
+        """Prompt preset records requested repos in preset metadata."""
+        payload = {
+            "name": "Metadata Repos Test",
+            "prompt": "Summarize open PRs",
+            "trigger": {"type": "cron", "schedule": "0 9 * * 1"},
+            "repos": [
+                {"url": "owner/repo1", "ref": "main", "provider": "github"},
+                {"url": "owner/repo2", "provider": "github"},
+            ],
+        }
+
+        response = await async_client.post(
+            "/api/automation/v1/preset/prompt", json=payload
+        )
+
+        assert response.status_code == 201
+        assert response.json()["preset_metadata"] == {
+            "preset_type": "prompt",
+            "prompt": "Summarize open PRs",
+            "repos": [
+                {"url": "owner/repo1", "ref": "main", "provider": "github"},
+                {"url": "owner/repo2", "provider": "github"},
+            ],
+        }
+
     async def test_create_from_prompt_defaults_to_active_model_profile(
         self, async_client, mock_authenticated_user
     ):
@@ -1517,6 +1564,34 @@ class TestCreateAutomationFromPlugin:
             assert config[0]["source"] == "github:owner/code-review-plugin"
             assert config[0]["ref"] == "v1.0.0"
             assert config[1]["source"] == "github:owner/security-plugin"
+
+    async def test_create_from_plugin_stores_preset_metadata(self, async_client):
+        """Plugin preset records plugins and repos in preset metadata."""
+        payload = {
+            "name": "Metadata Test",
+            "plugins": [
+                {"source": "github:owner/code-review-plugin", "ref": "v1.0.0"},
+                {"source": "github:owner/security-plugin"},
+            ],
+            "prompt": "Review all Python files for security issues",
+            "trigger": {"type": "cron", "schedule": "0 9 * * 1"},
+            "repos": [{"url": "owner/repo", "ref": "main", "provider": "github"}],
+        }
+
+        response = await async_client.post(
+            "/api/automation/v1/preset/plugin", json=payload
+        )
+
+        assert response.status_code == 201
+        assert response.json()["preset_metadata"] == {
+            "preset_type": "plugin",
+            "prompt": "Review all Python files for security issues",
+            "plugins": [
+                {"source": "github:owner/code-review-plugin", "ref": "v1.0.0"},
+                {"source": "github:owner/security-plugin"},
+            ],
+            "repos": [{"url": "owner/repo", "ref": "main", "provider": "github"}],
+        }
 
     async def test_create_from_plugin_defaults_to_active_model_profile(
         self, async_client, mock_authenticated_user

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -198,6 +198,20 @@ class TestCreateAutomation:
         assert automation is not None
         assert automation.telemetry_distinct_id == "ph-fe-creator"
 
+    async def test_create_automation_preset_metadata_is_null(self, async_client):
+        """Custom SDK automations are created without preset metadata."""
+        payload = {
+            "name": "My Test Automation",
+            "trigger": {"type": "cron", "schedule": "0 9 * * 5", "timezone": "UTC"},
+            "tarball_path": "s3://bucket/path/to/code.tar.gz",
+            "entrypoint": "uv run script.py",
+        }
+
+        response = await async_client.post("/api/automation/v1", json=payload)
+
+        assert response.status_code == 201
+        assert response.json()["preset_metadata"] is None
+
     async def test_create_automation_defaults_to_active_model_profile(
         self, async_client, mock_authenticated_user
     ):
@@ -1073,6 +1087,35 @@ class TestUpdateAutomation:
 
         # The superseded tarball file is removed so storage doesn't grow unbounded.
         assert old_storage_path not in preset_store._storage
+
+    async def test_update_prompt_syncs_preset_metadata(
+        self, async_client, async_session, preset_store
+    ):
+        """Editing the prompt updates the prompt recorded in preset metadata."""
+        # Arrange — a preset automation whose metadata records the original prompt.
+        automation = await _seed_prompt_preset_automation(
+            async_session, preset_store, "Original prompt"
+        )
+        automation.preset_metadata = {
+            "preset_type": "prompt",
+            "prompt": "Original prompt",
+            "repos": [{"url": "owner/repo"}],
+        }
+        await async_session.commit()
+
+        # Act — edit the prompt.
+        response = await async_client.patch(
+            f"/api/automation/v1/{automation.id}",
+            json={"prompt": "Updated prompt"},
+        )
+
+        # Assert — the metadata prompt follows the edit; other keys are preserved.
+        assert response.status_code == 200
+        assert response.json()["preset_metadata"] == {
+            "preset_type": "prompt",
+            "prompt": "Updated prompt",
+            "repos": [{"url": "owner/repo"}],
+        }
 
     async def test_update_name_does_not_regenerate_preset_tarball(
         self, async_client, async_session, preset_store


### PR DESCRIPTION
### Why

Preset automations (`POST /v1/preset/prompt`, `POST /v1/preset/plugin`) are built from user-provided configuration — a prompt, plugin sources — that gets baked into a generated tarball. Only the `prompt` survives as a column on `Automation`; everything else is opaque inside the tarball. The extension-owned Automation UI needs to display what an automation was built from, and today it can't.

### Summary

- **`Automation.preset_metadata`** — new nullable JSON column recording the creation-time preset configuration. Uses generic `sa.JSON`, not the JSONB proposed in #56: `AGENTS.md` forbids PostgreSQL-only types because self-hosted deployments run SQLite, both existing JSON columns already use `sa.JSON`, and this field is display metadata that is never queried or indexed.
- **Preset endpoints populate it** at creation:
  - prompt preset → `{"preset_type": "prompt", "prompt": ..., "repos": [...]}` (`repos` only when provided)
  - plugin preset → `{"preset_type": "plugin", "prompt": ..., "plugins": [...], "repos": [...]}` (each list only when provided; variant-based A/B automations omit `plugins`, matching the issue's schema which doesn't cover variants)
  - repos/plugins serialized with `model_dump(exclude_none=True)`, exactly as the tarball configs (`repos_config.json` / `plugins_config.json`) already are — which also means `PluginSource`'s credential-redacting serializer applies.
- **`AutomationResponse.preset_metadata`** — exposed on the API response (`None` for non-preset automations).
- **`PATCH /v1/{automation_id}`** — when a prompt edit regenerates the preset tarball, `preset_metadata["prompt"]` is updated too, so the metadata never contradicts what the automation actually runs. The dict is reassigned rather than mutated because in-place mutation of a JSON column is not change-tracked by SQLAlchemy.
- **Migration `013_add_preset_metadata.py`** — adds the column; downgrade drops it.
- Custom SDK automations (`POST /v1` with a user-uploaded tarball) are untouched and keep `preset_metadata = NULL`. Preset automations created before this change also have `NULL` — there is no backfill; metadata is recorded at creation time only.

### Issue Number

Resolves https://github.com/OpenHands/automation/issues/56

### How to Test

**1. Automated checks**

```bash
uv run ruff check && uv run ruff format --check .
uv run python -m pytest tests/ -q     # 1087 passed (6 new)
```

**2. The new tests bite.** With the source changes stashed and only the tests applied, all six fail; with the implementation restored, all pass:

- `test_create_from_prompt_stores_preset_metadata` — prompt preset, no repos → metadata is exactly `{preset_type, prompt}` (no `repos` key)
- `test_create_from_prompt_stores_repos_in_preset_metadata` — repos serialized with `exclude_none` (no `ref` key on a repo without one)
- `test_create_from_plugin_stores_preset_metadata` — plugins + repos recorded
- `test_ab_automation_preset_metadata_omits_plugins` — variant-based automation → no `plugins` key
- `test_create_automation_preset_metadata_is_null` — raw `POST /v1` → `preset_metadata: null`
- `test_update_prompt_syncs_preset_metadata` — PATCH prompt edit updates the metadata prompt and preserves the other keys

**3. Migration cycle** against a scratch SQLite database:

```bash
AUTOMATION_DB_URL=sqlite:////tmp/scratch.db uv run alembic upgrade head   # → 013 (head)
sqlite3 /tmp/scratch.db "PRAGMA table_info(automations);" | grep preset   # preset_metadata|JSON|nullable
AUTOMATION_DB_URL=sqlite:////tmp/scratch.db uv run alembic downgrade 012  # column dropped cleanly
```

**4. Manual sanity** — create a preset automation and read it back:

```bash
curl -X POST .../api/automation/v1/preset/prompt -d '{
  "name": "Daily PR summary",
  "prompt": "Summarize open PRs",
  "trigger": {"type": "cron", "schedule": "0 9 * * 1"},
  "repos": [{"url": "owner/repo", "provider": "github"}]
}'
# response includes:
# "preset_metadata": {"preset_type": "prompt", "prompt": "Summarize open PRs",
#                     "repos": [{"url": "owner/repo", "provider": "github"}]}
```

A raw `POST /v1` automation returns `"preset_metadata": null`.