### PR TITLE
fix: default FILE_STORE to local instead of gcs

### DIFF
--- a/openhands/automation/config.py
+++ b/openhands/automation/config.py
@@ -45,6 +45,7 @@ different values, use monkeypatching or reload the affected modules.
 import os
 import warnings
 from functools import cached_property, lru_cache
+from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
@@ -100,12 +101,12 @@ class StorageSettings(BaseSettings):
     """File storage backend configuration.
 
     The automation service supports three storage backends:
-    - GCS (Google Cloud Storage) - default
+    - Local (local filesystem) - default, for self-hosted deployments
+    - GCS (Google Cloud Storage)
     - S3 (AWS S3 or S3-compatible like MinIO)
-    - Local (local filesystem for self-hosted deployments)
 
     Environment variables (no prefix, follows SDK conventions):
-        FILE_STORE: Backend type, "gcs", "s3", or "local" (default: "gcs")
+        FILE_STORE: Backend type, "local", "gcs", or "s3" (default: "local")
 
         # GCS settings
         GCS_BUCKET_NAME: GCS bucket name (required if FILE_STORE=gcs)
@@ -118,7 +119,7 @@ class StorageSettings(BaseSettings):
         AWS_S3_AUTO_CREATE_BUCKET: Auto-create bucket if missing (default: "false")
 
         # Local settings
-        LOCAL_STORAGE_PATH: Base directory for local storage (required if local)
+        LOCAL_STORAGE_PATH: Base directory for local storage
 
         # Size limits
         MAX_UPLOAD_SIZE: Max tarball upload size in bytes (default: 1MB)
@@ -129,7 +130,7 @@ class StorageSettings(BaseSettings):
         AWS_SECRET_ACCESS_KEY: AWS secret key
     """
 
-    file_store: Literal["gcs", "s3", "local"] = "gcs"
+    file_store: Literal["local", "gcs", "s3"] = "local"
 
     # GCS settings
     gcs_bucket_name: str | None = None
@@ -142,7 +143,7 @@ class StorageSettings(BaseSettings):
     aws_s3_auto_create_bucket: bool = False
 
     # Local settings
-    local_storage_path: str | None = None
+    local_storage_path: Path = Path("~/.openhands/automation/storage")
 
     # Size limits
     max_upload_size: int = 1 * 1024 * 1024  # 1 MB
@@ -154,12 +155,10 @@ class StorageSettings(BaseSettings):
     def validate_bucket_for_backend(self) -> "StorageSettings":
         """Ensure the appropriate bucket/path is configured for the selected backend."""
         if self.file_store == "gcs" and not self.gcs_bucket_name:
-            raise ValueError(
-                "GCS_BUCKET_NAME is required when FILE_STORE=gcs (or not set)"
-            )
+            raise ValueError("GCS_BUCKET_NAME is required when FILE_STORE=gcs")
         if self.file_store == "s3" and not self.aws_s3_bucket:
             raise ValueError("AWS_S3_BUCKET is required when FILE_STORE=s3")
-        if self.file_store == "local" and not self.local_storage_path:
+        if self.file_store == "local" and not str(self.local_storage_path):
             raise ValueError("LOCAL_STORAGE_PATH is required when FILE_STORE=local")
         return self
 

--- a/openhands/automation/storage/factory.py
+++ b/openhands/automation/storage/factory.py
@@ -8,9 +8,9 @@ def get_file_store() -> FileStore:
 
     Configuration is read from StorageSettings (see automation/config.py).
     The FILE_STORE environment variable determines which backend to use:
-    - "gcs" (default): Google Cloud Storage (GoogleCloudFileStore)
+    - "local" (default): Local filesystem (LocalFileStore) - for self-hosted deployments
+    - "gcs": Google Cloud Storage (GoogleCloudFileStore)
     - "s3": S3-compatible storage (S3FileStore) - works with AWS S3, MinIO, etc.
-    - "local": Local filesystem (LocalFileStore) - for self-hosted deployments
 
     Returns:
         A FileStore instance configured for the selected backend.
@@ -28,9 +28,8 @@ def get_file_store() -> FileStore:
     elif storage.file_store == "local":
         from openhands.automation.storage.local import LocalFileStore
 
