### PR TITLE
Stamp observability metadata/tags on preset automation conversations

### DIFF
--- a/openhands/automation/presets/plugin/sdk_main.py
+++ b/openhands/automation/presets/plugin/sdk_main.py
@@ -148,6 +148,37 @@ def _conversation_supports_user_id() -> bool:
         return False
 
 
+def _conversation_supports_observability() -> bool:
+    try:
+        params = inspect.signature(Conversation.__new__).parameters
+        return "observability_metadata" in params and "observability_tags" in params
+    except (TypeError, ValueError):
+        return False
+
+
+def _build_observability_context(event_context, automation_run_id):
+    """Trace metadata and span tags marking this conversation as automation-run.
+
+    Uses the same ``trigger`` metadata key and ``trigger:<value>`` tag as the
+    app-server's observability context so Laminar queries can split automation
+    vs. UI-driven conversations uniformly.
+    """
+    metadata = {"trigger": "automation"}
+    tags = ["trigger:automation"]
+    if isinstance(event_context, dict):
+        trigger_type = event_context.get("trigger")
+        if trigger_type:
+            metadata["automation_trigger"] = trigger_type
+            tags.append(f"automation_trigger:{trigger_type}")
+        for key in ("automation_id", "automation_name"):
+            value = event_context.get(key)
+            if value:
+                metadata[key] = value
+    if automation_run_id:
+        metadata["automation_run_id"] = automation_run_id
+    return metadata, tags
+
+
 def _normalize_mcp_config(raw_mcp_config):
     if not raw_mcp_config:
         return {}
@@ -460,6 +491,16 @@ This automation was triggered by a webhook event:
     }
     if automation_user_id and _conversation_supports_user_id():
         conversation_kwargs["user_id"] = automation_user_id
+    if _conversation_supports_observability():
+        obs_metadata, obs_tags = _build_observability_context(
+            event_context, automation_run_id
+        )
+        if experiment_id:
+            obs_metadata["experiment_id"] = experiment_id
+            if selected_variant:
+                obs_metadata["experiment_variant"] = selected_variant
+        conversation_kwargs["observability_metadata"] = obs_metadata
+        conversation_kwargs["observability_tags"] = obs_tags
     conversation = Conversation(**conversation_kwargs)
     assert isinstance(conversation, RemoteConversation)
     print(f"  conversation created: {type(conversation).__name__}")

--- a/openhands/automation/presets/prompt/sdk_main.py
+++ b/openhands/automation/presets/prompt/sdk_main.py
@@ -151,6 +151,37 @@ def _conversation_supports_user_id() -> bool:
         return False
 
 
+def _conversation_supports_observability() -> bool:
+    try:
+        params = inspect.signature(Conversation.__new__).parameters
+        return "observability_metadata" in params and "observability_tags" in params
+    except (TypeError, ValueError):
+        return False
+
+
+def _build_observability_context(event_context, automation_run_id):
+    """Trace metadata and span tags marking this conversation as automation-run.
+
+    Uses the same ``trigger`` metadata key and ``trigger:<value>`` tag as the
+    app-server's observability context so Laminar queries can split automation
+    vs. UI-driven conversations uniformly.
+    """
+    metadata = {"trigger": "automation"}
+    tags = ["trigger:automation"]
+    if isinstance(event_context, dict):
+        trigger_type = event_context.get("trigger")
+        if trigger_type:
+            metadata["automation_trigger"] = trigger_type
+            tags.append(f"automation_trigger:{trigger_type}")
+        for key in ("automation_id", "automation_name"):
+            value = event_context.get(key)
+            if value:
+                metadata[key] = value
+    if automation_run_id:
+        metadata["automation_run_id"] = automation_run_id
+    return metadata, tags
+
+
 def _normalize_mcp_config(raw_mcp_config):
     if not raw_mcp_config:
         return {}
@@ -413,6 +444,12 @@ This automation was triggered by a webhook event:
     }
     if automation_user_id and _conversation_supports_user_id():
         conversation_kwargs["user_id"] = automation_user_id
+    if _conversation_supports_observability():
+        obs_metadata, obs_tags = _build_observability_context(
+            event_context, automation_run_id
+        )
+        conversation_kwargs["observability_metadata"] = obs_metadata
+        conversation_kwargs["observability_tags"] = obs_tags
     conversation = Conversation(**conversation_kwargs)
     assert isinstance(conversation, RemoteConversation)
     print(f"  conversation created: {type(conversation).__name__}")


### PR DESCRIPTION
## Why

Automation-run sessions and regular UI conversations are indistinguishable in Laminar today. Traces only carry `session_id` (the conversation UUID) — no origin signal in metadata or tags — so there's no way to filter automation traffic out of (or into) trace views, cost analysis, or signals.

Preset scripts create their `RemoteConversation` directly against the sandbox agent server, bypassing the app-server start path, so any origin stamping has to happen here. The SDK plumbing already exists (`Conversation(observability_metadata=..., observability_tags=...)` → `Laminar.set_trace_metadata` / root span tags) — the presets just weren't using it.

## What

Both preset scripts (`presets/prompt/sdk_main.py`, `presets/plugin/sdk_main.py`) now pass observability context to `Conversation()`:

| Field | Value | Source |
|---|---|---|
| metadata `trigger` | `automation` | constant — matches the app-server convention (see companion PR OpenHands/sandbox-server#9) so automation vs. UI traffic splits on one key |
| tag `trigger:automation` | — | same |
| metadata `automation_trigger` | `cron` / `event` | `AUTOMATION_EVENT_PAYLOAD.trigger` |
| tag `automation_trigger:<type>` | — | same |
| metadata `automation_id` / `automation_name` | — | `AUTOMATION_EVENT_PAYLOAD` |
| metadata `automation_run_id` | — | `AUTOMATION_RUN_ID` env |
| metadata `experiment_id` / `experiment_variant` | — | plugin preset A/B config, when present |

The kwargs are gated on an `inspect.signature` check (same pattern as the existing `_conversation_supports_user_id()` gate), so sandboxes running older SDK versions silently skip them instead of raising.

Example Laminar query after this lands:

```sql
SELECT simpleJSONExtractString(metadata, 'trigger') AS trigger, count()
FROM traces
WHERE start_time > now() - INTERVAL 7 DAY
GROUP BY trigger
```

or filter by the `trigger:automation` tag, or drill into a single automation via `metadata.automation_name`.

## Notes

- Preset scripts are packaged into the automation tarball at creation time, so **existing automations pick this up only when updated/re-created** (or whenever the preset script is refreshed).
- Companion PR: OpenHands/sandbox-server#9 threads `ConversationTrigger` into the app-server observability context, covering conversations started through `POST /api/v1/app-conversations` (GUI, Slack, Jira, resolver, and API-triggered automation conversations).

## Testing

- Extracted `_build_observability_context` from both scripts and unit-tested it directly (full payload, empty payload, cron-only) — all pass
- `pytest tests/test_preset_router.py tests/test_ab_testing_integration.py` — 114 passed
- Full suite: 940 passed; the 338 errors are pre-existing docker-socket-dependent tests that fail identically on the base commit in this environment
- `ruff check` / `ruff format --check` clean (presets dir is excluded from lint per `pyproject.toml`; verified the scripts are unchanged-lint-parity with base)

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b145e181-69c4-4751-9915-2ade9058377a)