### PR TITLE
fix(dispatcher): treat a missing tarball object as a permanent error

### DIFF
--- a/openhands/automation/dispatcher.py
+++ b/openhands/automation/dispatcher.py
@@ -71,8 +71,9 @@ async def _download_internal_tarball(
     """Download a tarball from storage using the TarballUpload record.
 
     Raises:
-        TarballNotFoundError: If the tarball upload record doesn't exist.
-            This is a permanent error that should disable the automation.
+        TarballNotFoundError: If the tarball upload record doesn't exist, or if
+            the record exists but its object is absent from storage. Both are
+            permanent errors that should disable the automation.
         ValueError: If no database session is provided.
     """
     if session is None:
@@ -91,7 +92,18 @@ async def _download_internal_tarball(
     from openhands.automation.storage import get_file_store
 
     store = get_file_store()
-    return store.read(upload.storage_path)
+    try:
+        return store.read(upload.storage_path)
+    except FileNotFoundError as e:
+        # The upload row survived but its object did not, so no retry can ever
+        # succeed. Without this the FileNotFoundError propagates as a plain
+        # Exception: the run is marked FAILED with a bare "Internal error" and
+        # the automation stays enabled, re-failing on every schedule tick.
+        raise TarballNotFoundError(
+            f"Automation tarball missing from storage: {upload.storage_path} "
+            f"(upload {upload_id}). The upload record exists but its object is "
+            "gone; recreate the automation to upload a new tarball."
+        ) from e
 
 
 async def _poll_pending_runs(

--- a/tests/test_disable_automation.py
+++ b/tests/test_disable_automation.py
@@ -44,6 +44,32 @@ def _create_mock_backend() -> MagicMock:
     return mock_backend
 
 
+def _storage_path(upload_id: uuid.UUID) -> str:
+    """Storage path for a test upload, mirroring the production layout."""
+    return f"automation/uploads/{TEST_ORG_ID}/{TEST_USER_ID}/{upload_id}.tar"
+
+
+async def _create_completed_upload(async_session_factory) -> uuid.UUID:
+    """Persist a live, COMPLETED upload row whose object is not in the store."""
+    from openhands.automation.models import TarballUpload, UploadStatus
+
+    upload_id = uuid.uuid4()
+    async with async_session_factory() as session:
+        session.add(
+            TarballUpload(
+                id=upload_id,
+                user_id=TEST_USER_ID,
+                org_id=TEST_ORG_ID,
+                name="test-upload",
+                status=UploadStatus.COMPLETED,
+                storage_path=_storage_path(upload_id),
+                size_bytes=1024,
+            )
+        )
+        await session.commit()
+    return upload_id
+
+
 def _docker_available() -> bool:
     """Check if Docker is available for testcontainers."""
     try:
@@ -227,6 +253,34 @@ class TestDownloadInternalTarball:
         assert "not found" in str(exc_info.value).lower()
         assert str(fake_upload_id) in str(exc_info.value)
 
+    async def test_raises_tarball_not_found_for_missing_object(
+        self, async_session_factory
+    ):
+        """TarballNotFoundError is raised when the row is live but the object is gone.
+
+        This is the C24 failure mode (OSS-9505): the object vanished from MinIO
+        while its Postgres row survived, so ``store.read`` raises
+        ``FileNotFoundError``. It must be reclassified as permanent, otherwise
+        the automation retries the same missing object forever.
+        """
+        from openhands.automation.dispatcher import _download_internal_tarball
+
+        upload_id = await _create_completed_upload(async_session_factory)
+        store = MagicMock()
+        store.read.side_effect = FileNotFoundError(
+            f"File not found: {_storage_path(upload_id)}"
+        )
+
+        with patch("openhands.automation.storage.get_file_store", return_value=store):
+            async with async_session_factory() as session:
+                with pytest.raises(TarballNotFoundError) as exc_info:
+                    await _download_internal_tarball(upload_id, session)
+
+        message = str(exc_info.value)
+        assert "missing from storage" in message
+        assert _storage_path(upload_id) in message
+        assert isinstance(exc_info.value.__cause__, FileNotFoundError)
+
 
 @requires_docker
 class TestExecuteRunDisablesAutomation:
@@ -306,6 +360,98 @@ class TestExecuteRunDisablesAutomation:
             run = result.scalars().first()
             assert run.status == AutomationRunStatus.FAILED
             assert "not found" in run.error_detail.lower()
+
+    @patch("openhands.automation.dispatcher.execute_in_context")
+    @patch("openhands.automation.dispatcher.get_backend")
+    async def test_disables_automation_on_missing_tarball_object(
+        self,
+        mock_get_backend,
+        mock_execute,
+        async_session_factory,
+        mock_settings,
+        mock_client,
+    ):
+        """A live upload row with no object disables the automation (OSS-9505).
+
+        Previously the ``FileNotFoundError`` escaped as a plain ``Exception``:
+        the run was marked FAILED with a bare "Internal error" and the
+        automation stayed enabled, re-failing on every schedule tick.
+        """
+        from openhands.automation.dispatcher import _execute_run
+        from openhands.automation.models import (
+            Automation,
+            AutomationRun,
+            AutomationRunStatus,
+        )
+
+        mock_get_backend.return_value = _create_mock_backend()
+
+        upload_id = await _create_completed_upload(async_session_factory)
+        async with async_session_factory() as session:
+            automation = Automation(
+                user_id=TEST_USER_ID,
+                org_id=TEST_ORG_ID,
+                name="Test Automation",
+                trigger={"type": "cron", "schedule": "* * * * *", "timezone": "UTC"},
+                tarball_path=f"oh-internal://uploads/{upload_id}",
+                entrypoint="uv run main.py",
+                enabled=True,
+            )
+            session.add(automation)
+            await session.commit()
+
+            run = AutomationRun(
+                automation_id=automation.id,
+                status=AutomationRunStatus.RUNNING,
+            )
+            session.add(run)
+            await session.commit()
+            automation_id = automation.id
+
+        store = MagicMock()
+        store.read.side_effect = FileNotFoundError(
+            f"File not found: {_storage_path(upload_id)}"
+        )
+
+        async with async_session_factory() as session:
+            from sqlalchemy.orm import selectinload
+
+            result = await session.execute(
+                select(AutomationRun)
+                .options(selectinload(AutomationRun.automation))
+                .where(AutomationRun.automation_id == automation_id)
+            )
+            run = result.scalars().first()
+
+            with patch(
+                "openhands.automation.storage.get_file_store", return_value=store
+            ):
+                await _execute_run(
+                    run, mock_settings, async_session_factory, mock_client
+                )
+
+        # The automation is disabled instead of retrying a permanently
+        # unreadable object on every tick.
+        async with async_session_factory() as session:
+            result = await session.execute(
+                select(Automation).where(Automation.id == automation_id)
+            )
+            assert result.scalars().first().enabled is False
+
+        # The customer sees the real cause, not "Internal error".
+        async with async_session_factory() as session:
+            result = await session.execute(
+                select(AutomationRun).where(
+                    AutomationRun.automation_id == automation_id
+                )
+            )
+            run = result.scalars().first()
+            assert run.status == AutomationRunStatus.FAILED
+            assert "missing from storage" in run.error_detail
+            assert "Internal error" not in run.error_detail
+
+        # Execution never started: we failed before entering the sandbox.
+        mock_execute.assert_not_called()
 
     @patch("openhands.automation.dispatcher.execute_in_context")
     @patch("openhands.automation.dispatcher.get_backend")


### PR DESCRIPTION
Fixes the customer-visible half of OSS-9505 ([C24] HappyFox #OS00000160): automation "run now" failing with an opaque `Internal error` that repeated on every schedule tick.

This is fix (2) from the issue. Fixes (1) (crash-safe tarball regeneration) and (3) (MinIO durability, PLTF-3455) are **not** in this PR.

> [!WARNING]
> **Do not merge as-is.** Review turned up an over-trigger in this approach — see "Known defect" below. Pushing a narrowing commit.

## The bug

`_download_internal_tarball` already raises `TarballNotFoundError` when the `TarballUpload` **row** is missing, but the subsequent `store.read(upload.storage_path)` was unguarded. When the row is live but its **object** is gone, `s3.py` maps `NoSuchKey` to `FileNotFoundError` — a plain `Exception`, which sails past the `except PermanentDispatchError` handler in dispatch step 4 and lands in `_execute_run_safe`. Two consequences, both of which C24 hit:

- the run is marked `FAILED` with the literal string `"Internal error"` and no detail;
- the automation is **not** disabled, so every schedule tick creates a sandbox, fails the same way, and tears it down (12 and 16 consecutive failures for the two affected automations).

## The fix

Wrap that one read and re-raise as `TarballNotFoundError`, which already subclasses `PermanentDispatchError`. No new machinery — the existing handler disables the automation and surfaces `str(exc)` as `error_detail`. The message names the missing storage path and the remedy (recreate the automation), since the original bytes are not retained anywhere and delete-and-recreate is the only recovery.

## Known defect (being fixed)

`s3.py::_handle_client_error` (lines 262-276) maps **every** `ClientError` to `FileNotFoundError`, not just `NoSuchKey`: `NoSuchBucket`, `AccessDenied`, and an `else` catch-all covering 500 `InternalError`, 503 `ServiceUnavailable`, `SlowDown` throttling and expired credentials all land there too.

So as committed, this PR treats a transient storage hiccup as permanent. On C24 that is not hypothetical — their MinIO is OOM-crash-looping, so a read landing during a restart returns 5xx, which would now permanently disable a healthy automation. Today those runs simply fail and recover on the next tick, so this would be a regression for the exact customer it targets.

Narrowing: raise an `ObjectNotFoundError(FileNotFoundError)` subclass only at the genuine-absence sites (`s3.py:267-268`, `local.py:64`, `google_cloud.py:102,137`) and catch that here instead of bare `FileNotFoundError`. Backward compatible — the seven existing `except FileNotFoundError` handlers keep behaving identically via the parent class, and every other `ClientError` stays transient.

## Tests

Two tests, both verified to fail without the source change:

- `test_raises_tarball_not_found_for_missing_object` — unit-level: live `COMPLETED` row, store raises `FileNotFoundError`, asserts the reclassification and that the original error is chained as `__cause__`.
- `test_disables_automation_on_missing_tarball_object` — end-to-end through `_execute_run`: asserts the automation ends up `enabled=False`, that `error_detail` names the real cause and is *not* `"Internal error"`, and that execution never entered the sandbox.

Full suite: 1148 passed. Pre-commit (ruff format/lint, pycodestyle, pyright) clean.

## Notes for the issue thread

**The attached `reconcile_tarballs.py` cannot discriminate the two candidate root causes the way step 4 of its runbook claims.** It says `RECORD_SOFT_DELETED` implies the edit/rollback bug — but in that scenario `source_upload.deleted_at` is only flushed, never committed, so the rollback reverts the soft-delete *and* `tarball_path` together. The surviving state is a live, `COMPLETED` row with no object: verdict `MISSING_OBJECT`, identical to MinIO loss. `RECORD_SOFT_DELETED` is effectively unreachable via that path, since both writes share one transaction. Breadth (are never-edited automations affected) remains a valid signal; worth also pulling 5xx responses on `PATCH /automations/{id}` from C24.

**Separate latent bug in the same area:** `preset_router.py:378` does `except FileNotFoundError: return None`, so a transient storage error during a prompt edit makes regeneration silently no-op. The PATCH returns 200 and the `prompt` column updates, but the tarball keeps the old baked prompt and nothing surfaces the divergence.