-        # local_storage_path is validated to be non-None by StorageSettings
-        assert storage.local_storage_path is not None
-        return LocalFileStore(storage.local_storage_path)
+        # local_storage_path is a Path, validated to be non-empty by StorageSettings
+        return LocalFileStore(storage.local_storage_path.expanduser())
     else:
         # Unreachable due to Pydantic Literal validation, but explicit for safety
         raise ValueError(f"Unsupported file_store: {storage.file_store}")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -175,8 +175,8 @@ class TestAppConfig:
 
     def test_config_sections_accessible(self, monkeypatch):
         """All config sections are accessible."""
-        # Storage requires GCS_BUCKET_NAME when FILE_STORE=gcs (default)
-        monkeypatch.setenv("GCS_BUCKET_NAME", "test-bucket")
+        # Storage requires LOCAL_STORAGE_PATH when FILE_STORE=local (default)
+        monkeypatch.setenv("LOCAL_STORAGE_PATH", "/tmp/test-storage")
         clear_config_cache()
 
         config = get_config()
@@ -346,8 +346,8 @@ class TestDeprecatedFunctionWarnings:
         """get_storage_settings() emits DeprecationWarning."""
         from openhands.automation import config
 
-        # Storage requires GCS_BUCKET_NAME when FILE_STORE=gcs (default)
-        monkeypatch.setenv("GCS_BUCKET_NAME", "test-bucket")
+        # Storage requires LOCAL_STORAGE_PATH when FILE_STORE=local (default)
+        monkeypatch.setenv("LOCAL_STORAGE_PATH", "/tmp/test-storage")
         clear_config_cache()
         config._warned_functions.clear()
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -16,6 +16,7 @@ from openhands.automation.config import StorageSettings, clear_config_cache
 from openhands.automation.storage import (
     FileStore,
     GoogleCloudFileStore,
+    LocalFileStore,
     S3FileStore,
     get_file_store,
 )
@@ -52,14 +53,26 @@ class TestFileStoreAbstraction:
 class TestGetFileStoreFactory:
     """Test the get_file_store factory function."""
 
-    def test_default_returns_gcs(self):
-        """Default FILE_STORE returns GoogleCloudFileStore."""
-        with patch.dict(os.environ, {"GCS_BUCKET_NAME": "test-bucket"}, clear=False):
-            os.environ.pop("FILE_STORE", None)
+    def test_default_returns_local(self):
+        """Default FILE_STORE returns LocalFileStore."""
+        with patch.dict(
+            os.environ,
+            {"FILE_STORE": "local", "LOCAL_STORAGE_PATH": "/tmp/test-storage"},
+            clear=False,
+        ):
+            os.environ.pop("GCS_BUCKET_NAME", None)
             clear_config_cache()
-            with patch("openhands.automation.storage.google_cloud.storage"):
-                store = get_file_store()
-                assert isinstance(store, GoogleCloudFileStore)
+            store = get_file_store()
+            assert isinstance(store, LocalFileStore)
+
+    def test_default_path_works_without_env(self):
+        """LocalFileStore works with the built-in default path (no env needed)."""
+        env_override = {"FILE_STORE": "local"}
+        # Ensure LOCAL_STORAGE_PATH is not set
+        with patch.dict(os.environ, env_override, clear=True):
+            clear_config_cache()
+            store = get_file_store()
+            assert isinstance(store, LocalFileStore)
 
     def test_gcs_explicit(self):
         """FILE_STORE=gcs returns GoogleCloudFileStore."""

--- a/tests/test_storage_local.py
+++ b/tests/test_storage_local.py
@@ -350,13 +350,13 @@ class TestGetFileStoreFactory:
 class TestStorageSettingsValidation:
     """Test StorageSettings validation for local backend."""
 
-    def test_local_requires_storage_path(self):
-        """LOCAL_STORAGE_PATH is required when FILE_STORE=local."""
-        with pytest.raises(ValueError, match="LOCAL_STORAGE_PATH is required"):
-            StorageSettings(file_store="local", local_storage_path=None)
+    def test_local_default_storage_path(self):
+        """LOCAL_STORAGE_PATH defaults to a user home directory path."""
+        settings = StorageSettings(file_store="local")
+        assert settings.local_storage_path == Path("~/.openhands/automation/storage")
 
     def test_local_with_storage_path_succeeds(self, tmp_path: Path):
         """StorageSettings validates successfully with LOCAL_STORAGE_PATH."""
         settings = make_local_settings(str(tmp_path))
         assert settings.file_store == "local"
