### PR TITLE
fix(presets): clear inherited VIRTUAL_ENV before building the run venv

### DIFF
--- a/openhands/automation/presets/plugin/setup.sh
+++ b/openhands/automation/presets/plugin/setup.sh
@@ -35,6 +35,13 @@ if [ -z "$SDK_VERSION" ]; then
 fi
 
 echo "[setup] Creating isolated virtual environment"
+# Clear any inherited active venv so the uv commands below target the .venv we
+# create here, not a venv from the parent process. This matters in local
+# agent-server mode: when the agent-server is launched via `uv run`, its child
+# bash shells inherit VIRTUAL_ENV, and `uv pip install` would otherwise install
+# into that inherited venv, leaving this .venv empty (main.py then fails with
+# ModuleNotFoundError: No module named 'openhands').
+unset VIRTUAL_ENV
 # Pin >=3.12 so uv doesn't default to an older system Python (e.g. macOS
 # CommandLineTools 3.9), which can't satisfy openhands-sdk's requires-python.
 uv venv .venv --python '>=3.12' --quiet

--- a/openhands/automation/presets/prompt/setup.sh
+++ b/openhands/automation/presets/prompt/setup.sh
@@ -35,6 +35,13 @@ if [ -z "$SDK_VERSION" ]; then
 fi
 
 echo "[setup] Creating isolated virtual environment"
+# Clear any inherited active venv so the uv commands below target the .venv we
+# create here, not a venv from the parent process. This matters in local
+# agent-server mode: when the agent-server is launched via `uv run`, its child
+# bash shells inherit VIRTUAL_ENV, and `uv pip install` would otherwise install
+# into that inherited venv, leaving this .venv empty (main.py then fails with
+# ModuleNotFoundError: No module named 'openhands').
+unset VIRTUAL_ENV
 # Pin >=3.12 so uv doesn't default to an older system Python (e.g. macOS
 # CommandLineTools 3.9), which can't satisfy openhands-sdk's requires-python.
 uv venv .venv --python '>=3.12' --quiet


### PR DESCRIPTION
## What

Clear an inherited `VIRTUAL_ENV` before building the per-run virtualenv in both preset `setup.sh` files (`prompt` and `plugin`).

## Why

In **local agent-server mode**, when the agent-server is launched via `uv run`, its child bash shells inherit `VIRTUAL_ENV` pointing at the agent-server's own venv. The preset `setup.sh` then does:

```bash
uv venv .venv --python '>=3.12' --quiet
uv pip install --quiet "openhands-sdk==${SDK_VERSION}" ...
```

`uv pip install` installs into `$VIRTUAL_ENV` when it's set, so the SDK lands in the **inherited** venv, not the freshly-created `.venv`. The run's `.venv` stays empty, `setup.sh` still prints `[setup] Done`, and `main.py` then fails:

```
ModuleNotFoundError: No module named 'openhands'
```

This makes local-agent-server automation runs fail on any deployment whose agent-server runs under `uv run`.

## Fix

`unset VIRTUAL_ENV` right before the `uv venv` / `uv pip install` calls, so uv targets the `.venv` created in the run's working directory. One line, both presets.

## Verification

Reproduced on a self-hosted local-mode deployment: a bash command run through the agent-server printed `VIRTUAL_ENV=/…/.venv`; runs failed at `import openhands` with an empty run `.venv`. After clearing `VIRTUAL_ENV`, the same install populated the run `.venv` correctly and the automation completed end-to-end.

Fixes #348
