### PR TITLE
feat(runs): report a live phase for every automation run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,7 @@ Completion is handled asynchronously:
 | `SANDBOX_ID` | From sandbox creation response | SDK reads for settings API calls |
 | `SESSION_API_KEY` | From sandbox creation response | SDK reads for settings API auth |
 | `AUTOMATION_CALLBACK_URL` | Constructed by dispatcher | SDK posts completion status here |
+| `AUTOMATION_PHASE_URL` | Constructed by dispatcher | `POST /v1/runs/{id}/phase` — code inside the sandbox reports its own phase here once the entrypoint owns it |
 | `AUTOMATION_RUN_ID` | Run ID | Included in callback payload |
 | `AUTOMATION_EVENT_PAYLOAD` | Trigger context JSON | Available to user's script; preset scripts also use it to set a descriptive conversation title |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,7 @@ Completion is handled asynchronously:
 | `SANDBOX_ID` | From sandbox creation response | SDK reads for settings API calls |
 | `SESSION_API_KEY` | From sandbox creation response | SDK reads for settings API auth |
 | `AUTOMATION_CALLBACK_URL` | Constructed by dispatcher | SDK posts completion status here |
-| `AUTOMATION_PHASE_URL` | Constructed by dispatcher | `POST /v1/runs/{id}/phase` — code inside the sandbox reports its own phase here once the entrypoint owns it |
+| `AUTOMATION_PHASE_URL` | Constructed by dispatcher | `POST /v1/runs/{id}/phase` — code inside the sandbox reports its own phase here once the entrypoint owns it. The `prompt`/`plugin` presets already do this (`_emit_phase` in their `sdk_main.py`); see [`docs/run-phase-reporting.md`](docs/run-phase-reporting.md) for the recipe to add it to a custom entrypoint |
 | `AUTOMATION_RUN_ID` | Run ID | Included in callback payload |
 | `AUTOMATION_EVENT_PAYLOAD` | Trigger context JSON | Available to user's script; preset scripts also use it to set a descriptive conversation title |
 

--- a/docs/run-phase-reporting.md
+++ b/docs/run-phase-reporting.md
@@ -94,10 +94,18 @@ you want phases in local mode.
 | 401 | The credential was missing or not the one this service accepts |
 | 403 | The caller does not own the automation this run belongs to |
 | 404 | No run with that `run_id` |
+| 409 | The run has already finished — see below |
 | 422 | The body broke one of the rules above |
 
 None of the error responses change the run's status or its stored phase —
 validation happens before anything is written.
+
+Only a `PENDING` or `RUNNING` run accepts a phase; any other status answers
+409 and keeps the phase it already had. A finished run's phase is a record of
+how far it got — for a failed run it is the place it stopped, which is what
+the UI shows beside the failure — so a straggling write from a sandbox that
+outlived its run cannot move it. A 409 late in a run is normal and needs no
+handling beyond the rule in the next section.
 
 ## Failure handling
 

--- a/docs/run-phase-reporting.md
+++ b/docs/run-phase-reporting.md
@@ -77,6 +77,9 @@ you want phases in local mode.
 
 - At least one of `code`/`label` must be non-blank after `.strip()`, or the
   request is rejected with 422.
+- `label` is what users read. Send one whenever the phase is meant for a
+  human: without it the UI falls back to showing the raw `code`, so
+  `checking_out` appears exactly like that, underscores and all.
 - Neither field may contain Unicode `Cc` (control) or `Zl`/`Zp` (line/paragraph
   separator) characters — also 422. `Cf` (format) characters are allowed, so
   emoji sequences and non-Latin labels pass through fine.

--- a/docs/run-phase-reporting.md
+++ b/docs/run-phase-reporting.md
@@ -79,7 +79,9 @@ you want phases in local mode.
   request is rejected with 422.
 - `label` is what users read. Send one whenever the phase is meant for a
   human: without it the UI falls back to showing the raw `code`, so
-  `checking_out` appears exactly like that, underscores and all.
+  `checking_out` appears exactly like that, underscores and all. A
+  whitespace-only label counts as none — it is stored as sent, and the UI
+  falls back the same way rather than rendering blank text.
 - Neither field may contain Unicode `Cc` (control) or `Zl`/`Zp` (line/paragraph
   separator) characters — also 422. `Cf` (format) characters are allowed, so
   emoji sequences and non-Latin labels pass through fine.

--- a/docs/run-phase-reporting.md
+++ b/docs/run-phase-reporting.md
@@ -1,0 +1,112 @@
+# Run Phase Reporting
+
+How to report human-readable progress from inside a running automation, so
+users see more than "running" for the whole duration — for example a
+code-review automation moving through "polling PRs by label" → "checking out
+PR #123" → "studying the diff" → "QA checks" → "posting comments".
+
+## Who needs this
+
+The service already reports its own phases up through `entrypoint_start`
+(queued → sandbox provisioning → bundle upload → entrypoint start). From
+`entrypoint_start` onward, phase reporting is up to your code — otherwise the
+phase goes dark for the rest of the run. The `prompt` and `plugin` presets do
+this already (see `openhands/automation/presets/{prompt,plugin}/sdk_main.py`,
+function `_emit_phase`); if you write a custom entrypoint script, add the same
+call yourself.
+
+## How
+
+`AUTOMATION_PHASE_URL` is injected into the sandbox as a complete, ready-to-POST
+URL (not a base to build on). POST it a JSON body with the phase's `code` and
+`label`:
+
+```python
+import json
+import os
+from urllib.request import Request, urlopen
+
+def emit_phase(code: str, label: str) -> None:
+    phase_url = os.environ.get("AUTOMATION_PHASE_URL")
+    if not phase_url:
+        return
+    credential = os.environ.get("AUTOMATION_CALLBACK_API_KEY") or os.environ.get(
+        "OPENHANDS_API_KEY"
+    )
+    headers = {"Content-Type": "application/json"}
+    if credential:
+        headers["Authorization"] = f"Bearer {credential}"
+    try:
+        body = json.dumps({"code": code, "label": label}).encode()
+        urlopen(Request(phase_url, data=body, headers=headers, method="POST"), timeout=5)
+    except Exception:
+        pass  # a phase is telemetry — never let it break the run
+```
+
+```bash
+curl -s -X POST "$AUTOMATION_PHASE_URL" \
+  -H "Authorization: Bearer ${AUTOMATION_CALLBACK_API_KEY:-$OPENHANDS_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"code": "checking_out", "label": "Checking out PR #123"}'
+```
+
+Authenticate with whichever of these two the sandbox actually has — they are
+mutually exclusive by mode, so trying one then the other is safe:
+
+- **Local mode**: `AUTOMATION_CALLBACK_API_KEY` — the automation service's own
+  key, injected by the local backend for exactly this purpose.
+- **Cloud mode**: `OPENHANDS_API_KEY` — the per-user Cloud API key.
+
+Do **not** use `SESSION_API_KEY` (or `OH_SESSION_API_KEYS_0`) here even though
+it is also present in the sandbox: that key authenticates to the *agent
+server*, a different service. In local mode the automation service checks the
+presented key against its own configured key and rejects anything else with
+401 — so sending the agent-server key silently drops every phase update.
+
+If the local deployment has no key configured at all, `AUTOMATION_CALLBACK_API_KEY`
+is never injected and an unauthenticated request is rejected too, so no phase can
+be reported by any means from inside the sandbox. Configure the service's key if
+you want phases in local mode.
+
+## Request body
+
+| Field | Type | Limit |
+|-------|------|-------|
+| `code` | string, optional | ≤ 128 chars, machine-readable, e.g. `"checking_out"` |
+| `label` | string, optional | ≤ 200 chars, free-form, e.g. `"Checking out PR #123"` |
+
+- At least one of `code`/`label` must be non-blank after `.strip()`, or the
+  request is rejected with 422.
+- Neither field may contain Unicode `Cc` (control) or `Zl`/`Zp` (line/paragraph
+  separator) characters — also 422. `Cf` (format) characters are allowed, so
+  emoji sequences and non-Latin labels pass through fine.
+- The body accepts only `code` and `label` — any other field is rejected with
+  422 (unknown fields are not silently ignored).
+- **A phase is one value** — the `(code, label)` pair. Every call replaces it
+  whole: send both fields even if only one changed, or the omitted one is
+  stored as `NULL`. There is no history, only the current phase.
+
+## Responses
+
+| Code | Meaning |
+|------|---------|
+| 200 | Recorded; the response is the updated run |
+| 401 | The credential was missing or not the one this service accepts |
+| 403 | The caller does not own the automation this run belongs to |
+| 404 | No run with that `run_id` |
+| 422 | The body broke one of the rules above |
+
+None of the error responses change the run's status or its stored phase —
+validation happens before anything is written.
+
+## Failure handling
+
+Emitting a phase must never break the automation. If `AUTOMATION_PHASE_URL` is
+absent, or the request fails, times out, or gets a non-2xx response, catch it
+and move on — a phase is telemetry, not a control signal.
+
+## Out of scope
+
+`scripts/test_tarball/main.py` is a manual smoke-test script for exercising
+the dispatch pipeline, not a template shipped to users. It does not report
+phases and is not part of this recipe.