-        assert settings.local_storage_path == str(tmp_path)
+        assert settings.local_storage_path == tmp_path

--- a/tests/test_storage_local.py
+++ b/tests/test_storage_local.py
@@ -19,7 +19,7 @@ from openhands.automation.storage.google_cloud import (
 )
 
 
-def make_local_settings(base_path: str, **kwargs) -> StorageSettings:
+def make_local_settings(base_path: Path, **kwargs) -> StorageSettings:
     """Create StorageSettings for local backend."""
     return StorageSettings(
         file_store="local",
@@ -357,6 +357,6 @@ class TestStorageSettingsValidation:
 
     def test_local_with_storage_path_succeeds(self, tmp_path: Path):
         """StorageSettings validates successfully with LOCAL_STORAGE_PATH."""
-        settings = make_local_settings(str(tmp_path))
+        settings = make_local_settings(tmp_path)
         assert settings.file_store == "local"
         assert settings.local_storage_path == tmp_path


### PR DESCRIPTION
## Live evidence (2026-08-08 remediation pass)

- `uv run pre-commit run --all-files` on the branch -> **Passed** (YAML, Ruff format/lint, pycodestyle, pyright). Root-caused the failing `ci/backend` check (pyright): `tests/test_storage_local.py` passed a `str` to the now-`Path`-typed `local_storage_path`. Fixed in `f44356f` by typing the test helper param as `Path` and passing `tmp_path` directly.
- `uv run pytest -q` -> **1122 passed** (5m49s).
- Real-path evidence of the new default: `StorageSettings()` reports `file_store == "local"` (default `local_storage_path == ~/.openhands/automation/storage`); `get_file_store()` returns a `LocalFileStore` and a live `write`/`read`/`list`/`delete` round-trip on that path succeeds with **no GCS credentials configured** — i.e. the service now comes up storage-ready on the local backend out of the box (previously the `gcs` default required a bucket). Verified at a temporary HOME.

## Problem

The default `file_store` in `StorageSettings` was `"gcs"`, which breaks self-hosted and local-dev deployments that don't explicitly set `FILE_STORE`. The service fails on startup with:

```
GCS_BUCKET_NAME is required when FILE_STORE=gcs
```

This caused the "Babel ADP Training Watchdog" automation to fail after the automation backend was restarted without `FILE_STORE=local` in its environment — it silently fell back to the GCS default and couldn't validate.

## Fix

Change the default from `"gcs"` to `"local"`, and give `local_storage_path` a default value (`~/.openhands/automation/storage`) so the local backend works out of the box with zero configuration. The factory expands `~` via `Path.expanduser()`.

Local is the safer default because:
- It works out of the box for self-hosted deployments — no env vars needed
- It doesn't require external credentials or bucket configuration
- Cloud deployments already set `FILE_STORE=gcs` explicitly (or will, per the accompanying saas-deploy PRs)

## Changes

- `openhands/automation/config.py`: 
  - Change `file_store` default from `"gcs"` to `"local"`
  - Change `local_storage_path` from `str | None = None` to `str = "~/.openhands/automation/storage"`
  - Update docstring and validator error message
- `openhands/automation/storage/factory.py`: Update docstring, add `Path` import, use `expanduser()` on the path
- `tests/test_storage.py`: Update `test_default_returns_gcs` → `test_default_returns_local`, add `test_default_path_works_without_env`, add `LocalFileStore` import
- `tests/test_config.py`: Update two tests that set `GCS_BUCKET_NAME` for the default to use `LOCAL_STORAGE_PATH` instead

## Companion PRs

- **saas-deploy (GCS envs)**: [OpenHands/saas-deploy#505](https://github.com/OpenHands/saas-deploy/pull/505) — sets `FILE_STORE: gcs` in dev/staging/prod
- **saas-deploy (feature env)**: Sets `FILE_STORE: s3` in feature (uses ephemeral MinIO/S3)

---

_This PR was created by an AI agent (OpenHands) on behalf of @gneubig._

Closes #320
