### PR TITLE
chore: PLTF-3502 add SonarQube analysis

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,9 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v5
+              with:
+                  # SonarQube reads git history to attribute issues to authors.
+                  fetch-depth: 0
 
             - name: Install uv
               uses: astral-sh/setup-uv@v7
@@ -47,3 +50,13 @@ jobs:
                   title: Coverage Report
                   create-new-comment: false
                   hide-report: false
+
+
+            # coverage.xml is written by the pytest step above. Fork PRs get no secrets,
+            # so the scan could only fail on a missing token -- skip rather than fail red.
+            - name: SonarQube analysis
+              if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+              uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
+              env:
+                  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+                  SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectKey=automation
+sonar.projectName=automation
+
+# tests/ is top level, so sources and tests are already disjoint -- SonarQube aborts if a
+# file is reachable from both.
+sonar.sources=openhands
+sonar.tests=tests
+
+# Written by tests.yml as --cov-report=xml:coverage.xml, in the same job as the scan, so
+# the report always matches the analysed commit.
+sonar.python.coverage.reportPaths=coverage.xml
+
+sonar.python.version=3.12
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Why

We're evaluating SonarQube as a code health scorecard across five repos, and this is the analysis config for this one. It runs as a step in `tests.yml` rather than a separate workflow, because the pytest step there already writes `coverage.xml` via `--cov-report=xml` — so coverage always comes from the commit being analysed, and no test run is duplicated. `sonar.sources` is `openhands` with `tests` declared separately: SonarQube requires the two to be disjoint sets and aborts if a file is reachable from both. The POC is time-boxed and the instance is disposable, so this is expected to be reverted rather than kept.

The scan is skipped for fork pull requests, which get no secrets and could only fail on a missing token.

## Validation

- **`coverage.xml` already exists at the path configured** — `tests.yml` runs pytest with `--cov=openhands/automation --cov-report=xml:coverage.xml`, so no new coverage plumbing was needed.
- **Sources and tests are disjoint** — `tests/` is top level, not nested inside `openhands/`, so the indexed-twice failure does not apply here.
- **`sonar.python.version=3.12` matches** `.python-version` and `requires-python = ">=3.12"`.
- **This repo is Python only** — 1.66 MB Python with no `package.json`, `frontend/` or JS lockfile, so no frontend coverage or dependency install is involved.
- **The scanner action is pinned to a full commit SHA**, with the version in a trailing comment.

This PR was drafted by an AI agent on behalf of the user.