--- a/migrations/versions/020_add_run_phase.py
+++ b/migrations/versions/020_add_run_phase.py
@@ -1,0 +1,36 @@
+"""Add phase columns to automation_runs table.
+
+Revision ID: 020
+Revises: 019
+Create Date: 2026-08-18
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "020"
+down_revision: str = "019"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "automation_runs", sa.Column("phase_code", sa.String(128), nullable=True)
+    )
+    op.add_column(
+        "automation_runs", sa.Column("phase_label", sa.String(200), nullable=True)
+    )
+    op.add_column(
+        "automation_runs",
+        sa.Column("phase_updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("automation_runs", "phase_updated_at")
+    op.drop_column("automation_runs", "phase_label")
+    op.drop_column("automation_runs", "phase_code")

--- a/openhands/automation/backends/local.py
+++ b/openhands/automation/backends/local.py
@@ -139,8 +139,8 @@ class LocalAgentServerBackend(ExecutionBackend):
         The workspace is isolated per-run to avoid conflicts between concurrent
         automations. Each run gets its own directory under the base workspace.
 
-        Note: AUTOMATION_CALLBACK_URL and AUTOMATION_RUN_ID are added by the
-        dispatcher after calling this method.
+        Note: AUTOMATION_CALLBACK_URL, AUTOMATION_PHASE_URL, and AUTOMATION_RUN_ID
+        are added by the dispatcher after calling this method.
         """
         # Use run-specific workspace directory for isolation
         run_workspace = self.get_work_dir(str(self._run.id))

