### PR TITLE
fix: recover MCP config for ACP automation presets

### DIFF
--- a/openhands/automation/presets/plugin/sdk_main.py
+++ b/openhands/automation/presets/plugin/sdk_main.py
@@ -160,6 +160,20 @@ def _normalize_mcp_config(raw_mcp_config):
     return raw_mcp_config
 
 
+def _get_workspace_mcp_config(workspace):
+    raw_mcp_config = workspace.get_mcp_config()
+    if raw_mcp_config:
+        return _normalize_mcp_config(raw_mcp_config)
+
+    # openhands-sdk 1.42.1 returns {} for ACPAgentSettings even though those
+    # settings contain mcp_config. Recover it until the SDK accepts ACP settings.
+    fetch_agent_settings = getattr(workspace, "_fetch_agent_settings", None)
+    if not callable(fetch_agent_settings):
+        return {}
+    settings = fetch_agent_settings()
+    return _normalize_mcp_config(getattr(settings, "mcp_config", {}))
+
+
 def _build_conversation_title(event_context) -> str | None:
     """Build a descriptive conversation title from the automation event context.
 
@@ -384,7 +398,7 @@ This automation was triggered by a webhook event:
     print("\n=== GET_MCP_CONFIG ===")
     mcp_config = {}
     try:
-        mcp_config = _normalize_mcp_config(workspace.get_mcp_config())
+        mcp_config = _get_workspace_mcp_config(workspace)
         if mcp_config:
             print(f"  servers: {list(mcp_config.keys())}")
         else:

--- a/openhands/automation/presets/prompt/sdk_main.py
+++ b/openhands/automation/presets/prompt/sdk_main.py
@@ -163,6 +163,20 @@ def _normalize_mcp_config(raw_mcp_config):
     return raw_mcp_config
 
 
+def _get_workspace_mcp_config(workspace):
+    raw_mcp_config = workspace.get_mcp_config()
+    if raw_mcp_config:
+        return _normalize_mcp_config(raw_mcp_config)
+
+    # openhands-sdk 1.42.1 returns {} for ACPAgentSettings even though those
+    # settings contain mcp_config. Recover it until the SDK accepts ACP settings.
+    fetch_agent_settings = getattr(workspace, "_fetch_agent_settings", None)
+    if not callable(fetch_agent_settings):
+        return {}
+    settings = fetch_agent_settings()
+    return _normalize_mcp_config(getattr(settings, "mcp_config", {}))
+
+
 def _build_conversation_title(event_context) -> str | None:
     """Build a descriptive conversation title from the automation event context.
 
@@ -353,7 +367,7 @@ This automation was triggered by a webhook event:
     print("\n=== GET_MCP_CONFIG ===")
     mcp_config = {}
     try:
-        mcp_config = _normalize_mcp_config(workspace.get_mcp_config())
+        mcp_config = _get_workspace_mcp_config(workspace)
         if mcp_config:
             print(f"  servers: {list(mcp_config.keys())}")
         else:

--- a/tests/test_preset_router.py
+++ b/tests/test_preset_router.py
@@ -76,6 +76,34 @@ def _load_preset_mcp_normalizer(
     return cast(Callable[[Any], Any], namespace["_normalize_mcp_config"])
 
 
+def _load_preset_workspace_mcp_loader(preset_name: str) -> Callable[[Any], Any]:
+    source_path = PRESETS_DIR / preset_name / "sdk_main.py"
+    module = ast.parse(source_path.read_text(), filename=str(source_path))
+    function_nodes = {
+        node.name: node
+        for node in module.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name in {"_normalize_mcp_config", "_get_workspace_mcp_config"}
+    }
+    assert "_get_workspace_mcp_config" in function_nodes, (
+        f"{preset_name} preset must recover MCP config from ACP settings"
+    )
+    namespace: dict[str, Any] = {"_coerce_mcp_config": coerce_mcp_config}
+    selected_nodes: list[ast.stmt] = [
+        function_nodes["_normalize_mcp_config"],
+        function_nodes["_get_workspace_mcp_config"],
+    ]
+    for node in selected_nodes:
+        ast.fix_missing_locations(node)
+    exec(
+        compile(
+            ast.Module(body=selected_nodes, type_ignores=[]), str(source_path), "exec"
+        ),
+        namespace,
+    )
+    return cast(Callable[[Any], Any], namespace["_get_workspace_mcp_config"])
+
+
 def _load_preset_title_builder(preset_name: str) -> Callable[[Any], str | None]:
     source_path = PRESETS_DIR / preset_name / "sdk_main.py"
     module = ast.parse(source_path.read_text(), filename=str(source_path))
@@ -224,6 +252,22 @@ def test_preset_mcp_normalizer_unwraps_without_sdk_coercer(preset_name):
     assert normalize(wrapped_config) == native_config
     assert normalize(native_config) == native_config
     assert normalize(None) == {}
+
+
+@pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
+def test_preset_recovers_mcp_config_from_acp_settings(preset_name):
+    load_mcp_config = _load_preset_workspace_mcp_loader(preset_name)
+    workspace = MagicMock()
+    workspace.get_mcp_config.return_value = {}
+    workspace._fetch_agent_settings.return_value.mcp_config = {
+        "Plane": {"command": "uvx", "args": ["plane-mcp-server", "stdio"]}
+    }
+
+    mcp_config = load_mcp_config(workspace)
+
+    assert list(mcp_config) == ["Plane"]
+    workspace.get_mcp_config.assert_called_once_with()
+    workspace._fetch_agent_settings.assert_called_once_with()
 
 
 _UTC_TIMESTAMP_RE = re.compile(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC")


### PR DESCRIPTION
## Summary

- recover persisted MCP configuration for ACP-backed automation workspaces when `Workspace.get_mcp_config()` returns an empty mapping
- preserve the existing public `get_mcp_config()` path whenever it returns configured servers
- apply the compatibility path consistently to both prompt and plugin presets
- add regression coverage for both presets

## Root cause

In `openhands-sdk==1.42.1`, `ACPAgentSettings` includes an `mcp_config` field, but `APIRemoteWorkspace.get_mcp_config()` returns `{}` unless the fetched settings are `OpenHandsAgentSettings`. As a result, ACP automation presets silently started without their configured MCP servers.

The compatibility helper falls back to the workspace's existing `_fetch_agent_settings()` result only when the public method returns no configuration. It can be removed once the SDK public method supports ACP settings directly.

## Verification

- `uv run pytest -q tests/test_preset_router.py` — 98 passed, 41 skipped
- `uv run ruff check tests/test_preset_router.py`
- `uv run pyright tests/test_preset_router.py`
- `uv run python -m py_compile openhands/automation/presets/prompt/sdk_main.py openhands/automation/presets/plugin/sdk_main.py tests/test_preset_router.py`
- `uv run pre-commit run --files openhands/automation/presets/prompt/sdk_main.py openhands/automation/presets/plugin/sdk_main.py tests/test_preset_router.py`
- live read-only automation run initialized configured MCP servers and completed successfully
