### PR TITLE
feat: accept catalog bundle automations on the raw create path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,6 +261,34 @@ The `/v1/preset/prompt` endpoint allows creating automations by simply providing
 - The generated tarball uses `python main.py` as the entrypoint and `setup.sh` as the setup script
 - Future presets (e.g., plugins) can be added as additional subdirectories under `openhands/automation/presets/`
 
+## Catalog Bundles
+
+A catalog entry in `OpenHands/extensions` normally ships a prompt and is created
+through a preset endpoint. An entry whose automation is deterministic machinery
+— polling, dedupe, its own state and API calls — ships a **script tarball**
+instead, and the host creates it through the ordinary raw path: `POST /v1/uploads`
+for the packed bundle, then `POST /v1` with the returned `oh-internal://` path.
+
+Nothing about execution differs — a bundle run is an ordinary tarball run. What
+the raw path shares with the presets is the catalog contract:
+
+- **`template` provenance** (`TemplateProvenance` in `schemas.py`) is accepted by
+  all three creation endpoints and stored under `preset_metadata["template"]`.
+  It makes creation idempotent: `find_existing_template_automation`
+  (`utils/templates.py`) is consulted first, and an entry already enabled for
+  this user comes back unchanged with a 200 instead of a second automation. The
+  same key is what `record_first_run_outcome` keys its one-time first-run
+  telemetry on, so bundles get that for free.
+- **Preflight** — `POST /v1/validate` accepts `"endpoint": "/v1"` and validates
+  the draft against `CreateAutomationRequest`. It checks the request body, not
+  the upload behind it: `tarball_path` ownership is verified at creation.
+- **`customTarball`** in `GET /v1/capabilities` `features` names the ability to
+  run a client-supplied tarball, so an entry can declare it in
+  `requires.features` and a client can tell whether a bundle card is runnable.
+
+A bundle has no `repos` field on `CreateAutomationRequest`, so it cannot ask the
+service to clone — it fetches what it needs itself.
+
 ## Git Sync
 
 Local/self-hosted deployments can mirror their automations to a git repo for

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,31 +263,27 @@ The `/v1/preset/prompt` endpoint allows creating automations by simply providing
 
 ## Catalog Bundles
 
-A catalog entry in `OpenHands/extensions` normally ships a prompt and is created
+A catalog entry in `OpenHands/extensions` normally ships a prompt, created
 through a preset endpoint. An entry whose automation is deterministic machinery
-— polling, dedupe, its own state and API calls — ships a **script tarball**
-instead, and the host creates it through the ordinary raw path: `POST /v1/uploads`
-for the packed bundle, then `POST /v1` with the returned `oh-internal://` path.
+— polling, dedupe, state, fixed API calls — ships a **script tarball** instead,
+which the host uploads (`POST /v1/uploads`) and creates from (`POST /v1`).
 
-Nothing about execution differs — a bundle run is an ordinary tarball run. What
-the raw path shares with the presets is the catalog contract:
+Execution is unchanged: a bundle run is an ordinary tarball run. What the raw
+path gained is the catalog contract the presets already had:
 
-- **`template` provenance** (`TemplateProvenance` in `schemas.py`) is accepted by
+- **`template` provenance** (`TemplateProvenance` in `schemas.py`), accepted by
   all three creation endpoints and stored under `preset_metadata["template"]`.
-  It makes creation idempotent: `find_existing_template_automation`
-  (`utils/templates.py`) is consulted first, and an entry already enabled for
-  this user comes back unchanged with a 200 instead of a second automation. The
-  same key is what `record_first_run_outcome` keys its one-time first-run
-  telemetry on, so bundles get that for free.
-- **Preflight** — `POST /v1/validate` accepts `"endpoint": "/v1"` and validates
-  the draft against `CreateAutomationRequest`. It checks the request body, not
-  the upload behind it: `tarball_path` ownership is verified at creation.
-- **`customTarball`** in `GET /v1/capabilities` `features` names the ability to
-  run a client-supplied tarball, so an entry can declare it in
-  `requires.features` and a client can tell whether a bundle card is runnable.
+  `find_existing_template_automation` (`utils/templates.py`) is consulted first,
+  so enabling an entry twice returns the existing automation with a 200.
+  `record_first_run_outcome` keys on the same value, so bundles get first-run
+  telemetry for free.
+- **Preflight**: `POST /v1/validate` accepts `"endpoint": "/v1"`. It validates
+  the body, not the upload — `tarball_path` ownership is checked at creation.
+- **`customTarball`** in `GET /v1/capabilities` `features`, so an entry can
+  require it and a client can tell whether a bundle card is runnable here.
 
-A bundle has no `repos` field on `CreateAutomationRequest`, so it cannot ask the
-service to clone — it fetches what it needs itself.
+`CreateAutomationRequest` has no `repos`, so a bundle cannot ask the service to
+clone; it fetches what it needs itself.
 
 ## Git Sync
 