--- a/openhands/automation/dispatcher.py
+++ b/openhands/automation/dispatcher.py
@@ -22,7 +22,7 @@ from datetime import timedelta
 from typing import Any
 
 import httpx
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
@@ -174,6 +174,31 @@ def _build_event_payload(
     return payload
 
 
+async def _record_run_phase(
+    session_factory: async_sessionmaker[AsyncSession],
+    run_id: uuid.UUID,
+    code: str,
+    label: str,
+) -> None:
+    """Persist the run's current service-owned phase (queued /
+    sandbox_provisioning / bundle_upload / entrypoint_start).
+
+    Telemetry, not control flow: mirrors update_sandbox_id/update_bash_command_id
+    in utils/run.py — a write failure is logged and swallowed here so it can
+    never fail the run itself.
+    """
+    try:
+        async with session_factory() as session:
+            await session.execute(
+                update(AutomationRun)
+                .where(AutomationRun.id == run_id)
+                .values(phase_code=code, phase_label=label, phase_updated_at=utcnow())
+            )
+            await session.commit()
+    except Exception:
+        logger.exception("Failed to record phase %r for run %s", code, run_id)
+
+
 async def _execute_run(
     run: AutomationRun,
     settings: ServiceSettings,
@@ -202,6 +227,9 @@ async def _execute_run(
         return log_extra(
             run_id=run_id, automation_id=automation_id, sandbox_id=sandbox_id
         )
+
+    async def _record_phase(code: str, label: str) -> None:
+        await _record_run_phase(session_factory, run.id, code, label)
 
     async def _fail(
         error: str,
@@ -236,6 +264,7 @@ async def _execute_run(
 
     # 2. Get execution context - if this fails, nothing to clean up
     # Note: This also initializes backend state (e.g., API key for cloud mode)
+    await _record_phase("sandbox_provisioning", "Provisioning sandbox")
     try:
         ctx = await backend.get_execution_context(client)
     except ConcurrencyLimitReachedError as exc:
@@ -291,8 +320,10 @@ async def _execute_run(
 
     # 3. Build env vars (must be after get_execution_context for cloud mode API key)
     callback_url = f"{settings.resolved_base_url.rstrip('/')}/v1/runs/{run_id}/complete"
+    phase_url = f"{settings.resolved_base_url.rstrip('/')}/v1/runs/{run_id}/phase"
     env_vars = backend.build_env_vars()
     env_vars["AUTOMATION_CALLBACK_URL"] = callback_url
+    env_vars["AUTOMATION_PHASE_URL"] = phase_url
     env_vars["AUTOMATION_RUN_ID"] = run_id
     env_vars["AUTOMATION_USER_ID"] = str(automation.user_id)
     env_vars["AUTOMATION_ORG_ID"] = str(automation.org_id)
@@ -396,6 +427,7 @@ async def _execute_run(
             timeout=effective_timeout,
             run_id=run_id,
             sandbox_id=ctx.sandbox_id,
+            phase_callback=_record_phase,
         )
     except PermanentDispatchError as exc:
         logger.error(
@@ -557,6 +589,7 @@ async def dispatch_pending_runs(
                 properties={"trigger_source": "dispatcher"},
                 session_factory=session_factory,
             )
+            await _record_run_phase(session_factory, run.id, "queued", "Queued")
             asyncio.create_task(
                 _execute_run_safe(run, settings, session_factory, client),
                 name=f"execute-run-{run.id}",

--- a/openhands/automation/execution.py
+++ b/openhands/automation/execution.py
@@ -9,6 +9,7 @@ import io
 import logging
 import re
 import tarfile
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import httpx
@@ -341,6 +342,7 @@ async def execute_in_context(
     timeout: int | None = None,
     run_id: str | None = None,
     sandbox_id: str | None = None,
+    phase_callback: Callable[[str, str], Awaitable[None]] | None = None,
 ) -> DispatchResult:
     """Execute automation code in an existing execution context.
 
@@ -364,6 +366,10 @@ async def execute_in_context(
             path (/tmp/automation-<run_id>.tar.gz) that prevents collisions
             when concurrent runs share the same filesystem (sandboxless mode)
         sandbox_id: Sandbox ID for logging (Cloud mode only)
+        phase_callback: Called with ``(code, label)`` as each service phase
+            (``bundle_upload``, ``entrypoint_start``) is entered. The caller
+            (dispatcher) owns persistence and is responsible for making this
+            never raise — a failure to record a phase must never fail the run.
 
     Returns:
         DispatchResult with success status
@@ -386,6 +392,9 @@ async def execute_in_context(
     env_path: str | None = None
 
     try:
+        if phase_callback is not None:
+            await phase_callback("bundle_upload", "Uploading bundle")
+
         # Get tarball into environment: upload bytes or download from URL
         if isinstance(tarball_source, bytes):
             logger.info("Uploading tarball", extra=_log_ctx())
@@ -416,6 +425,9 @@ async def execute_in_context(
             f" && ([ ! -f setup.sh ] || bash setup.sh)"
             f" && {entrypoint}"
         )
+
+        if phase_callback is not None:
+            await phase_callback("entrypoint_start", "Starting entrypoint")
 
         logger.info("Starting entrypoint: %s", entrypoint, extra=_log_ctx())
         command_id = await _start_bash(

--- a/openhands/automation/models.py
+++ b/openhands/automation/models.py
@@ -200,9 +200,9 @@ class AutomationRun(Base):
     # from the final conversation action.
     run_metadata: Mapped[dict | None] = mapped_column(JSON, nullable=True)
 
-    # Written by POST /v1/runs/{run_id}/phase. Last write wins — no source
-    # flag, no priority logic — and only the current phase is kept, so there
-    # is no history/timeline table to retain or prune.
+    # Written by the dispatcher for its preparation milestones and by code
+    # inside the sandbox via POST /v1/runs/{run_id}/phase. Last write wins,
+    # and only the current phase is kept — there is no history to prune.
     phase_code: Mapped[str | None] = mapped_column(String(128), nullable=True)
     phase_label: Mapped[str | None] = mapped_column(String(200), nullable=True)
     phase_updated_at: Mapped[datetime | None] = mapped_column(

--- a/openhands/automation/models.py
+++ b/openhands/automation/models.py
@@ -200,6 +200,15 @@ class AutomationRun(Base):
     # from the final conversation action.
     run_metadata: Mapped[dict | None] = mapped_column(JSON, nullable=True)
 
+    # Written by POST /v1/runs/{run_id}/phase. Last write wins — no source
+    # flag, no priority logic — and only the current phase is kept, so there
+    # is no history/timeline table to retain or prune.
+    phase_code: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    phase_label: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    phase_updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/openhands/automation/presets/plugin/sdk_main.py
+++ b/openhands/automation/presets/plugin/sdk_main.py
@@ -52,6 +52,7 @@ Env vars (Local mode):
 
 Common env vars:
   AUTOMATION_CALLBACK_URL    - completion callback endpoint (optional)
+  AUTOMATION_PHASE_URL       - phase-reporting endpoint; see _emit_phase() (optional)
   AUTOMATION_RUN_ID          - run ID for the callback payload (optional)
   AUTOMATION_USER_ID         - owner user ID for observability attribution (optional)
   AUTOMATION_ORG_ID          - owner org ID for observability context (optional)
@@ -71,6 +72,7 @@ import random
 import sys
 import time
 from datetime import datetime, timezone
+from urllib.request import Request, urlopen
 
 # Detect execution mode based on AGENT_SERVER_URL presence
 agent_server_url = os.environ.get("AGENT_SERVER_URL", "").rstrip("/")
@@ -119,6 +121,7 @@ else:
 print(
     f"  AUTOMATION_CALLBACK_URL: {os.environ.get('AUTOMATION_CALLBACK_URL') or 'NONE'}"
 )
+print(f"  AUTOMATION_PHASE_URL: {os.environ.get('AUTOMATION_PHASE_URL') or 'NONE'}")
 print(f"  AUTOMATION_MODEL: {model_profile or 'DEFAULT'}")
 print(f"  AUTOMATION_USER_ID: {'OK' if automation_user_id else 'NONE'}")
 print(f"  AUTOMATION_ORG_ID: {'OK' if os.environ.get('AUTOMATION_ORG_ID') else 'NONE'}")
@@ -136,6 +139,40 @@ from openhands.sdk.plugin import PluginSource
 from openhands.sdk.workspace.remote.base import RemoteWorkspace
 from openhands.tools.preset.default import get_default_agent
 from openhands.workspace import OpenHandsCloudWorkspace
+
+
+def _emit_phase(code: str, label: str) -> None:
+    """Best-effort report of the current phase to the automation service.
+
+    A phase is telemetry, not a control signal: once the service hands
+    control to this script (after ``entrypoint_start``), reporting is up to
+    us, but a missing AUTOMATION_PHASE_URL, a network error, a timeout, or a
+    non-2xx response must never interrupt the run — every failure here is
+    swallowed.
+
+    Credential: AUTOMATION_CALLBACK_API_KEY (local mode — the automation
+    service's own key, injected by backends/local.py) or OPENHANDS_API_KEY
+    (Cloud mode, injected by backends/cloud.py). Deliberately NOT
+    SESSION_API_KEY / OH_SESSION_API_KEYS_0 — those authenticate to the
+    *agent server*, a different service; the local automation service only
+    accepts its own local_api_key (see auth.py's local-mode fast path) and
+    would 401 on anything else.
+    """
+    phase_url = os.environ.get("AUTOMATION_PHASE_URL")
+    if not phase_url:
+        return
+    credential = os.environ.get("AUTOMATION_CALLBACK_API_KEY") or os.environ.get(
+        "OPENHANDS_API_KEY"
+    )
+    headers = {"Content-Type": "application/json"}
+    if credential:
+        headers["Authorization"] = f"Bearer {credential}"
+    try:
+        body = json.dumps({"code": code, "label": label}).encode("utf-8")
+        request = Request(phase_url, data=body, headers=headers, method="POST")
+        urlopen(request, timeout=5)
+    except Exception as e:
+        print(f"  phase report failed (non-fatal): {e}")
 
 
 def _conversation_supports_user_id() -> bool:
@@ -239,6 +276,10 @@ else:
 with workspace_ctx as workspace:
     # -- All remaining setup happens inside the workspace context --
     # This ensures failures trigger the __exit__ callback
+
+    # From here on, the service's last-written phase (entrypoint_start) is
+    # stale — this script owns phase reporting for the rest of the run.
+    _emit_phase("preparing", "Preparing agent workspace")
 
     # Parse event payload if present (for event-triggered automations)
     event_context = None
@@ -499,6 +540,7 @@ This automation was triggered by a webhook event:
 
     cost = None
     try:
+        _emit_phase("running_agent", "Running agent")
         print(f"  sending prompt: {USER_PROMPT[:80]}...")
         conversation.send_message(USER_PROMPT)
         conversation.run()

--- a/openhands/automation/presets/prompt/sdk_main.py
+++ b/openhands/automation/presets/prompt/sdk_main.py
@@ -56,6 +56,7 @@ Env vars (Local mode):
 
 Common env vars:
   AUTOMATION_CALLBACK_URL    - completion callback endpoint (optional)
+  AUTOMATION_PHASE_URL       - phase-reporting endpoint; see _emit_phase() (optional)
   AUTOMATION_RUN_ID          - run ID for the callback payload (optional)
   AUTOMATION_USER_ID         - owner user ID for observability attribution (optional)
   AUTOMATION_ORG_ID          - owner org ID for observability context (optional)
@@ -74,6 +75,7 @@ import os
 import sys
 import time
 from datetime import datetime, timezone
+from urllib.request import Request, urlopen
 
 # Detect execution mode based on AGENT_SERVER_URL presence
 agent_server_url = os.environ.get("AGENT_SERVER_URL", "").rstrip("/")
@@ -122,6 +124,7 @@ else:
 print(
     f"  AUTOMATION_CALLBACK_URL: {os.environ.get('AUTOMATION_CALLBACK_URL') or 'NONE'}"
 )
+print(f"  AUTOMATION_PHASE_URL: {os.environ.get('AUTOMATION_PHASE_URL') or 'NONE'}")
 print(f"  AUTOMATION_MODEL: {model_profile or 'DEFAULT'}")
 print(f"  AUTOMATION_USER_ID: {'OK' if automation_user_id else 'NONE'}")
 print(f"  AUTOMATION_ORG_ID: {'OK' if os.environ.get('AUTOMATION_ORG_ID') else 'NONE'}")
@@ -139,6 +142,40 @@ except ImportError:
 from openhands.sdk.workspace.remote.base import RemoteWorkspace
 from openhands.tools.preset.default import get_default_agent
 from openhands.workspace import OpenHandsCloudWorkspace
+
+
+def _emit_phase(code: str, label: str) -> None:
+    """Best-effort report of the current phase to the automation service.
+
+    A phase is telemetry, not a control signal: once the service hands
+    control to this script (after ``entrypoint_start``), reporting is up to
+    us, but a missing AUTOMATION_PHASE_URL, a network error, a timeout, or a
+    non-2xx response must never interrupt the run — every failure here is
+    swallowed.
+
+    Credential: AUTOMATION_CALLBACK_API_KEY (local mode — the automation
+    service's own key, injected by backends/local.py) or OPENHANDS_API_KEY
+    (Cloud mode, injected by backends/cloud.py). Deliberately NOT
+    SESSION_API_KEY / OH_SESSION_API_KEYS_0 — those authenticate to the
+    *agent server*, a different service; the local automation service only
+    accepts its own local_api_key (see auth.py's local-mode fast path) and
+    would 401 on anything else.
+    """
+    phase_url = os.environ.get("AUTOMATION_PHASE_URL")
+    if not phase_url:
+        return
+    credential = os.environ.get("AUTOMATION_CALLBACK_API_KEY") or os.environ.get(
+        "OPENHANDS_API_KEY"
+    )
+    headers = {"Content-Type": "application/json"}
+    if credential:
+        headers["Authorization"] = f"Bearer {credential}"
+    try:
+        body = json.dumps({"code": code, "label": label}).encode("utf-8")
+        request = Request(phase_url, data=body, headers=headers, method="POST")
+        urlopen(request, timeout=5)
+    except Exception as e:
+        print(f"  phase report failed (non-fatal): {e}")
 
 
 def _conversation_supports_user_id() -> bool:
@@ -246,6 +283,10 @@ else:
 with workspace_ctx as workspace:
     # -- All remaining setup happens inside the workspace context --
     # This ensures failures trigger the __exit__ callback
+
+    # From here on, the service's last-written phase (entrypoint_start) is
+    # stale — this script owns phase reporting for the rest of the run.
+    _emit_phase("preparing", "Preparing agent workspace")
 
     # Parse event payload if present (for event-triggered automations)
     event_context = None
@@ -449,6 +490,7 @@ This automation was triggered by a webhook event:
 
     cost = None
     try:
+        _emit_phase("running_agent", "Running agent")
         print(f"  sending prompt: {USER_PROMPT[:80]}...")
         conversation.send_message(USER_PROMPT)
         conversation.run()

--- a/openhands/automation/router.py
+++ b/openhands/automation/router.py
@@ -39,6 +39,7 @@ from openhands.automation.schemas import (
     AutomationRunResponse,
     CreateAutomationRequest,
     RunCompleteRequest,
+    RunPhaseRequest,
     UpdateAutomationRequest,
 )
 from openhands.automation.storage import FileStore, get_file_store
@@ -597,6 +598,62 @@ async def complete_run(
                 )
             )
 
+    return AutomationRunResponse.model_validate(run)
+
+
+# --- Run phase callback ---
+
+
+@router.post("/runs/{run_id}/phase")
+async def update_run_phase(
+    run_id: uuid.UUID,
+    body: RunPhaseRequest,
+    user: AuthenticatedUser = Depends(_require_manage_automations),
+    session: AsyncSession = Depends(get_session),
+) -> AutomationRunResponse:
+    """Receive a phase update from code running inside the sandbox.
+
+    Called by automation code (via the SDK) to report human-readable
+    progress within a run, e.g. {"code": "checking_out", "label": "Checking
+    out PR #123"}. Authenticated via the same credentials that were passed
+    into the sandbox. The credentials are validated against
+    ``/api/v1/users/me`` (by ``authenticate_request``) and the resulting user
+    must own the run's parent automation.
+
+    Last write wins at the pair level: a phase is the (code, label) pair as
+    a whole, so every call replaces the entire pair, not just the fields it
+    carries. A request with only ``label`` stores that label with
+    ``phase_code`` cleared to NULL, and vice versa — never merging with the
+    previous write. There is no history — only the current phase is stored.
+    No run status transition happens here.
+    """
+    result = await session.execute(
+        select(AutomationRun)
+        .where(AutomationRun.id == run_id)
+        .options(selectinload(AutomationRun.automation))
+    )
+    run = result.scalars().first()
+    if run is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Run not found")
+
+    # Verify the caller owns this automation
+    automation = run.automation
+    if automation.user_id != user.user_id or automation.org_id != user.org_id:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Not your automation")
+
+    # A phase is one value — the (code, label) pair — so a write replaces
+    # both. An omitted field is stored as NULL rather than left behind, so a
+    # pair nobody ever wrote together can never be observed.
+    values: dict = {
+        "phase_code": body.code,
+        "phase_label": body.label,
+        "phase_updated_at": utcnow(),
+    }
+
+    stmt = update(AutomationRun).where(AutomationRun.id == run_id).values(**values)
+    await session.execute(stmt)
+
+    await session.refresh(run)
     return AutomationRunResponse.model_validate(run)
 
 

--- a/openhands/automation/router.py
+++ b/openhands/automation/router.py
@@ -626,6 +626,12 @@ async def update_run_phase(
     ``phase_code`` cleared to NULL, and vice versa — never merging with the
     previous write. There is no history — only the current phase is stored.
     No run status transition happens here.
+
+    Only a PENDING or RUNNING run accepts a phase; anything else is 409,
+    matching ``cancel_run``. A finished run's phase is a record of where it
+    got to — for a failed run it is the place it stopped, which the UI shows
+    next to the failure — so a late write from a sandbox that outlived the
+    run must not be able to overwrite it.
     """
     result = await session.execute(
         select(AutomationRun)
@@ -641,6 +647,16 @@ async def update_run_phase(
     if automation.user_id != user.user_id or automation.org_id != user.org_id:
         raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Not your automation")
 
+    # Only an in-flight run has a current phase to report.
+    if run.status not in (AutomationRunStatus.PENDING, AutomationRunStatus.RUNNING):
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail=(
+                f"Run is {run.status.value}, only PENDING or"
+                " RUNNING runs accept a phase"
+            ),
+        )
+
     # A phase is one value — the (code, label) pair — so a write replaces
     # both. An omitted field is stored as NULL rather than left behind, so a
     # pair nobody ever wrote together can never be observed.
@@ -650,8 +666,26 @@ async def update_run_phase(
         "phase_updated_at": utcnow(),
     }
 
-    stmt = update(AutomationRun).where(AutomationRun.id == run_id).values(**values)
-    await session.execute(stmt)
+    # Re-check the status in the UPDATE itself: the completion callback may
+    # land between the check above and this write, and the phase of a run
+    # that has just finished must stay the one it finished in.
+    stmt = (
+        update(AutomationRun)
+        .where(
+            AutomationRun.id == run_id,
+            AutomationRun.status.in_(
+                [AutomationRunStatus.PENDING, AutomationRunStatus.RUNNING]
+            ),
+        )
+        .values(**values)
+    )
+    db_result: CursorResult = await session.execute(stmt)  # type: ignore[assignment]
+
+    if db_result.rowcount == 0:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail="Run finished concurrently, phase not recorded",
+        )
 
     await session.refresh(run)
     return AutomationRunResponse.model_validate(run)

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -2,11 +2,20 @@
 
 import json
 import re
+import unicodedata
 import uuid
 from enum import StrEnum
 from typing import Annotated, Any, Final, Literal
 
-from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Discriminator,
+    Field,
+    Tag,
+    field_validator,
+    model_validator,
+)
 from pydantic.alias_generators import to_camel
 
 from openhands.automation.constants import MODEL_PROFILE_PATTERN
@@ -36,6 +45,16 @@ _SHELL_META_RE = re.compile(r"[;&|`$(){}<>!\\\n\r]")
 
 # Path traversal pattern
 _PATH_TRAVERSAL_RE = re.compile(r"(^|/)\.\.(/|$)")
+
+# Categories disallowed in a phase code/label: control (Cc) plus the line and
+# paragraph separators (Zl, Zp), which catch non-ASCII cases like U+2028 that
+# an ASCII 0x00-0x1f/0x7f range would miss.
+#
+# Format (Cf) is deliberately absent: U+2028/U+2029 are already covered above,
+# while banning Cf would reject legitimate labels — the zero-width joiners
+# inside emoji sequences, the bidi marks Arabic and Hebrew carry, and the ZWNJ
+# Persian and Indic scripts require. Phase labels are not English-only.
+_FORBIDDEN_PHASE_TEXT_CATEGORIES = frozenset({"Cc", "Zl", "Zp"})
 
 
 class CronTrigger(BaseModel):
@@ -773,6 +792,51 @@ class RunCompleteRequest(BaseModel):
             return value
 
 
+class RunPhaseRequest(BaseModel):
+    """Payload for POST /runs/{run_id}/phase.
+
+    Sent by code running inside the sandbox to report human-readable
+    progress within a run (e.g. "Checking out PR #123"). At least one of
+    ``code``/``label`` must be provided. Each write overwrites the run's
+    current phase in place (last write wins) — there is no history.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    code: str | None = Field(
+        default=None,
+        max_length=128,
+        description="Machine-readable phase code, e.g. 'checking_out'",
+    )
+    label: str | None = Field(
+        default=None,
+        max_length=200,
+        description="Free-form human-readable phase label",
+    )
+
+    @field_validator("code", "label")
+    @classmethod
+    def validate_no_control_or_separator_chars(cls, v: str | None) -> str | None:
+        if v is not None and any(
+            unicodedata.category(ch) in _FORBIDDEN_PHASE_TEXT_CATEGORIES for ch in v
+        ):
+            raise ValueError(
+                "must not contain control or line/paragraph separator characters"
+            )
+        return v
+
+    @model_validator(mode="after")
+    def validate_at_least_one_field(self) -> "RunPhaseRequest":
+        # Blank/whitespace-only is treated as absent here so it can't satisfy
+        # this check — otherwise it would be indistinguishable downstream
+        # from "no phase reported".
+        code_present = self.code is not None and self.code.strip() != ""
+        label_present = self.label is not None and self.label.strip() != ""
+        if not code_present and not label_present:
+            raise ValueError("at least one of code or label must be provided")
+        return self
+
+
 class AutomationRunResponse(BaseModel):
     """Response for a single automation run."""
 
@@ -787,6 +851,9 @@ class AutomationRunResponse(BaseModel):
     sandbox_id: str | None
     bash_command_id: str | None = None
     run_metadata: dict[str, Any] | None = None
+    phase_code: str | None = None
+    phase_label: str | None = None
+    phase_updated_at: UtcDatetime | None = None
     created_at: UtcDatetime
     started_at: UtcDatetime | None
     completed_at: UtcDatetime | None

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -5,6 +5,7 @@ The dispatcher polls for PENDING automation runs and marks them as RUNNING.
 
 import asyncio
 import uuid
+from contextlib import asynccontextmanager
 from datetime import timedelta
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -13,6 +14,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
+from openhands.automation import dispatcher
 from openhands.automation.config import get_config
 from openhands.automation.dispatcher import (
     _build_event_payload,
@@ -1076,3 +1078,366 @@ class TestExecuteRunConcurrencyLimit:
             assert updated.status_detail["source"] == "sandbox_api"
             assert updated.status_detail["operation"] == "get_execution_context"
             assert updated.status_detail["transient"] is False
+
+
+class TestServicePhases:
+    """A run, from being queued through entrypoint start, records the
+    four service phases, in order, with a non-decreasing phase_updated_at.
+
+    Per S01, a phase is last-write-wins with no history table — only the
+    current (code, label) pair is stored. So the sequence is only observable
+    at write time. The order test hooks the existing, name-stable call sites
+    (get_execution_context, _download_in_sandbox, _start_bash) and reads the
+    DB row at each one — it does not know or depend on the name of whatever
+    internal function performs the write.
+    """
+
+    async def _make_pending_run(self, async_session_factory) -> uuid.UUID:
+        async with async_session_factory() as session:
+            automation = Automation(
+                user_id=TEST_USER_ID,
+                org_id=TEST_ORG_ID,
+                name="Phase Test",
+                trigger={"type": "cron", "schedule": "* * * * *", "timezone": "UTC"},
+                tarball_path="https://example.com/code.tar.gz",
+                entrypoint="uv run main.py",
+                enabled=True,
+            )
+            session.add(automation)
+            await session.commit()
+
+            run = AutomationRun(
+                automation_id=automation.id,
+                status=AutomationRunStatus.PENDING,
+            )
+            session.add(run)
+            await session.commit()
+            return run.id
+
+    async def _reload_with_automation(
+        self, async_session_factory, run_id: uuid.UUID
+    ) -> AutomationRun:
+        async with async_session_factory() as session:
+            return (
+                (
+                    await session.execute(
+                        select(AutomationRun)
+                        .options(selectinload(AutomationRun.automation))
+                        .where(AutomationRun.id == run_id)
+                    )
+                )
+                .scalars()
+                .first()
+            )
+
+    def _fake_backend(self) -> MagicMock:
+        backend = MagicMock()
+        ctx = MagicMock(
+            agent_url="http://agent.test", sandbox_id=None, session_key="sk"
+        )
+        backend.get_execution_context = AsyncMock(return_value=ctx)
+        backend.build_env_vars = MagicMock(return_value={})
+        backend.get_work_dir = MagicMock(return_value="/workspace")
+        backend.release_context = AsyncMock()
+        return backend
+
+    def _wire_phase_snapshots(
+        self, async_session_factory, run_id, mock_download, mock_start_bash
+    ):
+        """Hook the three sandbox boundaries so each records the run's phase at
+        the moment it is reached, giving an ordered trace of what the dispatcher
+        wrote. Returns the trace, the backend to patch in, and the snapshot
+        callable for phases a test needs to sample outside those boundaries."""
+        snapshots: list[tuple[Any, Any, Any]] = []
+
+        async def snapshot() -> None:
+            async with async_session_factory() as session:
+                row = await session.get(AutomationRun, run_id)
+                snapshots.append(
+                    (row.phase_code, row.phase_label, row.phase_updated_at)
+                )
+
+        backend = self._fake_backend()
+        ctx = backend.get_execution_context.return_value
+
+        async def _get_context_with_snapshot(client):
+            await snapshot()  # sandbox_provisioning
+            return ctx
+
+        backend.get_execution_context = _get_context_with_snapshot
+
+        async def _download_with_snapshot(*args, **kwargs):
+            await snapshot()  # bundle_upload
+
+        mock_download.side_effect = _download_with_snapshot
+
+        async def _start_bash_with_snapshot(*args, **kwargs):
+            await snapshot()  # entrypoint_start
+            return "cmd-1"
+
+        mock_start_bash.side_effect = _start_bash_with_snapshot
+
+        return snapshots, backend, snapshot
+
+    @patch("openhands.automation.execution._start_bash", new_callable=AsyncMock)
+    @patch(
+        "openhands.automation.execution._download_in_sandbox", new_callable=AsyncMock
+    )
+    @patch("openhands.automation.execution._upload", new_callable=AsyncMock)
+    @patch("openhands.automation.dispatcher._execute_run_safe", new_callable=AsyncMock)
+    async def test_phases_recorded_in_order_with_nondecreasing_timestamps(
+        self,
+        mock_execute_safe,
+        mock_upload,
+        mock_download,
+        mock_start_bash,
+        async_session_factory,
+        mock_settings,
+        mock_client,
+    ):
+        """queued -> sandbox_provisioning -> bundle_upload -> entrypoint_start,
+        with each captured at its natural call site, and phase_updated_at
+        non-decreasing across the four snapshots."""
+        run_id = await self._make_pending_run(async_session_factory)
+        snapshots, backend, snapshot = self._wire_phase_snapshots(
+            async_session_factory, run_id, mock_download, mock_start_bash
+        )
+
+        dispatched = await dispatch_pending_runs(
+            async_session_factory, mock_settings, mock_client
+        )
+        assert len(dispatched) == 1
+        await snapshot()  # dispatch has returned: expect "queued"
+
+        run = await self._reload_with_automation(async_session_factory, run_id)
+
+        with patch("openhands.automation.dispatcher.get_backend", return_value=backend):
+            await _execute_run(run, mock_settings, async_session_factory, mock_client)
+
+        codes = [code for code, _, _ in snapshots]
+        assert codes == [
+            "queued",
+            "sandbox_provisioning",
+            "bundle_upload",
+            "entrypoint_start",
+        ]
+
+        timestamps = [ts for _, _, ts in snapshots]
+        assert timestamps == sorted(timestamps)
+
+        async with async_session_factory() as session:
+            final = await session.get(AutomationRun, run_id)
+            assert final.phase_code == "entrypoint_start"
+            assert final.phase_label == "Starting entrypoint"
+            assert final.phase_updated_at == timestamps[-1]
+
+    @patch("openhands.automation.dispatcher._execute_run_safe", new_callable=AsyncMock)
+    async def test_failure_during_provisioning_keeps_last_phase(
+        self, mock_execute_safe, async_session_factory, mock_settings, mock_client
+    ):
+        """A dispatch failure between sandbox_provisioning and bundle_upload
+        must leave phase_code/label at "sandbox_provisioning" — not cleared,
+        not reverted to "queued"."""
+        run_id = await self._make_pending_run(async_session_factory)
+
+        dispatched = await dispatch_pending_runs(
+            async_session_factory, mock_settings, mock_client
+        )
+        assert len(dispatched) == 1
+
+        run = await self._reload_with_automation(async_session_factory, run_id)
+
+        backend = MagicMock()
+        backend.get_execution_context = AsyncMock(
+            side_effect=RuntimeError("sandbox exploded")
+        )
+        backend.release_context = AsyncMock()
+
+        with patch("openhands.automation.dispatcher.get_backend", return_value=backend):
+            await _execute_run(run, mock_settings, async_session_factory, mock_client)
+
+        async with async_session_factory() as session:
+            final = await session.get(AutomationRun, run_id)
+            assert final.status == AutomationRunStatus.FAILED
+            assert final.phase_code == "sandbox_provisioning"
+            assert final.phase_label == "Provisioning sandbox"
+
+    @patch("openhands.automation.execution._start_bash", new_callable=AsyncMock)
+    @patch(
+        "openhands.automation.execution._download_in_sandbox", new_callable=AsyncMock
+    )
+    @patch("openhands.automation.execution._upload", new_callable=AsyncMock)
+    @patch("openhands.automation.dispatcher._execute_run_safe", new_callable=AsyncMock)
+    async def test_phase_write_failure_does_not_fail_the_run(
+        self,
+        mock_execute_safe,
+        mock_upload,
+        mock_download,
+        mock_start_bash,
+        async_session_factory,
+        mock_settings,
+        mock_client,
+    ):
+        """A DB failure on the *first* phase-write attempt ("queued") must not
+        raise out of dispatch, and must not stop later phases (and the run
+        itself) from proceeding normally — the phase is telemetry, not
+        control flow. The failure is injected by intercepting any UPDATE
+        naming the public ``phase_code`` column, once, at the SQL-text level
+        — an external boundary (the DB session), not the unit under test."""
+        mock_start_bash.return_value = "cmd-1"
+        run_id = await self._make_pending_run(async_session_factory)
+
+        failed_once = {"done": False}
+        real_factory = async_session_factory
+
+        @asynccontextmanager
+        async def guarded_session_factory():
+            async with real_factory() as session:
+                real_execute = session.execute
+
+                async def guarded_execute(statement, *args, **kwargs):
+                    is_phase_update = getattr(
+                        statement, "is_update", False
+                    ) and "phase_code" in str(statement)
+                    if not failed_once["done"] and is_phase_update:
+                        failed_once["done"] = True
+                        raise RuntimeError("simulated phase-write DB failure")
+                    return await real_execute(statement, *args, **kwargs)
+
+                session.execute = guarded_execute
+                yield session
+
+        # The dispatcher only ever calls the factory as an async context
+        # manager, which this stand-in satisfies; pyright still wants the
+        # nominal ``async_sessionmaker`` type, so cast at the boundary.
+        guarded_factory = cast(Any, guarded_session_factory)
+
+        dispatched = await dispatch_pending_runs(
+            guarded_factory, mock_settings, mock_client
+        )
+        assert len(dispatched) == 1  # dispatch succeeded despite the failed write
+
+        run = await self._reload_with_automation(async_session_factory, run_id)
+        backend = self._fake_backend()
+
+        with patch("openhands.automation.dispatcher.get_backend", return_value=backend):
+            await _execute_run(run, mock_settings, guarded_factory, mock_client)
+
+        async with async_session_factory() as session:
+            final = await session.get(AutomationRun, run_id)
+            # The run reached entrypoint start normally...
+            assert final.bash_command_id == "cmd-1"
+            # ...and later phase writes (once the guard has already fired
+            # once) landed correctly — the earlier failure didn't corrupt or
+            # block them.
+            assert final.phase_code == "entrypoint_start"
+        assert failed_once["done"] is True  # the injected failure did fire
+
+    @patch("openhands.automation.execution._start_bash", new_callable=AsyncMock)
+    @patch(
+        "openhands.automation.execution._download_in_sandbox", new_callable=AsyncMock
+    )
+    @patch("openhands.automation.execution._upload", new_callable=AsyncMock)
+    async def test_real_dispatch_to_execute_run_handoff_preserves_phase_order(
+        self,
+        mock_upload,
+        mock_download,
+        mock_start_bash,
+        async_session_factory,
+        mock_settings,
+        mock_client,
+    ):
+        """Drives the real dispatch_pending_runs -> create_task -> _execute_run
+        handoff — unlike the other phase tests, _execute_run_safe is NOT
+        mocked here, so the spawned background task genuinely races the rest
+        of dispatch_pending_runs. Only the genuine sandbox/network boundaries
+        are mocked (get_execution_context via the fake backend,
+        _download_in_sandbox, _start_bash, _upload). The spawned task is
+        found via the asyncio.all_tasks() diff and awaited directly — no
+        sleep/poll loop for *that* part, so waiting for it is deterministic.
+
+        This is the seam where a "queued" write reordered to *after*
+        create_task can lose a last-write-wins race against the spawned
+        task's entire chain (sandbox_provisioning -> bundle_upload ->
+        entrypoint_start): if the reordered "queued" write happens to commit
+        *after* entrypoint_start, the run's final observable phase is wrongly
+        "queued" instead of "entrypoint_start" — exactly the kind of drift
+        this test rules out. A real DB round trip is normally fast enough that
+        this outcome rarely flips within a single test run, so the "queued"
+        write specifically is wrapped with a bounded forced delay (via
+        _record_run_phase, the exact seam named in review) — long enough for
+        the spawned task's entirely-mocked chain to finish first every time,
+        making the mutation's failure reliable rather than a coin flip. It
+        has no effect on the correct ordering: there, "queued" is written —
+        and fully committed — strictly before create_task is even called, so
+        the task doesn't exist yet for the delay to race against."""
+        mock_start_bash.return_value = "cmd-1"
+        run_id = await self._make_pending_run(async_session_factory)
+        hook_snapshots, backend, _snapshot = self._wire_phase_snapshots(
+            async_session_factory, run_id, mock_download, mock_start_bash
+        )
+
+        original_record_phase = dispatcher._record_run_phase
+
+        async def _record_phase_with_forced_delay(
+            session_factory_arg, run_id_arg, code, label
+        ):
+            if code == "queued":
+                await asyncio.sleep(0.2)
+            await original_record_phase(session_factory_arg, run_id_arg, code, label)
+
+        with (
+            patch("openhands.automation.dispatcher.get_backend", return_value=backend),
+            patch(
+                "openhands.automation.dispatcher._record_run_phase",
+                side_effect=_record_phase_with_forced_delay,
+            ),
+        ):
+            tasks_before = asyncio.all_tasks()
+            dispatched = await dispatch_pending_runs(
+                async_session_factory, mock_settings, mock_client
+            )
+            assert len(dispatched) == 1
+
+            # Under a mis-ordered "queued" write, the spawned task can race
+            # all the way to completion (and drop out of all_tasks()) before
+            # dispatch_pending_runs even returns — so 0 new tasks found here
+            # is possible and fine; await whatever is still in flight rather
+            # than requiring exactly one.
+            # Match by the name dispatch_pending_runs gives the task, so a
+            # background task some future driver spawns here can never be
+            # mistaken for ours and awaited forever.
+            new_tasks = {
+                t
+                for t in asyncio.all_tasks() - tasks_before
+                if (t.get_name() or "").startswith("execute-run-")
+            }
+            assert len(new_tasks) <= 1
+            for task in new_tasks:
+                await task  # run the real _execute_run_safe to completion
+
+        # The three phases inside the spawned task never race anything else —
+        # no other coroutine writes phase_code while it runs — so their
+        # relative order is safe to assert directly from the hooks above.
+        # "queued" is deliberately not read live here: by the time any
+        # separate read could observe it, the spawned task may already have
+        # raced past it (see docstring), so its ordering is proven instead by
+        # the final-state assertion below plus the fully-controlled sequence
+        # in test_phases_recorded_in_order_with_nondecreasing_timestamps.
+        codes = [code for code, _, _ in hook_snapshots]
+        assert codes == ["sandbox_provisioning", "bundle_upload", "entrypoint_start"]
+
+        timestamps = [ts for _, _, ts in hook_snapshots]
+        assert timestamps == sorted(timestamps)
+
+        # The real proof for this test: even though "queued" is the last call
+        # to actually *commit* (it was forced to lag behind), the run's final
+        # observable phase must still be "entrypoint_start" — not "queued"
+        # clobbering it after the fact. This is exactly what a "queued" write
+        # reordered to after create_task would break.
+        async with async_session_factory() as session:
+            final = await session.get(AutomationRun, run_id)
+            assert final.phase_code == "entrypoint_start"
+            assert final.phase_label == "Starting entrypoint"
+            assert final.bash_command_id == "cmd-1"
+            assert final.phase_updated_at >= timestamps[-1]

--- a/tests/test_preset_router.py
+++ b/tests/test_preset_router.py
@@ -3,6 +3,7 @@
 import ast
 import io
 import json
+import os
 import re
 import socket
 import tarfile
@@ -12,6 +13,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import MagicMock
+from urllib.request import Request, urlopen
 
 import pytest
 
@@ -23,6 +25,7 @@ from openhands.automation.preset_router import (
     _replace_prompt_in_tarball,
     _resolve_experiment_variant_models,
 )
+from openhands.automation.schemas import RunPhaseRequest
 from openhands.sdk.mcp.config import coerce_mcp_config, dump_mcp_config
 from openhands.sdk.plugin import PluginSource
 from openhands.workspace import RepoSource
@@ -74,6 +77,38 @@ def _load_preset_mcp_normalizer(
         namespace,
     )
     return cast(Callable[[Any], Any], namespace["_normalize_mcp_config"])
+
+
+def _load_preset_phase_emitter(
+    preset_name: str, *, urlopen_fn: Callable[..., Any] | None = None
+) -> Callable[[str, str], None]:
+    """Extract ``_emit_phase`` from a preset's sdk_main.py for isolated testing.
+
+    ``urlopen_fn`` stands in for the real network call — the only external
+    boundary the function has — so tests can observe or fail it without
+    touching a socket.
+    """
+    source_path = PRESETS_DIR / preset_name / "sdk_main.py"
+    module = ast.parse(source_path.read_text(), filename=str(source_path))
+    function_node = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_emit_phase"
+    )
+    namespace: dict[str, Any] = {
+        "os": os,
+        "json": json,
+        "Request": Request,
+        "urlopen": urlopen_fn if urlopen_fn is not None else urlopen,
+    }
+    ast.fix_missing_locations(function_node)
+    exec(
+        compile(
+            ast.Module(body=[function_node], type_ignores=[]), str(source_path), "exec"
+        ),
+        namespace,
+    )
+    return cast(Callable[[str, str], None], namespace["_emit_phase"])
 
 
 def _load_preset_title_builder(preset_name: str) -> Callable[[Any], str | None]:
@@ -2189,3 +2224,281 @@ class TestCreateAutomationFromPlugin:
             assert config[0]["source"] == "github:owner/minimal-plugin"
             # No ref or repo_path since they were None
             assert "ref" not in config[0]
+
+
+# --- Run Phase Reporting ---
+
+
+class TestPresetPhaseReporting:
+    """Once the entrypoint hands control to the preset's own code, the phase
+    it reports must be the template's own code, not the service's last
+    written phase (``entrypoint_start``).
+    """
+
+    @pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
+    def test_emit_phase_posts_code_and_label_with_bearer_auth(
+        self, preset_name, monkeypatch
+    ):
+        """A configured AUTOMATION_PHASE_URL gets a POST with the (code, label)
+        pair and a Bearer credential built from the sandbox's own API key."""
+        monkeypatch.setenv(
+            "AUTOMATION_PHASE_URL", "https://automation.example/v1/runs/abc/phase"
+        )
+        monkeypatch.setenv("OPENHANDS_API_KEY", "test-api-key")
+        captured: dict[str, Any] = {}
+
+        def fake_urlopen(request, timeout=None):
+            captured["url"] = request.full_url
+            captured["method"] = request.get_method()
+            captured["body"] = json.loads(request.data.decode())
+            captured["auth"] = request.get_header("Authorization")
+            captured["timeout"] = timeout
+
+        emit_phase = _load_preset_phase_emitter(preset_name, urlopen_fn=fake_urlopen)
+
+        emit_phase("running_agent", "Running agent")
+
+        assert captured["url"] == "https://automation.example/v1/runs/abc/phase"
+        assert captured["method"] == "POST"
+        assert captured["body"] == {"code": "running_agent", "label": "Running agent"}
+        assert captured["auth"] == "Bearer test-api-key"
+        assert captured["timeout"] == 5
+
+    @pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
+    def test_emit_phase_uses_callback_api_key_in_local_mode(
+        self, preset_name, monkeypatch
+    ):
+        """Local mode (backends/local.py) injects AUTOMATION_CALLBACK_API_KEY —
+        the automation service's own key for this exact purpose — not
+        SESSION_API_KEY, which is the *agent server's* key for a different
+        service and must never be sent here (a trust-boundary crossing)."""
+        monkeypatch.setenv(
+            "AUTOMATION_PHASE_URL", "https://automation.example/v1/runs/abc/phase"
+        )
+        monkeypatch.delenv("OPENHANDS_API_KEY", raising=False)
+        monkeypatch.setenv("SESSION_API_KEY", "agent-server-key")
+        monkeypatch.setenv("AUTOMATION_CALLBACK_API_KEY", "callback-key-value")
+        captured: dict[str, Any] = {}
+
+        def fake_urlopen(request, timeout=None):
+            captured["auth"] = request.get_header("Authorization")
+
+        emit_phase = _load_preset_phase_emitter(preset_name, urlopen_fn=fake_urlopen)
+
+        emit_phase("running_agent", "Running agent")
+
+        assert captured["auth"] == "Bearer callback-key-value"
+
+    @pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
+    def test_emit_phase_uses_openhands_api_key_in_cloud_mode(
+        self, preset_name, monkeypatch
+    ):
+        """Cloud mode (backends/cloud.py) injects only OPENHANDS_API_KEY."""
+        monkeypatch.setenv(
+            "AUTOMATION_PHASE_URL", "https://automation.example/v1/runs/abc/phase"
+        )
+        monkeypatch.setenv("OPENHANDS_API_KEY", "cloud-api-key")
+        monkeypatch.delenv("AUTOMATION_CALLBACK_API_KEY", raising=False)
+        captured: dict[str, Any] = {}
+
+        def fake_urlopen(request, timeout=None):
+            captured["auth"] = request.get_header("Authorization")
+
+        emit_phase = _load_preset_phase_emitter(preset_name, urlopen_fn=fake_urlopen)
+
+        emit_phase("running_agent", "Running agent")
+
+        assert captured["auth"] == "Bearer cloud-api-key"
+
+    @pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
+    def test_emit_phase_is_noop_without_phase_url(self, preset_name, monkeypatch):
+        """Missing AUTOMATION_PHASE_URL must not attempt a network call."""
+        monkeypatch.delenv("AUTOMATION_PHASE_URL", raising=False)
+
+        def fake_urlopen(request, timeout=None):
+            raise AssertionError("urlopen must not be called without a phase URL")
+
+        emit_phase = _load_preset_phase_emitter(preset_name, urlopen_fn=fake_urlopen)
+
+        emit_phase("running_agent", "Running agent")  # must not raise
+
+    @pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
+    def test_emit_phase_swallows_network_failure(
+        self, preset_name, monkeypatch, capsys
+    ):
+        """A failing or timing-out phase endpoint must never break the
+        automation — the exception is swallowed, not propagated."""
+        monkeypatch.setenv(
+            "AUTOMATION_PHASE_URL", "https://automation.example/v1/runs/abc/phase"
+        )
+
+        def fake_urlopen(request, timeout=None):
+            raise TimeoutError("simulated network timeout")
+
+        emit_phase = _load_preset_phase_emitter(preset_name, urlopen_fn=fake_urlopen)
+
+        emit_phase("running_agent", "Running agent")  # must not raise
+
+        assert "non-fatal" in capsys.readouterr().out
+
+    def test_prompt_preset_reports_agent_phase_before_running(self):
+        """By the time the prompt preset reaches the agent's work
+        (conversation.send_message/run), the phase it has emitted is its own
+        'running_agent' code — never the service's 'entrypoint_start'."""
+        tarball_bytes = _generate_tarball("Test prompt")
+        with tarfile.open(fileobj=io.BytesIO(tarball_bytes), mode="r:gz") as tar:
+            main_file = tar.extractfile("main.py")
+            assert main_file is not None
+            main_content = main_file.read().decode("utf-8")
+
+        preparing_idx = main_content.find('_emit_phase("preparing"')
+        running_idx = main_content.find('_emit_phase("running_agent"')
+        send_message_idx = main_content.find("conversation.send_message(USER_PROMPT)")
+
+        assert preparing_idx != -1, "preset must emit a phase on entering the workspace"
+        assert running_idx != -1, "preset must emit a phase before the agent runs"
+        assert send_message_idx != -1
+        assert preparing_idx < running_idx < send_message_idx
+        assert '_emit_phase("entrypoint_start"' not in main_content
+
+    def test_plugin_preset_reports_agent_phase_before_running(self):
+        """Same guarantee for the plugin preset template."""
+        plugins = [PluginSource(source="github:owner/repo")]
+        tarball_bytes = _generate_plugin_tarball(plugins, "Test prompt")
+        with tarfile.open(fileobj=io.BytesIO(tarball_bytes), mode="r:gz") as tar:
+            main_file = tar.extractfile("main.py")
+            assert main_file is not None
+            main_content = main_file.read().decode("utf-8")
+
+        preparing_idx = main_content.find('_emit_phase("preparing"')
+        running_idx = main_content.find('_emit_phase("running_agent"')
+        send_message_idx = main_content.find("conversation.send_message(USER_PROMPT)")
+
+        assert preparing_idx != -1, "preset must emit a phase on entering the workspace"
+        assert running_idx != -1, "preset must emit a phase before the agent runs"
+        assert send_message_idx != -1
+        assert preparing_idx < running_idx < send_message_idx
+        assert '_emit_phase("entrypoint_start"' not in main_content
+
+
+class TestPresetPhaseCallSiteEvidence:
+    """Stronger evidence than a text search on the same file.
+
+    ``_generate_tarball``/``_generate_plugin_tarball`` embed sdk_main.py
+    verbatim (preset_router.py reads it with ``.read_text()``), so a
+    substring check on the generated main.py is a text test on the source
+    file itself — it cannot tell a real call site from a look-alike comment,
+    a call gated behind an unreachable branch, or a value that would fail
+    S01's own validation. These tests walk the AST instead: they extract the
+    literal (code, label) actually passed to ``_emit_phase`` at each call
+    site, confirm each one is unconditionally reachable, and validate the
+    literals against the real ``RunPhaseRequest`` from S01.
+    """
+
+    @staticmethod
+    def _parse(preset_name: str) -> ast.Module:
+        source_path = PRESETS_DIR / preset_name / "sdk_main.py"
+        return ast.parse(source_path.read_text(), filename=str(source_path))
+
+    @staticmethod
+    def _parent_map(tree: ast.Module) -> dict[int, ast.AST]:
+        parents: dict[int, ast.AST] = {}
+        for node in ast.walk(tree):
+            for child in ast.iter_child_nodes(node):
+                parents[id(child)] = node
+        return parents
+
+    @staticmethod
+    def _emit_phase_calls(tree: ast.Module) -> list[ast.Call]:
+        return [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_emit_phase"
+        ]
+
+    @pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
+    def test_call_site_literals_are_accepted_by_run_phase_request(self, preset_name):
+        """Every (code, label) literal at a real _emit_phase call site must
+        validate against S01's actual RunPhaseRequest — not just look
+        plausible in source. Catches an oversized label (S01 would 422 it)
+        and an 'entrypoint_start' code regardless of quote style or string
+        concatenation, because the AST literal is compared, not source text.
+        A negative control proves the check is not vacuous: an over-length
+        label is rejected by the same validator used above.
+        """
+        tree = self._parse(preset_name)
+        calls = self._emit_phase_calls(tree)
+        assert len(calls) >= 2, "expected at least 'preparing' and 'running_agent'"
+
+        codes = []
+        for call in calls:
+            assert len(call.args) == 2 and not call.keywords, (
+                "_emit_phase call must pass (code, label) as two positional args"
+            )
+            code_node, label_node = call.args
+            try:
+                code_val = ast.literal_eval(code_node)
+                label_val = ast.literal_eval(label_node)
+            except (ValueError, TypeError):
+                pytest.fail(
+                    "_emit_phase call site must use plain string literals, not "
+                    "a computed expression, so the emitted phase is verifiable"
+                )
+            # The real S01 validator — proves the body S01 would actually
+            # receive is accepted, not merely a string that looks like one.
+            RunPhaseRequest(code=code_val, label=label_val)
+            codes.append(code_val)
+
+        assert "running_agent" in codes
+        assert "entrypoint_start" not in codes
+
+        # Negative control: the same validator must reject what it should.
+        with pytest.raises(Exception):
+            RunPhaseRequest(code="x", label="y" * 201)
+
+    @pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
+    def test_call_sites_are_unconditionally_reachable(self, preset_name):
+        """Neither call site may be nested under an `if` — an unreachable
+        guard leaves the source text (and any substring check on it) intact
+        while silently suppressing the phase report at runtime."""
+        tree = self._parse(preset_name)
+        parents = self._parent_map(tree)
+        calls = self._emit_phase_calls(tree)
+        assert calls
+
+        for call in calls:
+            node: ast.AST = call
+            while True:
+                parent = parents.get(id(node))
+                assert parent is not None, (
+                    "call site must be reachable from module body"
+                )
+                # A call the module never reaches is the same silent no-op as
+                # a missing call. `try` is allowed: the running_agent call
+                # legitimately lives in one.
+                assert not isinstance(
+                    parent,
+                    (ast.If, ast.For, ast.While, ast.FunctionDef, ast.AsyncFunctionDef),
+                ), (
+                    "_emit_phase call must not be nested inside a branch, a loop "
+                    f"or a function body (found {type(parent).__name__})"
+                )
+                if isinstance(parent, ast.Module):
+                    break
+                node = parent
+
+    @pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
+    def test_preset_imports_urllib_request(self, preset_name):
+        """A deleted urllib import turns _emit_phase into a silent no-op: the
+        NameError inside its own try block is swallowed by its
+        `except Exception`. Assert the import actually exists."""
+        tree = self._parse(preset_name)
+        imported_names = {
+            alias.asname or alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module == "urllib.request"
+            for alias in node.names
+        }
+        assert {"Request", "urlopen"} <= imported_names

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -2643,6 +2643,309 @@ class TestCompleteRun:
         assert "first_run" not in metadata
 
 
+class TestRunPhase:
+    """Tests for POST /runs/{run_id}/phase endpoint."""
+
+    async def _seed_running_run(
+        self, async_session, user_id=TEST_USER_ID, org_id=TEST_ORG_ID
+    ):
+        from openhands.automation.models import AutomationRun, AutomationRunStatus
+
+        automation = Automation(
+            user_id=user_id,
+            org_id=org_id,
+            name="Test Automation",
+            trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
+            tarball_path="s3://bucket/code.tar.gz",
+            entrypoint="uv run script.py",
+        )
+        async_session.add(automation)
+        await async_session.commit()
+
+        run = AutomationRun(
+            automation_id=automation.id,
+            status=AutomationRunStatus.RUNNING,
+        )
+        async_session.add(run)
+        await async_session.commit()
+        return automation, run
+
+    async def test_run_without_phase_write_reports_null_phase(
+        self, async_client, async_session
+    ):
+        """A RUNNING run nobody wrote a phase for reports an all-null phase."""
+        automation, run = await self._seed_running_run(async_session)
+
+        response = await async_client.get(f"/api/automation/v1/{automation.id}/runs")
+
+        assert response.status_code == 200
+        data = response.json()["runs"][0]
+        assert data["phase_code"] is None
+        assert data["phase_label"] is None
+        assert data["phase_updated_at"] is None
+
+    async def test_phase_write_visible_in_run_list(self, async_client, async_session):
+        """A phase write by the owner is reflected in the runs list."""
+        automation, run = await self._seed_running_run(async_session)
+
+        before_request = utcnow()
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"code": "checking_out", "label": "Checking out PR #123"},
+        )
+
+        assert response.status_code == 200
+
+        list_response = await async_client.get(
+            f"/api/automation/v1/{automation.id}/runs"
+        )
+        assert list_response.status_code == 200
+        data = list_response.json()["runs"][0]
+        assert data["phase_code"] == "checking_out"
+        assert data["phase_label"] == "Checking out PR #123"
+        assert data["phase_updated_at"] is not None
+
+        from datetime import datetime
+
+        from openhands.automation.utils.time import ensure_utc
+
+        phase_updated_at = ensure_utc(datetime.fromisoformat(data["phase_updated_at"]))
+        assert phase_updated_at >= before_request
+
+    async def test_second_phase_write_overwrites_first(
+        self, async_client, async_session
+    ):
+        """Two sequential writes to the same run — the read returns the second."""
+        automation, run = await self._seed_running_run(async_session)
+
+        resp1 = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"code": "checking_out", "label": "Checking out PR #123"},
+        )
+        assert resp1.status_code == 200
+
+        resp2 = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"code": "running_tests", "label": "Running test suite"},
+        )
+        assert resp2.status_code == 200
+
+        list_response = await async_client.get(
+            f"/api/automation/v1/{automation.id}/runs"
+        )
+        data = list_response.json()["runs"][0]
+        assert data["phase_code"] == "running_tests"
+        assert data["phase_label"] == "Running test suite"
+
+    async def test_second_write_omitting_a_field_clears_it(
+        self, async_client, async_session
+    ):
+        """A phase is a pair — a partial second write replaces the
+        whole pair, it does not merge with the first. The field the second
+        request omits must come back None, never the first write's stale
+        value (a "frankenstein" pair nobody ever wrote)."""
+        automation, run = await self._seed_running_run(async_session)
+
+        resp1 = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"code": "checking_out", "label": "Checking out PR #123"},
+        )
+        assert resp1.status_code == 200
+
+        resp2 = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"label": "Running test suite"},
+        )
+        assert resp2.status_code == 200
+        assert resp2.json()["phase_code"] is None
+        assert resp2.json()["phase_label"] == "Running test suite"
+
+        list_response = await async_client.get(
+            f"/api/automation/v1/{automation.id}/runs"
+        )
+        data = list_response.json()["runs"][0]
+        assert data["phase_code"] is None
+        assert data["phase_label"] == "Running test suite"
+
+    async def test_label_exactly_200_chars_is_accepted_and_stored_whole(
+        self, async_client, async_session
+    ):
+        """A 200-character label passes and is stored in full."""
+        automation, run = await self._seed_running_run(async_session)
+        label = "x" * 200
+
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"code": "c", "label": label},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["phase_label"] == label
+        assert len(response.json()["phase_label"]) == 200
+
+    async def test_label_201_chars_is_rejected_and_phase_unchanged(
+        self, async_client, async_session
+    ):
+        """A 201-character label is rejected with 422, phase/status untouched."""
+        from openhands.automation.models import AutomationRunStatus
+
+        automation, run = await self._seed_running_run(async_session)
+        label = "x" * 201
+
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"code": "c", "label": label},
+        )
+
+        assert response.status_code == 422
+
+        await async_session.refresh(run)
+        assert run.phase_code is None
+        assert run.phase_label is None
+        assert run.phase_updated_at is None
+        assert run.status == AutomationRunStatus.RUNNING
+
+    async def test_label_with_control_character_is_rejected_and_phase_unchanged(
+        self, async_client, async_session
+    ):
+        """A label with \\n (or another control char) → 422, phase unchanged."""
+        from openhands.automation.models import AutomationRunStatus
+
+        automation, run = await self._seed_running_run(async_session)
+
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"code": "c", "label": "line one\nline two"},
+        )
+
+        assert response.status_code == 422
+
+        await async_session.refresh(run)
+        assert run.phase_code is None
+        assert run.phase_label is None
+        assert run.phase_updated_at is None
+        assert run.status == AutomationRunStatus.RUNNING
+
+    async def test_code_with_control_character_is_rejected_and_phase_unchanged(
+        self, async_client, async_session
+    ):
+        """code carries the same log/UI-injection exposure as label — control
+        characters must be rejected there too, symmetric with the label
+        check above."""
+        from openhands.automation.models import AutomationRunStatus
+
+        automation, run = await self._seed_running_run(async_session)
+
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"code": "a\nb\x07c"},
+        )
+
+        assert response.status_code == 422
+
+        await async_session.refresh(run)
+        assert run.phase_code is None
+        assert run.phase_label is None
+        assert run.phase_updated_at is None
+        assert run.status == AutomationRunStatus.RUNNING
+
+    async def test_label_with_unicode_line_separator_is_rejected(
+        self, async_client, async_session
+    ):
+        """The control/separator check must cover non-ASCII separators like
+        U+2028 LINE SEPARATOR, not just the ASCII 0x00-0x1f/0x7f range."""
+        automation, run = await self._seed_running_run(async_session)
+
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"code": "c", "label": "line one line two"},
+        )
+
+        assert response.status_code == 422
+
+    async def test_label_with_emoji_and_cyrillic_is_accepted(
+        self, async_client, async_session
+    ):
+        """Phase labels come from automations that are not English-only, so the
+        separator check must not reject ordinary international text. Pinned
+        because the obvious way to catch U+2028 — rejecting the Cf category —
+        also rejects the zero-width joiners that hold an emoji sequence
+        together, and the bidi marks Arabic and Hebrew labels carry."""
+        automation, run = await self._seed_running_run(async_session)
+        # A ZWJ-joined family emoji, then Cyrillic. The joiners stay escaped
+        # because they are invisible in source.
+        label = "\U0001f468\u200d\U0001f469\u200d\U0001f467 Сборка проекта"
+
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"code": "building", "label": label},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["phase_label"] == label
+
+    async def test_request_without_code_or_label_is_rejected(
+        self, async_client, async_session
+    ):
+        """A request with neither code nor label → 422."""
+        automation, run = await self._seed_running_run(async_session)
+
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={},
+        )
+
+        assert response.status_code == 422
+
+    async def test_whitespace_only_label_alone_is_treated_as_absent(
+        self, async_client, async_session
+    ):
+        """An empty/whitespace-only label with no code must not satisfy the
+        at-least-one-field check — it is indistinguishable from no phase."""
+        automation, run = await self._seed_running_run(async_session)
+
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"label": "   "},
+        )
+
+        assert response.status_code == 422
+
+    async def test_non_owner_gets_403_and_phase_unchanged(
+        self, async_client, async_session
+    ):
+        """A caller who does not own the automation → 403, phase unchanged."""
+        from openhands.automation.models import AutomationRunStatus
+
+        automation, run = await self._seed_running_run(
+            async_session, user_id=OTHER_USER_ID, org_id=OTHER_ORG_ID
+        )
+
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"code": "checking_out", "label": "Checking out PR #123"},
+        )
+
+        assert response.status_code == 403
+
+        await async_session.refresh(run)
+        assert run.phase_code is None
+        assert run.phase_label is None
+        assert run.status == AutomationRunStatus.RUNNING
+
+    async def test_nonexistent_run_id_returns_404(self, async_client):
+        """An unknown run_id → 404."""
+        fake_id = uuid.uuid4()
+
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{fake_id}/phase",
+            json={"code": "checking_out"},
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Run not found"
+
+
 class TestDownloadTarball:
     """Tests for GET /{automation_id}/tarball endpoint."""
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -2945,6 +2945,84 @@ class TestRunPhase:
         assert response.status_code == 404
         assert response.json()["detail"] == "Run not found"
 
+    async def test_pending_run_accepts_a_phase(self, async_client, async_session):
+        """A PENDING run is still in flight, so it takes a phase.
+
+        Boundary for the terminal-status guard below: it must reject finished
+        runs without also rejecting the queued ones, which are exactly the
+        runs whose phase the user has nothing else to go on for.
+        """
+        from openhands.automation.models import AutomationRunStatus
+
+        automation, run = await self._seed_running_run(async_session)
+        run.status = AutomationRunStatus.PENDING
+        await async_session.commit()
+
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"code": "queued", "label": "Waiting for a sandbox"},
+        )
+
+        assert response.status_code == 200
+        await async_session.refresh(run)
+        assert run.phase_code == "queued"
+
+    async def test_failed_run_keeps_the_phase_it_stopped_at(
+        self, async_client, async_session
+    ):
+        """A late write cannot overwrite where a failed run stopped.
+
+        The failure surfaces show that phase as the place the run died, and a
+        sandbox that outlives the run — or any other process holding the same
+        credential — must not be able to move it afterwards.
+        """
+        from openhands.automation.models import AutomationRunStatus
+
+        automation, run = await self._seed_running_run(async_session)
+        await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"code": "sandbox_provisioning", "label": "Setting up sandbox"},
+        )
+        run.status = AutomationRunStatus.FAILED
+        await async_session.commit()
+
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"code": "running_agent", "label": "Running the agent"},
+        )
+
+        assert response.status_code == 409
+        await async_session.refresh(run)
+        assert run.phase_code == "sandbox_provisioning"
+        assert run.phase_label == "Setting up sandbox"
+
+    async def test_terminal_run_rejects_a_phase(self, async_client, async_session):
+        """Every terminal status refuses a phase, as ``cancel_run`` does."""
+        from openhands.automation.models import AutomationRunStatus
+
+        for terminal in (
+            AutomationRunStatus.COMPLETED,
+            AutomationRunStatus.CANCELLED,
+            AutomationRunStatus.SKIPPED,
+        ):
+            automation, run = await self._seed_running_run(async_session)
+            run.status = terminal
+            await async_session.commit()
+
+            response = await async_client.post(
+                f"/api/automation/v1/runs/{run.id}/phase",
+                json={"code": "running_agent", "label": "Running the agent"},
+            )
+
+            assert response.status_code == 409, terminal
+            assert terminal.value in response.json()["detail"]
+
+            await async_session.refresh(run)
+            assert run.phase_code is None, terminal
+            assert run.phase_label is None, terminal
+            assert run.phase_updated_at is None, terminal
+            assert run.status == terminal
+
 
 class TestDownloadTarball:
     """Tests for GET /{automation_id}/tarball endpoint."""