--- a/openhands/automation/capabilities_router.py
+++ b/openhands/automation/capabilities_router.py
@@ -61,11 +61,9 @@ DraftModel = (
 
 # Draft models keyed by the endpoint they would be posted to. Validating with
 # the model creation itself uses is what keeps preflight from drifting.
-# "/v1" is the raw create path, which a catalog entry shipping its own tarball
-# posts to: without it a mapping mistake between the setup form and the request
-# body surfaces as a 422 at creation time, which is what preflight prevents.
-# Preflight validates the body, not the upload behind it — a tarball_path is
-# checked for scheme here and for ownership when the automation is created.
+# "/v1" is the raw create path, used by an entry shipping its own tarball. Its
+# tarball_path is checked for scheme here and for ownership only at creation:
+# preflight validates the body, not the upload behind it.
 _DRAFT_MODELS: dict[str, type[DraftModel]] = {
     "/v1": CreateAutomationRequest,
     "/v1/preset/prompt": CreatePromptAutomationRequest,
@@ -76,8 +74,7 @@ _DRAFT_MODELS: dict[str, type[DraftModel]] = {
 # packages into a run, not from configuration.
 _STATIC_FEATURES = (
     "conversationDispatch",
-    # This deployment can run a tarball the client supplies, so a catalog entry
-    # may ship a script bundle instead of a prompt.
+    # Can run a client-supplied tarball, so an entry may ship a script bundle.
     "customTarball",
     "mcpTools",
     "presetPlugin",

--- a/openhands/automation/capabilities_router.py
+++ b/openhands/automation/capabilities_router.py
@@ -33,6 +33,7 @@ from openhands.automation.preset_router import (
 from openhands.automation.scheduler import POLL_INTERVAL_SECONDS
 from openhands.automation.schemas import (
     CapabilitiesResponse,
+    CreateAutomationRequest,
     CronCapabilities,
     CronTrigger,
     DraftValidationError,
@@ -52,11 +53,21 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1", tags=["Capabilities"])
 
-DraftModel = CreatePromptAutomationRequest | CreatePluginAutomationRequest
+DraftModel = (
+    CreateAutomationRequest
+    | CreatePromptAutomationRequest
+    | CreatePluginAutomationRequest
+)
 
 # Draft models keyed by the endpoint they would be posted to. Validating with
 # the model creation itself uses is what keeps preflight from drifting.
+# "/v1" is the raw create path, which a catalog entry shipping its own tarball
+# posts to: without it a mapping mistake between the setup form and the request
+# body surfaces as a 422 at creation time, which is what preflight prevents.
+# Preflight validates the body, not the upload behind it — a tarball_path is
+# checked for scheme here and for ownership when the automation is created.
 _DRAFT_MODELS: dict[str, type[DraftModel]] = {
+    "/v1": CreateAutomationRequest,
     "/v1/preset/prompt": CreatePromptAutomationRequest,
     "/v1/preset/plugin": CreatePluginAutomationRequest,
 }
@@ -65,6 +76,9 @@ _DRAFT_MODELS: dict[str, type[DraftModel]] = {
 # packages into a run, not from configuration.
 _STATIC_FEATURES = (
     "conversationDispatch",
+    # This deployment can run a tarball the client supplies, so a catalog entry
+    # may ship a script bundle instead of a prompt.
+    "customTarball",
     "mcpTools",
     "presetPlugin",
     "presetPrompt",

--- a/openhands/automation/preset_router.py
+++ b/openhands/automation/preset_router.py
@@ -21,15 +21,19 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
-from sqlalchemy import func, literal, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from openhands.automation.auth import AuthenticatedUser, authenticate_request
 from openhands.automation.constants import MODEL_PROFILE_PATTERN
-from openhands.automation.db import get_session, using_sqlite
+from openhands.automation.db import get_session
 from openhands.automation.git_sync import mark_git_sync_dirty
 from openhands.automation.models import Automation, TarballUpload, UploadStatus
-from openhands.automation.schemas import AutomationResponse, Trigger
+from openhands.automation.schemas import (
+    AutomationResponse,
+    TemplateProvenance,
+    Trigger,
+)
 from openhands.automation.storage import FileStore, get_file_store
 from openhands.automation.telemetry import (
     capture_automation_event,
@@ -41,6 +45,10 @@ from openhands.automation.utils.tarball_validation import (
     build_internal_url,
     build_upload_storage_path,
     parse_internal_upload_id,
+)
+from openhands.automation.utils.templates import (
+    TEMPLATE_EXISTS_RESPONSE,
+    find_existing_template_automation,
 )
 from openhands.automation.utils.timeout import (
     build_automation_timeout_description,
@@ -114,51 +122,6 @@ def _safe_truncate(text: str, max_bytes: int) -> str:
 async def _bytes_to_async_iter(data: bytes) -> AsyncIterator[bytes]:
     """Convert bytes to an async iterator yielding a single chunk."""
     yield data
-
-
-# Cap on the serialized size of template provenance config, so an opaque
-# payload cannot bloat the preset_metadata JSON column.
-MAX_TEMPLATE_CONFIG_BYTES = 16_384
-
-
-class TemplateProvenance(BaseModel):
-    """Opaque provenance of the extension-owned template an automation came from.
-
-    The service stores this verbatim under ``preset_metadata["template"]`` and
-    never validates it against any catalog — template definitions are owned by
-    OpenHands/extensions. Must not contain secrets.
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    id: str = Field(
-        ...,
-        min_length=1,
-        max_length=100,
-        description="Identifier of the extension template (catalog entry id).",
-    )
-    version: str = Field(
-        ...,
-        min_length=1,
-        max_length=50,
-        description="Version of the template at creation time.",
-    )
-    config: dict[str, Any] | None = Field(
-        default=None,
-        description=(
-            "Non-secret configuration the user submitted when enabling the "
-            "template (e.g. setup form values)."
-        ),
-    )
-
-    @field_validator("config")
-    @classmethod
-    def validate_config_size(cls, v: dict[str, Any] | None) -> dict[str, Any] | None:
-        if v is not None and len(json.dumps(v)) > MAX_TEMPLATE_CONFIG_BYTES:
-            raise ValueError(
-                f"config must serialize to at most {MAX_TEMPLATE_CONFIG_BYTES} bytes"
-            )
-        return v
 
 
 class CreatePromptAutomationRequest(BaseModel):
@@ -460,57 +423,8 @@ async def regenerate_preset_prompt_tarball(
     return build_internal_url(new_upload_id)
 
 
-async def _find_existing_template_automation(
-    session: AsyncSession,
-    user: AuthenticatedUser,
-    template_id: str,
-) -> Automation | None:
-    """Find the caller's live automation created from the given template.
-
-    Cross-database JSON extraction mirrors ``get_event_automations``: SQLite
-    uses ``json_extract``, PostgreSQL uses the ``->`` / ``->>`` operators. Rows
-    without template provenance yield NULL and are excluded on both databases.
-
-    Two concurrent creates can both miss the existing row (there is no
-    cross-database unique index on a JSON path); the earliest-created row wins
-    subsequent lookups.
-    """
-    if using_sqlite():
-        template_filter = func.json_extract(
-            Automation.preset_metadata, "$.template.id"
-        ) == literal(template_id)
-    else:
-        template_filter = Automation.preset_metadata.op("->")("template").op("->>")(
-            "id"
-        ) == literal(template_id)
-
-    result = await session.execute(
-        select(Automation)
-        .where(
-            Automation.user_id == user.user_id,
-            Automation.org_id == user.org_id,
-            Automation.deleted_at.is_(None),
-            template_filter,
-        )
-        .order_by(Automation.created_at.asc())
-        .limit(1)
-    )
-    return result.scalars().first()
-
-
-_TEMPLATE_EXISTS_RESPONSE: dict[int | str, dict[str, Any]] = {
-    200: {
-        "model": AutomationResponse,
-        "description": (
-            "An automation created from this template already exists for this "
-            "user; it is returned unchanged."
-        ),
-    },
-}
-
-
 @router.post(
-    "/prompt", status_code=status.HTTP_201_CREATED, responses=_TEMPLATE_EXISTS_RESPONSE
+    "/prompt", status_code=status.HTTP_201_CREATED, responses=TEMPLATE_EXISTS_RESPONSE
 )
 async def create_automation_from_prompt(
     body: CreatePromptAutomationRequest,
@@ -537,8 +451,8 @@ async def create_automation_from_prompt(
     # Idempotent creation: enabling the same extension template twice returns
     # the existing automation unchanged instead of creating a duplicate.
     if body.template is not None:
-        existing = await _find_existing_template_automation(
-            session, user, body.template.id
+        existing = await find_existing_template_automation(
+            session, user.user_id, user.org_id, body.template.id
         )
         if existing is not None:
             response.status_code = status.HTTP_200_OK
@@ -910,7 +824,7 @@ def _format_plugin_sources_for_description(plugins: list[PluginSource]) -> str:
 
 
 @router.post(
-    "/plugin", status_code=status.HTTP_201_CREATED, responses=_TEMPLATE_EXISTS_RESPONSE
+    "/plugin", status_code=status.HTTP_201_CREATED, responses=TEMPLATE_EXISTS_RESPONSE
 )
 async def create_automation_from_plugin(
     body: CreatePluginAutomationRequest,
@@ -944,8 +858,8 @@ async def create_automation_from_plugin(
     # Idempotent creation: enabling the same extension template twice returns
     # the existing automation unchanged instead of creating a duplicate.
     if body.template is not None:
-        existing = await _find_existing_template_automation(
-            session, user, body.template.id
+        existing = await find_existing_template_automation(
+            session, user.user_id, user.org_id, body.template.id
         )
         if existing is not None:
             response.status_code = status.HTTP_200_OK

--- a/openhands/automation/router.py
+++ b/openhands/automation/router.py
@@ -83,14 +83,12 @@ async def create_automation(
     - Internal upload: oh-internal://uploads/{uuid} (from /v1/uploads)
     - External public URL: https://, s3://, or gs:// URLs
 
-    A catalog entry that ships its own tarball creates through this endpoint
-    rather than a preset, so it may carry the same ``template`` provenance the
-    preset endpoints accept — stored, and used to keep creation idempotent.
+    An entry shipping its own tarball creates here rather than through a
+    preset, so it may carry the same ``template`` provenance those accept.
     """
-    # Idempotent creation: enabling the same extension template twice returns
-    # the existing automation unchanged instead of creating a duplicate. This
-    # runs before tarball validation so a repeat enable costs one query and
-    # leaves the freshly uploaded tarball unreferenced rather than adopted.
+    # Enabling the same template twice returns the existing automation rather
+    # than a duplicate. Before tarball validation, so a repeat enable costs one
+    # query and leaves the new upload unreferenced rather than adopting it.
     if body.template is not None:
         existing = await find_existing_template_automation(
             session, user.user_id, user.org_id, body.template.id

--- a/openhands/automation/router.py
+++ b/openhands/automation/router.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import re
 import uuid
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.responses import RedirectResponse
@@ -49,6 +50,10 @@ from openhands.automation.utils.tarball_validation import (
     parse_internal_upload_id,
     validate_tarball_path,
 )
+from openhands.automation.utils.templates import (
+    TEMPLATE_EXISTS_RESPONSE,
+    find_existing_template_automation,
+)
 from openhands.automation.utils.timeout import default_automation_timeout
 
 
@@ -62,10 +67,13 @@ _require_manage_automations = require_permission("manage_automations")
 # --- CRUD ---
 
 
-@router.post("", status_code=status.HTTP_201_CREATED)
+@router.post(
+    "", status_code=status.HTTP_201_CREATED, responses=TEMPLATE_EXISTS_RESPONSE
+)
 async def create_automation(
     body: CreateAutomationRequest,
     request: Request,
+    response: Response,
     user: AuthenticatedUser = Depends(_require_manage_automations),
     session: AsyncSession = Depends(get_session),
 ) -> AutomationResponse:
@@ -74,7 +82,23 @@ async def create_automation(
     The tarball_path can be either:
     - Internal upload: oh-internal://uploads/{uuid} (from /v1/uploads)
     - External public URL: https://, s3://, or gs:// URLs
+
+    A catalog entry that ships its own tarball creates through this endpoint
+    rather than a preset, so it may carry the same ``template`` provenance the
+    preset endpoints accept — stored, and used to keep creation idempotent.
     """
+    # Idempotent creation: enabling the same extension template twice returns
+    # the existing automation unchanged instead of creating a duplicate. This
+    # runs before tarball validation so a repeat enable costs one query and
+    # leaves the freshly uploaded tarball unreferenced rather than adopted.
+    if body.template is not None:
+        existing = await find_existing_template_automation(
+            session, user.user_id, user.org_id, body.template.id
+        )
+        if existing is not None:
+            response.status_code = status.HTTP_200_OK
+            return AutomationResponse.model_validate(existing)
+
     # Validate tarball_path (checks ownership for internal uploads)
     await validate_tarball_path(
         tarball_path=body.tarball_path,
@@ -84,11 +108,16 @@ async def create_automation(
     )
     model = resolve_model_profile_for_user(body.model, user)
 
+    preset_metadata: dict[str, Any] | None = None
+    if body.template is not None:
+        preset_metadata = {"template": body.template.model_dump(exclude_none=True)}
+
     auto = Automation(
         user_id=user.user_id,
         org_id=user.org_id,
         name=body.name,
         model=model,
+        preset_metadata=preset_metadata,
         trigger=body.trigger.model_dump(),
         tarball_path=body.tarball_path,
         setup_script_path=body.setup_script_path,
@@ -103,12 +132,16 @@ async def create_automation(
     await session.flush()
     await session.refresh(auto)
     await mark_git_sync_dirty(session, auto)
+    creation_properties: dict[str, Any] = {"creation_path": "raw"}
+    if body.template is not None:
+        creation_properties["template_id"] = body.template.id
+        creation_properties["template_version"] = body.template.version
     await capture_automation_event(
         "automation_created",
         request=request,
         user=user,
         automation=auto,
-        properties={"creation_path": "raw"},
+        properties=creation_properties,
     )
     return AutomationResponse.model_validate(auto)
 

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -1,5 +1,6 @@
 """Pydantic request/response schemas for the API."""
 
+import json
 import re
 import uuid
 from enum import StrEnum
@@ -244,6 +245,57 @@ def validate_command_string(
     return v
 
 
+# --- Template provenance ---
+
+# Cap on the serialized size of template provenance config, so an opaque
+# payload cannot bloat the preset_metadata JSON column.
+MAX_TEMPLATE_CONFIG_BYTES = 16_384
+
+
+class TemplateProvenance(BaseModel):
+    """Opaque provenance of the extension-owned template an automation came from.
+
+    The service stores this verbatim under ``preset_metadata["template"]`` and
+    never validates it against any catalog — template definitions are owned by
+    OpenHands/extensions. Must not contain secrets.
+
+    Lives here rather than in ``preset_router`` because every creation path
+    accepts it: the two preset endpoints and the raw ``POST /v1`` a catalog
+    entry shipping its own tarball uses.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        description="Identifier of the extension template (catalog entry id).",
+    )
+    version: str = Field(
+        ...,
+        min_length=1,
+        max_length=50,
+        description="Version of the template at creation time.",
+    )
+    config: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Non-secret configuration the user submitted when enabling the "
+            "template (e.g. setup form values)."
+        ),
+    )
+
+    @field_validator("config")
+    @classmethod
+    def validate_config_size(cls, v: dict[str, Any] | None) -> dict[str, Any] | None:
+        if v is not None and len(json.dumps(v)) > MAX_TEMPLATE_CONFIG_BYTES:
+            raise ValueError(
+                f"config must serialize to at most {MAX_TEMPLATE_CONFIG_BYTES} bytes"
+            )
+        return v
+
+
 # --- Requests ---
 
 
@@ -285,6 +337,15 @@ class CreateAutomationRequest(BaseModel):
             "If true, leave the sandbox for runtime TTL cleanup after the run "
             "finishes. If false or null, explicitly clean it up after "
             "completion (or after post-run callbacks, when configured)."
+        ),
+    )
+    template: TemplateProvenance | None = Field(
+        default=None,
+        description=(
+            "Opaque provenance of the extension template this automation is "
+            "created from. Enables idempotent creation: when a live automation "
+            "for the same user and template id already exists, it is returned "
+            "unchanged with HTTP 200 instead of creating a duplicate."
         ),
     )
 
@@ -764,8 +825,12 @@ class ValidateDraftRequest(_SetupContractModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    endpoint: Literal["/v1/preset/prompt", "/v1/preset/plugin"] = Field(
-        ..., description="Creation endpoint the draft will be sent to"
+    endpoint: Literal["/v1", "/v1/preset/prompt", "/v1/preset/plugin"] = Field(
+        ...,
+        description=(
+            "Creation endpoint the draft will be sent to. '/v1' is the raw "
+            "create path a catalog entry shipping its own tarball uses."
+        ),
     )
     draft: dict[str, Any] = Field(
         ..., description="The request body that would be sent to that endpoint"

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -4,7 +4,7 @@ import json
 import re
 import uuid
 from enum import StrEnum
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Final, Literal
 
 from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, field_validator
 from pydantic.alias_generators import to_camel
@@ -247,21 +247,17 @@ def validate_command_string(
 
 # --- Template provenance ---
 
-# Cap on the serialized size of template provenance config, so an opaque
-# payload cannot bloat the preset_metadata JSON column.
-MAX_TEMPLATE_CONFIG_BYTES = 16_384
+# Keeps an opaque payload from bloating the preset_metadata JSON column.
+MAX_TEMPLATE_CONFIG_BYTES: Final[int] = 16_384
 
 
 class TemplateProvenance(BaseModel):
-    """Opaque provenance of the extension-owned template an automation came from.
+    """The extension-owned template an automation was created from.
 
-    The service stores this verbatim under ``preset_metadata["template"]`` and
-    never validates it against any catalog — template definitions are owned by
-    OpenHands/extensions. Must not contain secrets.
-
-    Lives here rather than in ``preset_router`` because every creation path
-    accepts it: the two preset endpoints and the raw ``POST /v1`` a catalog
-    entry shipping its own tarball uses.
+    Stored verbatim under ``preset_metadata["template"]`` and never validated
+    against any catalog, which OpenHands/extensions owns. Must not contain
+    secrets. Every creation path accepts it, which is why it lives here rather
+    than in ``preset_router``.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -342,10 +338,9 @@ class CreateAutomationRequest(BaseModel):
     template: TemplateProvenance | None = Field(
         default=None,
         description=(
-            "Opaque provenance of the extension template this automation is "
-            "created from. Enables idempotent creation: when a live automation "
-            "for the same user and template id already exists, it is returned "
-            "unchanged with HTTP 200 instead of creating a duplicate."
+            "Provenance of the extension template this automation comes from. "
+            "Makes creation idempotent: a live automation for the same user and "
+            "template id is returned unchanged with HTTP 200."
         ),
     )
 
@@ -828,8 +823,8 @@ class ValidateDraftRequest(_SetupContractModel):
     endpoint: Literal["/v1", "/v1/preset/prompt", "/v1/preset/plugin"] = Field(
         ...,
         description=(
-            "Creation endpoint the draft will be sent to. '/v1' is the raw "
-            "create path a catalog entry shipping its own tarball uses."
+            "Creation endpoint the draft will be sent to. '/v1' is the raw path, "
+            "which an entry shipping its own tarball uses."
         ),
     )
     draft: dict[str, Any] = Field(

--- a/openhands/automation/utils/templates.py
+++ b/openhands/automation/utils/templates.py
@@ -1,9 +1,7 @@
 """Lookup for automations created from an extension catalog template.
 
-Template provenance is stored under ``preset_metadata["template"]`` by every
-creation path — both preset endpoints and the raw ``POST /v1`` a catalog entry
-shipping its own tarball uses — so the lookup that makes creation idempotent
-lives here rather than in any one router.
+Every creation path stores provenance under ``preset_metadata["template"]``, so
+the lookup that makes creation idempotent belongs to none of them in particular.
 """
 
 import uuid
@@ -17,8 +15,8 @@ from openhands.automation.models import Automation
 from openhands.automation.schemas import AutomationResponse
 
 
-# The 200 every creation path returns when the template is already enabled,
-# documented alongside its 201 in the OpenAPI schema.
+# Documents the 200 a creation path returns when the template is already
+# enabled, alongside its 201, in the OpenAPI schema.
 TEMPLATE_EXISTS_RESPONSE: dict[int | str, dict[str, Any]] = {
     200: {
         "model": AutomationResponse,
@@ -38,13 +36,13 @@ async def find_existing_template_automation(
 ) -> Automation | None:
     """Find the caller's live automation created from the given template.
 
-    Cross-database JSON extraction mirrors ``get_event_automations``: SQLite
-    uses ``json_extract``, PostgreSQL uses the ``->`` / ``->>`` operators. Rows
-    without template provenance yield NULL and are excluded on both databases.
+    JSON extraction mirrors ``get_event_automations``: ``json_extract`` on
+    SQLite, ``->``/``->>`` on PostgreSQL. Rows without provenance yield NULL and
+    are excluded on both.
 
-    Two concurrent creates can both miss the existing row (there is no
-    cross-database unique index on a JSON path); the earliest-created row wins
-    subsequent lookups.
+    Two concurrent creates can both miss the existing row, since no
+    cross-database unique index on a JSON path is available; the earliest-created
+    row wins subsequent lookups.
     """
     if using_sqlite():
         template_filter = func.json_extract(

--- a/openhands/automation/utils/templates.py
+++ b/openhands/automation/utils/templates.py
@@ -1,0 +1,69 @@
+"""Lookup for automations created from an extension catalog template.
+
+Template provenance is stored under ``preset_metadata["template"]`` by every
+creation path — both preset endpoints and the raw ``POST /v1`` a catalog entry
+shipping its own tarball uses — so the lookup that makes creation idempotent
+lives here rather than in any one router.
+"""
+
+import uuid
+from typing import Any
+
+from sqlalchemy import func, literal, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from openhands.automation.db import using_sqlite
+from openhands.automation.models import Automation
+from openhands.automation.schemas import AutomationResponse
+
+
+# The 200 every creation path returns when the template is already enabled,
+# documented alongside its 201 in the OpenAPI schema.
+TEMPLATE_EXISTS_RESPONSE: dict[int | str, dict[str, Any]] = {
+    200: {
+        "model": AutomationResponse,
+        "description": (
+            "An automation created from this template already exists for this "
+            "user; it is returned unchanged."
+        ),
+    },
+}
+
+
+async def find_existing_template_automation(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    org_id: uuid.UUID,
+    template_id: str,
+) -> Automation | None:
+    """Find the caller's live automation created from the given template.
+
+    Cross-database JSON extraction mirrors ``get_event_automations``: SQLite
+    uses ``json_extract``, PostgreSQL uses the ``->`` / ``->>`` operators. Rows
+    without template provenance yield NULL and are excluded on both databases.
+
+    Two concurrent creates can both miss the existing row (there is no
+    cross-database unique index on a JSON path); the earliest-created row wins
+    subsequent lookups.
+    """
+    if using_sqlite():
+        template_filter = func.json_extract(
+            Automation.preset_metadata, "$.template.id"
+        ) == literal(template_id)
+    else:
+        template_filter = Automation.preset_metadata.op("->")("template").op("->>")(
+            "id"
+        ) == literal(template_id)
+
+    result = await session.execute(
+        select(Automation)
+        .where(
+            Automation.user_id == user_id,
+            Automation.org_id == org_id,
+            Automation.deleted_at.is_(None),
+            template_filter,
+        )
+        .order_by(Automation.created_at.asc())
+        .limit(1)
+    )
+    return result.scalars().first()

--- a/tests/test_capabilities_router.py
+++ b/tests/test_capabilities_router.py
@@ -37,6 +37,13 @@ EVENT_DRAFT = {
     },
 }
 
+BUNDLE_DRAFT = {
+    "name": "PR reviewer",
+    "tarball_path": "oh-internal://uploads/12345678-1234-1234-1234-123456789abc",
+    "entrypoint": "uv run main.py",
+    "trigger": {"type": "cron", "schedule": "*/15 * * * *", "timezone": "UTC"},
+}
+
 GITHUB_USER = {"id": 3, "login": "someone"}
 
 
@@ -46,7 +53,7 @@ def with_trigger(draft: dict, **overrides: str) -> dict:
 
 
 def preflight(draft: dict, **extra: object) -> dict:
-    """Build a preflight request body for the prompt-preset endpoint."""
+    """Build a preflight request body, defaulting to the prompt-preset endpoint."""
     return {
         "automationId": "github-pr-reviewer",
         "endpoint": "/v1/preset/prompt",
@@ -130,6 +137,7 @@ class TestGetCapabilities:
         assert "UTC" in body["triggers"]["cron"]["timezones"]
         assert "webhookDelivery" in body["features"]
         assert "kvStore" in body["features"]
+        assert "customTarball" in body["features"]
 
     async def test_advertises_the_configured_timeout_ceiling(
         self, async_client, ready_deployment, monkeypatch
@@ -368,6 +376,42 @@ class TestValidateDraft:
         body = response.json()
         assert body["valid"] is False
         assert addressed_errors(body) == [("model", "model_profile_not_found")]
+
+    async def test_valid_bundle_draft_reports_no_errors(self, async_client):
+        """A catalog entry shipping its own tarball can preflight its draft too."""
+        response = await async_client.post(
+            VALIDATE_URL,
+            json=preflight(BUNDLE_DRAFT, endpoint="/v1"),
+        )
+
+        assert response.status_code == 200
+        assert response.json()["valid"] is True
+
+    async def test_bundle_draft_reports_schema_errors(self, async_client):
+        """A body the raw create endpoint would 422 is caught before creation."""
+        draft = {**BUNDLE_DRAFT}
+        del draft["entrypoint"]
+
+        response = await async_client.post(
+            VALIDATE_URL, json=preflight(draft, endpoint="/v1")
+        )
+
+        body = response.json()
+        assert body["valid"] is False
+        assert ("entrypoint", "missing") in addressed_errors(body)
+
+    async def test_bundle_draft_is_checked_against_the_cron_floor(self, async_client):
+        """Trigger checks are model-agnostic, so a bundle gets them unchanged."""
+        response = await async_client.post(
+            VALIDATE_URL,
+            json=preflight(
+                with_trigger(BUNDLE_DRAFT, schedule="*/10 * * * * *"), endpoint="/v1"
+            ),
+        )
+
+        body = response.json()
+        assert body["valid"] is False
+        assert addressed_errors(body) == [("trigger.schedule", "interval_too_short")]
 
     async def test_unknown_creation_endpoint_is_rejected(self, async_client):
         """Preflight only validates drafts for the endpoints it may name."""

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -212,6 +212,121 @@ class TestCreateAutomation:
         assert response.status_code == 201
         assert response.json()["preset_metadata"] is None
 
+    async def test_create_automation_stores_template_provenance(self, async_client):
+        """A catalog entry shipping its own tarball records where it came from."""
+        payload = {
+            "name": "PR Reviewer Bundle",
+            "trigger": {"type": "cron", "schedule": "*/5 * * * *"},
+            "tarball_path": "s3://bucket/path/to/bundle.tar.gz",
+            "entrypoint": "uv run main.py",
+            "template": {
+                "id": "github-pr-reviewer",
+                "version": "1.2.0",
+                "config": {"repos": ["OpenHands/automation"]},
+            },
+        }
+
+        response = await async_client.post("/api/automation/v1", json=payload)
+
+        assert response.status_code == 201
+        assert response.json()["preset_metadata"] == {
+            "template": {
+                "id": "github-pr-reviewer",
+                "version": "1.2.0",
+                "config": {"repos": ["OpenHands/automation"]},
+            }
+        }
+
+    async def test_create_automation_with_known_template_returns_existing(
+        self, async_client
+    ):
+        """Enabling the same bundle twice returns the first automation, 200."""
+        payload = {
+            "name": "PR Reviewer Bundle",
+            "trigger": {"type": "cron", "schedule": "*/5 * * * *"},
+            "tarball_path": "s3://bucket/path/to/bundle.tar.gz",
+            "entrypoint": "uv run main.py",
+            "template": {"id": "github-pr-reviewer", "version": "1.2.0"},
+        }
+        first = await async_client.post("/api/automation/v1", json=payload)
+        assert first.status_code == 201
+
+        second = await async_client.post("/api/automation/v1", json=payload)
+
+        assert second.status_code == 200
+        assert second.json()["id"] == first.json()["id"]
+        listing = await async_client.get("/api/automation/v1")
+        assert listing.json()["total"] == 1
+
+    async def test_create_automation_shares_template_identity_with_presets(
+        self, async_client
+    ):
+        """A template enabled as a preset is not enabled again as a bundle."""
+        first = await async_client.post(
+            "/api/automation/v1/preset/prompt",
+            json={
+                "name": "Reviewer",
+                "prompt": "Review open pull requests.",
+                "trigger": {"type": "cron", "schedule": "*/5 * * * *"},
+                "template": {"id": "shared-entry", "version": "1.0.0"},
+            },
+        )
+        assert first.status_code == 201
+
+        second = await async_client.post(
+            "/api/automation/v1",
+            json={
+                "name": "Reviewer Bundle",
+                "trigger": {"type": "cron", "schedule": "*/5 * * * *"},
+                "tarball_path": "s3://bucket/path/to/bundle.tar.gz",
+                "entrypoint": "uv run main.py",
+                "template": {"id": "shared-entry", "version": "2.0.0"},
+            },
+        )
+
+        assert second.status_code == 200
+        assert second.json()["id"] == first.json()["id"]
+
+    async def test_deleted_bundle_automation_does_not_block_reenabling(
+        self, async_client
+    ):
+        """After deleting a bundle automation, the entry can be enabled again."""
+        payload = {
+            "name": "Recreate Me",
+            "trigger": {"type": "cron", "schedule": "*/5 * * * *"},
+            "tarball_path": "s3://bucket/path/to/bundle.tar.gz",
+            "entrypoint": "uv run main.py",
+            "template": {"id": "github-pr-reviewer", "version": "1.2.0"},
+        }
+        first = await async_client.post("/api/automation/v1", json=payload)
+        deleted = await async_client.delete(f"/api/automation/v1/{first.json()['id']}")
+        assert deleted.status_code == 204
+
+        second = await async_client.post("/api/automation/v1", json=payload)
+
+        assert second.status_code == 201
+        assert second.json()["id"] != first.json()["id"]
+
+    async def test_create_automation_rejects_oversized_template_config(
+        self, async_client
+    ):
+        """A template config over the serialized-size cap is a validation error."""
+        payload = {
+            "name": "Oversized Config",
+            "trigger": {"type": "cron", "schedule": "*/5 * * * *"},
+            "tarball_path": "s3://bucket/path/to/bundle.tar.gz",
+            "entrypoint": "uv run main.py",
+            "template": {
+                "id": "big-entry",
+                "version": "1.0.0",
+                "config": {"blob": "x" * 20_000},
+            },
+        }
+
+        response = await async_client.post("/api/automation/v1", json=payload)
+
+        assert response.status_code == 422
+
     async def test_create_automation_defaults_to_active_model_profile(
         self, async_client, mock_authenticated_user
     ):


### PR DESCRIPTION
Closes #344.

A catalog entry that ships a **script tarball** instead of a prompt creates through the ordinary raw path — `POST /v1/uploads`, then `POST /v1` — which already works. What was missing is the three things the preset paths have and the raw path did not, each visible to the client.

## 1. `template` provenance on `CreateAutomationRequest`

`TemplateProvenance` moves from `preset_router.py` to `schemas.py` (unchanged shape), and `CreateAutomationRequest` gains `template: TemplateProvenance | None`. On the raw create path it is stored under `preset_metadata["template"]`, exactly as the presets store it, which gives a bundle automation the same four things: a record of the catalog entry and version, idempotent creation (the second enable returns the existing automation with **200** instead of creating a duplicate), stored config for a later edit dialog, and a way for a client to show the entry as already enabled.

The lookup is the existing one — `_find_existing_template_automation` moves to `utils/templates.py` as `find_existing_template_automation` and is now called by all three creation endpoints, so template identity is shared across them: an entry enabled as a preset is not enabled again as a bundle. Same for `TEMPLATE_EXISTS_RESPONSE`, which was duplicated per endpoint.

The lookup runs before tarball validation, matching the presets, so a repeat enable costs one query and leaves the freshly uploaded tarball unreferenced rather than adopting it.

## 2. Preflight for the raw create body

`ValidateDraftRequest.endpoint` accepts `"/v1"` and `_DRAFT_MODELS["/v1"] = CreateAutomationRequest`. The cron/event checks in `validate_draft` were already model-agnostic and needed no change. Preflight validates the request body, not the upload behind it — `tarball_path` is checked for scheme here and for ownership at creation.

## 3. A capability flag

`customTarball` is added to `_STATIC_FEATURES`, so an extensions entry can declare the requirement in `requires.features` and a client can tell whether a bundle card is runnable on this deployment.

## Notes

- Nothing here changes the execution path. A bundle run is an ordinary tarball run.
- `record_first_run_outcome` already keys its one-time first-run telemetry on `preset_metadata["template"]`, so bundle automations get that for free.
- `automation_created` telemetry on the raw path now carries `template_id`/`template_version` when a template is present, matching the presets.
- Left out deliberately, per the issue's open question: `repos` on `CreateAutomationRequest`. `github-pr-reviewer` fetches what it needs itself. Worth deciding separately whether the raw path should gain it for parity.

## Test plan

- `tests/test_router.py::TestCreateAutomation` — provenance stored and returned; second enable returns the first automation with 200 and the listing still totals 1; a template enabled as a preset is not re-enabled as a bundle; deleting frees the entry to be enabled again; oversized `config` is a 422.
- `tests/test_capabilities_router.py` — `customTarball` advertised; a `/v1` draft preflights clean; a missing `entrypoint` is reported against its field instead of surfacing as a 422 at creation; the cron floor applies to a bundle draft unchanged.
- Full unit suite: `uv run pytest tests/ --ignore=tests/integration` → 1300 passed. Two failures in `tests/test_router.py` (`test_create_automation_success`, `test_dispatch_automation_success`) reproduce on `main` when those files are run alone and are unrelated to this change.
- `pre-commit run --files ...` (ruff format/lint, pycodestyle, pyright) passes.