### PR DESCRIPTION
HUMAN:

I checked this by hand on a local stack. First the cases in the screenshots on
the frontend PR (OpenHands/OpenHands#16740) — the phase on the automations
list, on the activity-log rows, and the full label on hover — all driven by
this service. On top of that I ran a real but mocked scenario: a mock
automation whose entrypoint does no real work but reports its phases through
the new endpoint. I watched the phases arrive in order as the run progressed,
and saw a failed run keep the phase it stopped at.

AGENT:

Verified beyond unit tests: pre-commit and the full pytest suite, plus the
end-to-end local dispatch described under "Testing" below.

---

## Why

An automation run reports one thing for its entire lifetime: `RUNNING`. A run
that takes minutes looks identical at second 5 and second 300, and a run that
fails tells you *that* it failed, never *where* it stopped — provisioning, the
bundle upload, the entrypoint, or somewhere inside the automation's own code.

This adds a current phase to a run: a short machine code, a human label, and
the moment it was written. The service records its own preparation milestones;
code running inside the sandbox reports the rest through a new endpoint.

Relates to OpenHands/OpenHands#16572. Frontend side: https://github.com/OpenHands/OpenHands/pull/16740

## What changed

- **Storage** — three nullable columns on `automation_runs` (`phase_code`,
  `phase_label`, `phase_updated_at`) plus migration `016`. Nullable with no
  backfill: an existing run simply has no phase, which is the truth.
- **Endpoint** — `POST /v1/runs/{run_id}/phase`, authenticated like the
  existing completion callback, 404 for an unknown run and 403 for someone
  else's automation. Every write replaces the whole `(code, label)` pair —
  last write wins, only the current phase is kept, so there is no history
  table to retain or prune. At least one of `code`/`label` is required.
- **Service phases** — the dispatcher records `queued`,
  `sandbox_provisioning`, `bundle_upload` and `entrypoint_start` as it
  prepares a run. A failed phase write never fails the run: a phase is
  telemetry, not control flow.
- **Preset phases** — the `prompt` and `plugin` templates report `preparing`
  and `running_agent` from inside the sandbox, using the same endpoint any
  custom automation can use.
- **Docs** — `docs/run-phase-reporting.md` is the recipe for custom
  entrypoints, including which credential to use.

## The credential subtlety worth a reviewer's attention

The sandbox holds two keys. `SESSION_API_KEY` authenticates to the *agent
server*; the automation service rejects it. Phase reports must use
`AUTOMATION_CALLBACK_API_KEY` (local mode) or `OPENHANDS_API_KEY` (cloud).
Getting this wrong is silent — the POST 401s, the caller swallows it because a
phase must never break a run, and phases simply never appear while every test
stays green. The preset templates and the docs both spell this out.

## Testing

- `uv run pre-commit run --all-files` — clean (yamlfmt, ruff format, ruff
  lint, pycodestyle, pyright).
- `uv run pytest tests/` — 1337 passed. 36 of those are new: the endpoint's
  contract (auth, ownership, validation, replacement semantics), the
  dispatcher milestones against a real DB seam, and AST assertions that both
  preset templates emit the phases with the right credential.
- **End-to-end on a local stack**, not only unit tests: a custom automation
  whose entrypoint is a shell script that does no real work but reports real
  phases through the endpoint. Dispatching it walks
  `queued → sandbox_provisioning → bundle_upload → entrypoint_start →
  preparing → …` and finishes `COMPLETED` in ~56s; a second variant that
  reports `FAILED` through the completion callback keeps its last phase
  visible on the failed run, which is the point of the feature.

