### PR TITLE
fix: treat missing tarball objects as permanent and defer superseded deletes until commit

### DIFF
--- a/openhands/automation/dispatcher.py
+++ b/openhands/automation/dispatcher.py
@@ -77,8 +77,9 @@ async def _download_internal_tarball(
     """Download a tarball from storage using the TarballUpload record.
 
     Raises:
-        TarballNotFoundError: If the tarball upload record doesn't exist.
-            This is a permanent error that should disable the automation.
+        TarballNotFoundError: If the tarball upload record doesn't exist, or if
+            the record exists but its storage object is missing. Both are
+            permanent errors that should disable the automation.
         ValueError: If no database session is provided.
     """
     if session is None:
@@ -94,10 +95,19 @@ async def _download_internal_tarball(
             "The tarball may have been deleted."
         )
 
-    from openhands.automation.storage import get_file_store
+    from openhands.automation.storage import ObjectNotFoundError, get_file_store
 
     store = get_file_store()
-    return store.read(upload.storage_path)
+    try:
+        return store.read(upload.storage_path)
+    except ObjectNotFoundError as e:
+        # Only confirmed absence is permanent; transient storage errors raise
+        # plain FileNotFoundError and keep retrying on the next schedule tick.
+        raise TarballNotFoundError(
+            f"Internal tarball object missing from storage at "
+            f"{upload.storage_path!r} for upload {upload_id}. "
+            "Recreate the automation to restore it."
+        ) from e
 
 
 async def _poll_pending_runs(

--- a/openhands/automation/git_sync/loop.py
+++ b/openhands/automation/git_sync/loop.py
@@ -58,7 +58,7 @@ from openhands.automation.models import (
     UploadStatus,
 )
 from openhands.automation.schemas import Trigger, validate_command_string
-from openhands.automation.storage import get_file_store
+from openhands.automation.storage import ObjectNotFoundError, get_file_store
 from openhands.automation.utils import utcnow
 from openhands.automation.utils.periodic_loop import run_periodic_loop
 from openhands.automation.utils.service_metadata import (
@@ -357,13 +357,20 @@ async def _stored_tarball_matches(
         return False
 
 
-async def _delete_superseded_upload(session: AsyncSession, tarball_path: str) -> None:
-    """Remove the upload an automation just stopped pointing at.
+async def _delete_superseded_upload(
+    session: AsyncSession, tarball_path: str, pending_storage_deletes: list[str]
+) -> None:
+    """Mark the upload an automation just stopped pointing at for removal.
 
     Without this, every git-side edit left the previous upload row and file
     referenced by nothing, so routine PR edits accumulated a tarball copy per
     merge with no reaper to collect them. Mirrors the cleanup
     `regenerate_preset_prompt_tarball` does for prompt edits.
+
+    Soft-deletes the record in the current transaction; the storage object is
+    only queued on `pending_storage_deletes` and removed after the cycle's
+    commit. Deleting before the commit destroyed the object irreversibly while
+    a rollback revived the record, stranding it pointing at a missing object.
     """
     upload_id = parse_internal_upload_id(tarball_path)
     if upload_id is None:
@@ -375,21 +382,22 @@ async def _delete_superseded_upload(session: AsyncSession, tarball_path: str) ->
     if upload is None or upload.deleted_at is not None:
         return
 
-    file_removed = False
-    try:
-        await asyncio.to_thread(get_file_store().delete, upload.storage_path)
-        file_removed = True
-    except FileNotFoundError:
-        file_removed = True
-    except Exception:
-        logger.exception(
-            "Failed to delete superseded tarball at %s", upload.storage_path
-        )
-    # Soft-delete only once the file is confirmed gone: a failed delete leaves
-    # the record live, so the file stays discoverable for a retry rather than
-    # becoming a hidden orphan.
-    if file_removed:
-        upload.deleted_at = utcnow()
+    upload.deleted_at = utcnow()
+    pending_storage_deletes.append(upload.storage_path)
+
+
+async def _delete_pending_storage_objects(storage_paths: list[str]) -> None:
+    """Best-effort removal of superseded tarball objects after the commit."""
+    if not storage_paths:
+        return
+    file_store = get_file_store()
+    for path in storage_paths:
+        try:
+            await asyncio.to_thread(file_store.delete, path)
+        except ObjectNotFoundError:
+            pass  # already gone
+        except Exception:
+            logger.exception("Failed to delete superseded tarball at %s", path)
 
 
 async def _resolve_tarball_path(
@@ -398,6 +406,7 @@ async def _resolve_tarball_path(
     deserialized: DeserializedAutomation,
     slug: str,
     existing: Automation | None,
+    pending_storage_deletes: list[str],
 ) -> str:
     if deserialized.tarball_bytes is not None:
         if existing is not None and await _stored_tarball_matches(
@@ -417,7 +426,9 @@ async def _resolve_tarball_path(
             slug,
         )
         if existing is not None:
-            await _delete_superseded_upload(session, existing.tarball_path)
+            await _delete_superseded_upload(
+                session, existing.tarball_path, pending_storage_deletes
+            )
         return new_path
 
     tarball_source = fields.get("tarball_source") or {}
@@ -439,6 +450,7 @@ async def _validate_and_resolve_fields(
     fields: dict,
     deserialized: DeserializedAutomation,
     slug: str,
+    pending_storage_deletes: list[str],
     existing: Automation | None = None,
 ) -> dict:
     """Validate automation.yaml fields and resolve a tarball_path, mirroring
@@ -459,7 +471,7 @@ async def _validate_and_resolve_fields(
     )
     timeout = validate_automation_timeout(fields.get("timeout"))
     tarball_path = await _resolve_tarball_path(
-        session, fields, deserialized, slug, existing
+        session, fields, deserialized, slug, existing, pending_storage_deletes
     )
 
     return {
@@ -486,9 +498,10 @@ async def _create_automation_from_git(
     deserialized: DeserializedAutomation,
     dir_files: dict[str, bytes],
     head: str,
+    pending_storage_deletes: list[str],
 ) -> None:
     values = await _validate_and_resolve_fields(
-        session, deserialized.fields, deserialized, slug
+        session, deserialized.fields, deserialized, slug, pending_storage_deletes
     )
     local_user = _get_local_user()
     automation = Automation(
@@ -516,6 +529,7 @@ async def _update_automation_from_git(
     deserialized: DeserializedAutomation,
     dir_files: dict[str, bytes],
     head: str,
+    pending_storage_deletes: list[str],
 ) -> None:
     new_hash = compute_content_hash(dir_files)
     if new_hash == state.content_hash:
@@ -531,7 +545,12 @@ async def _update_automation_from_git(
         )
 
     values = await _validate_and_resolve_fields(
-        session, deserialized.fields, deserialized, state.slug, existing=automation
+        session,
+        deserialized.fields,
+        deserialized,
+        state.slug,
+        pending_storage_deletes,
+        existing=automation,
     )
     for column, value in values.items():
         setattr(automation, column, value)
@@ -612,6 +631,7 @@ async def _import_from_git(
     timeout: float,
     encryption_key: str,
     result: SyncCycleResult,
+    pending_storage_deletes: list[str],
 ) -> None:
     all_dirs = _list_slug_directories(sync_root)
 
@@ -635,6 +655,9 @@ async def _import_from_git(
             continue
 
         dir_files = await asyncio.to_thread(_read_directory_files, directory)
+        # A rolled-back savepoint revives the soft-deleted upload rows queued
+        # inside it, so their storage paths must not stay pending for deletion.
+        pending_snapshot = len(pending_storage_deletes)
         try:
             # One SAVEPOINT per directory: a failure rolls back just its writes
             # (a half-populated Automation, a flushed TarballUpload) and leaves
@@ -648,18 +671,30 @@ async def _import_from_git(
 
                 if state is None:
                     await _create_automation_from_git(
-                        session, slug, deserialized, dir_files, head
+                        session,
+                        slug,
+                        deserialized,
+                        dir_files,
+                        head,
+                        pending_storage_deletes,
                     )
                     result.imported += 1
                 else:
                     await _update_automation_from_git(
-                        session, state, deserialized, dir_files, head
+                        session,
+                        state,
+                        deserialized,
+                        dir_files,
+                        head,
+                        pending_storage_deletes,
                     )
         except (ValidationError, ValueError) as e:
+            del pending_storage_deletes[pending_snapshot:]
             logger.warning(
                 "Skipping invalid automation directory %r from git: %s", slug, e
             )
         except Exception:
+            del pending_storage_deletes[pending_snapshot:]
             # Deliberately broad: anything escaping aborts the whole cycle --
             # no export, no push -- every cycle until someone fixes that one
             # directory by hand. Traceback logged, since reaching here means an
@@ -945,6 +980,11 @@ async def _run_sync_cycle_locked(
 
     result = SyncCycleResult(head=head)
 
+    # Storage paths of superseded uploads soft-deleted during the import; their
+    # objects are only removed after the commit below succeeds, so a rollback
+    # can never revive a record whose object is already gone.
+    pending_storage_deletes: list[str] = []
+
     # Committed *before* the push, not held open across it: SQLite holds its
     # single-writer lock for the whole transaction, and a push can take up to
     # git_sync_git_timeout_seconds.
@@ -970,6 +1010,7 @@ async def _run_sync_cycle_locked(
                 timeout,
                 encryption_key,
                 result,
+                pending_storage_deletes,
             )
 
         # After the import, so automations that arrived from git this cycle
@@ -980,6 +1021,10 @@ async def _run_sync_cycle_locked(
         # run regardless of whether anything was exported (see below).
         await _export_dirty_automations(session, sync_root, encryption_key, result)
         await session.commit()
+
+    # Only after the commit: the soft-deletes are durable, so removing the
+    # objects can no longer strand a live record. A commit failure skips this.
+    await _delete_pending_storage_objects(pending_storage_deletes)
 
     # Unconditional, not gated on `exported`: commit_and_push also retries a
     # previous cycle's unpushed commit and pushes to a newly-repointed remote.

--- a/openhands/automation/preset_router.py
+++ b/openhands/automation/preset_router.py
@@ -19,7 +19,15 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Request,
+    Response,
+    status,
+)
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -34,7 +42,7 @@ from openhands.automation.schemas import (
     TemplateProvenance,
     Trigger,
 )
-from openhands.automation.storage import FileStore, get_file_store
+from openhands.automation.storage import FileStore, ObjectNotFoundError, get_file_store
 from openhands.automation.telemetry import (
     capture_automation_event,
     get_request_telemetry_context,
@@ -298,10 +306,23 @@ def _replace_prompt_in_tarball(tarball_bytes: bytes, new_prompt: str) -> bytes |
     return out_buffer.read()
 
 
+def _delete_storage_object_best_effort(
+    file_store: FileStore, storage_path: str
+) -> None:
+    """Best-effort post-commit removal of a superseded tarball object."""
+    try:
+        file_store.delete(storage_path)
+    except ObjectNotFoundError:
+        pass  # already gone -- nothing to clean up
+    except Exception:
+        logger.exception("Failed to delete superseded tarball at %s", storage_path)
+
+
 async def regenerate_preset_prompt_tarball(
     automation: Automation,
     new_prompt: str,
     session: AsyncSession,
+    background_tasks: BackgroundTasks,
 ) -> str | None:
     """Rebuild a preset automation's tarball with an updated prompt.
 
@@ -313,6 +334,8 @@ async def regenerate_preset_prompt_tarball(
     Reads the automation's current internal-upload tarball, swaps in ``new_prompt``
     (leaving all other files untouched), uploads the result as a new internal upload,
     and returns its ``oh-internal://`` URL for the caller to store on ``tarball_path``.
+    The superseded upload is soft-deleted in the current transaction; its storage
+    object is removed via ``background_tasks`` only after the transaction commits.
 
     Returns ``None`` — leaving the tarball unchanged — when the automation is not a
     regenerable preset: its ``tarball_path`` is an external URL, the referenced upload
@@ -333,7 +356,10 @@ async def regenerate_preset_prompt_tarball(
 
     try:
         current_tarball = file_store.read(source_upload.storage_path)
-    except FileNotFoundError:
+    except ObjectNotFoundError:
+        # Only confirmed absence means "not regenerable"; a transient storage
+        # error must propagate (rolling back the edit) rather than silently
+        # leaving the old prompt baked into the tarball.
         return None
 
     new_tarball = _replace_prompt_in_tarball(current_tarball, new_prompt)
@@ -376,46 +402,32 @@ async def regenerate_preset_prompt_tarball(
             detail=f"Failed to upload regenerated tarball: {e!s}",
         )
 
-    # The old tarball is now superseded. Remove its file and soft-delete the
-    # upload record so repeated prompt edits don't accumulate orphaned storage.
-    # Only soft-delete once the file is confirmed gone: if the delete fails the
-    # record stays live so the still-present file remains discoverable for a
-    # later retry/cleanup instead of becoming a hidden orphan (file on disk,
-    # record marked deleted).
-    old_object_delete_succeeded = False
-    old_object_already_missing = False
-    try:
-        file_store.delete(source_upload.storage_path)
-        old_object_delete_succeeded = True
-    except FileNotFoundError:
-        old_object_already_missing = True
-    except Exception as e:
-        logger.exception(
-            "Failed to delete superseded tarball at %s: %s",
-            source_upload.storage_path,
-            e,
-        )
-    file_removed = old_object_delete_succeeded or old_object_already_missing
-    if file_removed:
-        source_upload.deleted_at = utcnow()
+    # The old tarball is now superseded. Soft-delete its record inside this
+    # transaction, but remove its storage object only after the commit, via a
+    # background task (which runs only for a successful response, after the
+    # function-scoped session has committed -- see update_automation). Deleting
+    # before the commit destroyed the object irreversibly while a rollback
+    # reverted this soft-delete and the tarball_path update, stranding a live
+    # record pointing at a missing object. Worst case now -- a crash between
+    # commit and task -- leaks an orphaned object whose record is already
+    # soft-deleted, which is the recoverable direction.
+    source_upload.deleted_at = utcnow()
+    background_tasks.add_task(
+        _delete_storage_object_best_effort, file_store, source_upload.storage_path
+    )
 
     logger.info(
         "Regenerated preset tarball: automation_id=%s, old_upload_id=%s, "
-        "new_upload_id=%s, old_object_delete_succeeded=%s, "
-        "old_object_already_missing=%s",
+        "new_upload_id=%s",
         automation.id,
         source_upload.id,
         new_upload_id,
-        old_object_delete_succeeded,
-        old_object_already_missing,
         extra={
             "automation_id": str(automation.id),
             "old_upload_id": str(source_upload.id),
             "old_storage_path": source_upload.storage_path,
             "new_upload_id": str(new_upload_id),
             "new_storage_path": storage_path,
-            "old_object_delete_succeeded": old_object_delete_succeeded,
-            "old_object_already_missing": old_object_already_missing,
         },
     )
 

--- a/openhands/automation/router.py
+++ b/openhands/automation/router.py
@@ -6,7 +6,16 @@ import re
 import uuid
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+    status,
+)
 from fastapi.responses import RedirectResponse
 from sqlalchemy import func, select, update
 from sqlalchemy.engine import CursorResult
@@ -194,8 +203,14 @@ async def update_automation(
     automation_id: uuid.UUID,
     body: UpdateAutomationRequest,
     request: Request,
+    background_tasks: BackgroundTasks,
     user: AuthenticatedUser = Depends(_require_manage_automations),
-    session: AsyncSession = Depends(get_session),
+    # Function scope commits the session when the handler returns, BEFORE the
+    # response is sent and its background tasks run. With the default request
+    # scope the deferred tarball delete would run before the commit, and a
+    # commit failure would strand a live upload record pointing at an
+    # already-deleted object.
+    session: AsyncSession = Depends(get_session, scope="function"),
 ) -> AutomationResponse:
     """Partially update an automation."""
     auto = await _get_user_automation(session, automation_id, user.user_id, user.org_id)
@@ -223,7 +238,7 @@ async def update_automation(
         and auto.prompt != original_prompt
     ):
         new_tarball_path = await regenerate_preset_prompt_tarball(
-            auto, auto.prompt, session
+            auto, auto.prompt, session, background_tasks
         )
         if new_tarball_path is not None:
             auto.tarball_path = new_tarball_path

--- a/openhands/automation/storage/__init__.py
+++ b/openhands/automation/storage/__init__.py
@@ -1,5 +1,5 @@
 from openhands.automation.storage.factory import get_file_store
-from openhands.automation.storage.file_store import FileStore
+from openhands.automation.storage.file_store import FileStore, ObjectNotFoundError
 from openhands.automation.storage.google_cloud import (
     FileSizeLimitExceeded,
     GoogleCloudFileStore,
@@ -13,6 +13,7 @@ __all__ = [
     "FileSizeLimitExceeded",
     "GoogleCloudFileStore",
     "LocalFileStore",
+    "ObjectNotFoundError",
     "S3FileStore",
     "get_file_store",
 ]

--- a/openhands/automation/storage/file_store.py
+++ b/openhands/automation/storage/file_store.py
@@ -7,6 +7,17 @@ from collections.abc import AsyncIterator
 BUCKET_PREFIX = "automation"
 
 
+class ObjectNotFoundError(FileNotFoundError):
+    """The storage object at the given path genuinely does not exist.
+
+    Backends raise this only on confirmed absence (S3 404/NoSuchKey, GCS
+    NotFound, a missing local file). Transient and access errors keep raising
+    plain FileNotFoundError, so callers that must distinguish "gone forever"
+    from "unreadable right now" can catch this subclass while existing
+    ``except FileNotFoundError`` handlers keep working unchanged.
+    """
+
+
 class FileStore(ABC):
     """Abstract base class for file storage operations."""
 
@@ -25,7 +36,8 @@ class FileStore(ABC):
         """Read and return the contents of the file at the given path.
 
         Raises:
-            FileNotFoundError: If the file does not exist.
+            ObjectNotFoundError: If the file does not exist.
+            FileNotFoundError: For other storage errors (backend-dependent).
         """
         pass
 
@@ -36,7 +48,12 @@ class FileStore(ABC):
 
     @abstractmethod
     def delete(self, path: str) -> None:
-        """Delete the file at the given path."""
+        """Delete the file at the given path.
+
+        Raises:
+            ObjectNotFoundError: If the file does not exist (LocalFileStore is
+                silently idempotent instead).
+        """
         pass
 
     @abstractmethod

--- a/openhands/automation/storage/google_cloud.py
+++ b/openhands/automation/storage/google_cloud.py
@@ -6,7 +6,11 @@ from typing import TYPE_CHECKING
 from google.cloud import storage
 from google.cloud.exceptions import NotFound
 
-from openhands.automation.storage.file_store import BUCKET_PREFIX, FileStore
+from openhands.automation.storage.file_store import (
+    BUCKET_PREFIX,
+    FileStore,
+    ObjectNotFoundError,
+)
 
 
 if TYPE_CHECKING:
@@ -92,14 +96,14 @@ class GoogleCloudFileStore(FileStore):
             The file contents as bytes.
 
         Raises:
-            FileNotFoundError: If the file does not exist.
+            ObjectNotFoundError: If the file does not exist.
         """
         full_path = self._prefixed_path(path)
         blob = self.bucket.blob(full_path)
         try:
             return blob.download_as_bytes()
         except NotFound:
-            raise FileNotFoundError(f"File not found: {full_path}")
+            raise ObjectNotFoundError(f"File not found: {full_path}")
 
     def list(self, path: str) -> list[str]:
         """
@@ -127,14 +131,14 @@ class GoogleCloudFileStore(FileStore):
                   with "automation/").
 
         Raises:
-            FileNotFoundError: If the file doesn't exist.
+            ObjectNotFoundError: If the file doesn't exist.
         """
         full_path = self._prefixed_path(path)
         blob = self.bucket.blob(full_path)
         try:
             blob.delete()
         except NotFound:
-            raise FileNotFoundError(f"File not found: {full_path}")
+            raise ObjectNotFoundError(f"File not found: {full_path}")
 
     async def write_stream(
         self,

--- a/openhands/automation/storage/local.py
+++ b/openhands/automation/storage/local.py
@@ -5,7 +5,7 @@ import shutil
 from collections.abc import AsyncIterator
 from pathlib import Path
 
-from openhands.automation.storage.file_store import FileStore
+from openhands.automation.storage.file_store import FileStore, ObjectNotFoundError
 from openhands.automation.storage.google_cloud import FileSizeLimitExceeded
 
 
@@ -61,7 +61,7 @@ class LocalFileStore(FileStore):
         """Read and return the contents of the file at the given path."""
         full_path = self._full_path(path)
         if not full_path.exists():
-            raise FileNotFoundError(f"File not found: {path}")
+            raise ObjectNotFoundError(f"File not found: {path}")
         return full_path.read_bytes()
 
     def list(self, path: str) -> list[str]:

--- a/openhands/automation/storage/s3.py
+++ b/openhands/automation/storage/s3.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING, Any
 import boto3
 import botocore.exceptions
 
-from openhands.automation.storage.file_store import BUCKET_PREFIX, FileStore
+from openhands.automation.storage.file_store import (
+    BUCKET_PREFIX,
+    FileStore,
+    ObjectNotFoundError,
+)
 from openhands.automation.storage.google_cloud import FileSizeLimitExceeded
 
 
@@ -192,7 +196,8 @@ class S3FileStore(FileStore):
             The file contents as bytes.
 
         Raises:
-            FileNotFoundError: If the file does not exist.
+            ObjectNotFoundError: If the file does not exist.
+            FileNotFoundError: For other S3 errors.
         """
         full_path = self._prefixed_path(path)
         try:
@@ -236,7 +241,8 @@ class S3FileStore(FileStore):
                   with "automation/").
 
         Raises:
-            FileNotFoundError: If the file doesn't exist or access is denied.
+            ObjectNotFoundError: If the file doesn't exist.
+            FileNotFoundError: For other S3 errors, including access denied.
         """
         full_path = self._prefixed_path(path)
         try:
@@ -271,7 +277,8 @@ class S3FileStore(FileStore):
             path: The S3 key/path involved.
 
         Raises:
-            FileNotFoundError: For not-found and access errors (to match FileStore API).
+            ObjectNotFoundError: If the key genuinely does not exist (404/NoSuchKey).
+            FileNotFoundError: For all other errors (to match FileStore API).
         """
         error_code = e.response.get("Error", {}).get("Code")
         error_msg = e.response.get("Error", {}).get("Message", "")
@@ -289,7 +296,7 @@ class S3FileStore(FileStore):
                 f"Bucket '{self.bucket_name}' does not exist"
             ) from e
         elif error_code in ("404", "NoSuchKey"):
-            raise FileNotFoundError(f"File not found: {path}") from e
+            raise ObjectNotFoundError(f"File not found: {path}") from e
         elif error_code == "AccessDenied":
             raise FileNotFoundError(
                 f"Access denied to '{self.bucket_name}/{path}'"

--- a/tests/test_disable_automation.py
+++ b/tests/test_disable_automation.py
@@ -44,6 +44,32 @@ def _create_mock_backend() -> MagicMock:
     return mock_backend
 
 
+def _storage_path(upload_id: uuid.UUID) -> str:
+    """Storage path for a test upload, mirroring the production layout."""
+    return f"uploads/{TEST_ORG_ID}/{TEST_USER_ID}/{upload_id}.tar"
+
+
+async def _create_completed_upload(async_session_factory) -> uuid.UUID:
+    """Persist a live, COMPLETED upload row whose object is not in the store."""
+    from openhands.automation.models import TarballUpload, UploadStatus
+
+    upload_id = uuid.uuid4()
+    async with async_session_factory() as session:
+        session.add(
+            TarballUpload(
+                id=upload_id,
+                user_id=TEST_USER_ID,
+                org_id=TEST_ORG_ID,
+                name="test-upload",
+                status=UploadStatus.COMPLETED,
+                storage_path=_storage_path(upload_id),
+                size_bytes=1024,
+            )
+        )
+        await session.commit()
+    return upload_id
+
+
 def _docker_available() -> bool:
     """Check if Docker is available for testcontainers."""
     try:
@@ -226,6 +252,59 @@ class TestDownloadInternalTarball:
 
         assert "not found" in str(exc_info.value).lower()
         assert str(fake_upload_id) in str(exc_info.value)
+
+    async def test_raises_tarball_not_found_for_missing_object(
+        self, async_session_factory
+    ):
+        """TarballNotFoundError is raised when the row is live but the object is gone.
+
+        This is the OSS-9505 failure mode: the object vanished from storage
+        while its upload row survived. Confirmed absence is permanent, so it
+        must be reclassified instead of retrying forever.
+        """
+        from openhands.automation.dispatcher import _download_internal_tarball
+        from openhands.automation.storage import ObjectNotFoundError
+
+        upload_id = await _create_completed_upload(async_session_factory)
+        store = MagicMock()
+        store.read.side_effect = ObjectNotFoundError(
+            f"File not found: {_storage_path(upload_id)}"
+        )
+
+        with patch("openhands.automation.storage.get_file_store", return_value=store):
+            async with async_session_factory() as session:
+                with pytest.raises(TarballNotFoundError) as exc_info:
+                    await _download_internal_tarball(upload_id, session)
+
+        message = str(exc_info.value)
+        assert "missing from storage" in message
+        assert _storage_path(upload_id) in message
+        assert isinstance(exc_info.value.__cause__, ObjectNotFoundError)
+
+    async def test_transient_storage_error_is_not_reclassified(
+        self, async_session_factory
+    ):
+        """A transient storage error must not become a permanent dispatch error.
+
+        The storage layer maps transient S3 failures (5xx, throttling) to plain
+        FileNotFoundError. Reclassifying those would permanently disable a
+        healthy automation during a storage outage; they must propagate
+        unchanged so the run fails and retries on the next tick.
+        """
+        from openhands.automation.dispatcher import _download_internal_tarball
+
+        upload_id = await _create_completed_upload(async_session_factory)
+        store = MagicMock()
+        store.read.side_effect = FileNotFoundError(
+            "S3 read failed (ServiceUnavailable): try again"
+        )
+
+        with patch("openhands.automation.storage.get_file_store", return_value=store):
+            async with async_session_factory() as session:
+                with pytest.raises(FileNotFoundError) as exc_info:
+                    await _download_internal_tarball(upload_id, session)
+
+        assert not isinstance(exc_info.value, TarballNotFoundError)
 
 
 @requires_docker

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -35,6 +35,7 @@ from openhands.automation.git_sync.loop import (
     GIT_SYNC_LAST_COMMIT_KEY,
     GIT_SYNC_LAST_ERROR_AT_KEY,
     GIT_SYNC_LAST_ERROR_KEY,
+    _delete_superseded_upload,
 )
 from openhands.automation.git_sync.serializer import encrypt_file_tree
 from openhands.automation.models import (
@@ -1753,6 +1754,34 @@ class TestTarballUploadLifecycle:
             assert automation.tarball_path != old_path
             old_upload = await session.get(TarballUpload, old_upload_id)
             assert old_upload.deleted_at is not None
+            # The superseded object itself is removed once the cycle commits.
+            with pytest.raises(FileNotFoundError):
+                file_store.read(old_upload.storage_path)
+
+    async def test_superseding_does_not_delete_the_object_before_commit(
+        self, sqlite_session_factory, file_store
+    ):
+        """Superseding an upload must leave its storage object intact.
+
+        The object is only removed after the cycle's commit. Deleting it here
+        meant a rolled-back cycle revived the upload row pointing at an
+        already-destroyed object, permanently breaking dispatch (OSS-9505).
+        """
+        # Arrange
+        automation_id = await _create_internal_automation(
+            sqlite_session_factory, file_store
+        )
+        pending: list[str] = []
+
+        # Act — supersede the upload inside a transaction that never commits.
+        async with sqlite_session_factory() as session:
+            automation = await session.get(Automation, automation_id)
+            upload_id = parse_internal_upload_id(automation.tarball_path)
+            await _delete_superseded_upload(session, automation.tarball_path, pending)
+
+        # Assert — only the path was queued; the object is still readable.
+        assert pending == [f"uploads/test/{upload_id}.tar"]
+        assert file_store.read(pending[0])
 
 
 class TestEnabledKeyWithNullValue:

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -14,6 +14,7 @@ from openhands.automation.models import (
     UploadStatus,
 )
 from openhands.automation.preset_router import _build_storage_path, _generate_tarball
+from openhands.automation.storage import ObjectNotFoundError
 from openhands.automation.utils import utcnow
 from openhands.automation.utils.tarball_validation import (
     build_internal_url,
@@ -1300,6 +1301,94 @@ class TestUpdateAutomation:
         assert response.status_code == 500
         await async_session.refresh(automation)
         assert automation.tarball_path == original_tarball_path
+
+    async def test_update_prompt_transient_storage_error_fails_the_edit(
+        self, async_client, async_session, preset_store
+    ):
+        """A transient storage error during a prompt edit fails the request.
+
+        Previously it was swallowed as "nothing to regenerate": the PATCH
+        returned 200 and updated the prompt column while the tarball kept the
+        old baked prompt, so the automation silently kept running the previous
+        prompt.
+        """
+        # Arrange — reading the current tarball fails transiently (e.g. S3 5xx).
+        automation = await _seed_prompt_preset_automation(
+            async_session, preset_store, "Original prompt"
+        )
+        preset_store.read = MagicMock(
+            side_effect=FileNotFoundError("S3 read failed (ServiceUnavailable)")
+        )
+
+        # Act & Assert — the request fails (rolling back the edit in
+        # production) instead of succeeding with a stale tarball.
+        with pytest.raises(FileNotFoundError):
+            await async_client.patch(
+                f"/api/automation/v1/{automation.id}",
+                json={"prompt": "Updated prompt"},
+            )
+        preset_store.write_stream.assert_not_called()
+
+    async def test_update_prompt_missing_source_tarball_skips_regeneration(
+        self, async_client, async_session, preset_store
+    ):
+        """A confirmed-missing source tarball leaves the tarball untouched.
+
+        Only genuine absence means "not a regenerable preset": the prompt
+        column still updates, but no new upload is written and the automation
+        keeps its existing tarball reference.
+        """
+        # Arrange — the current tarball object is confirmed absent.
+        automation = await _seed_prompt_preset_automation(
+            async_session, preset_store, "Original prompt"
+        )
+        original_tarball_path = automation.tarball_path
+        preset_store.read = MagicMock(side_effect=ObjectNotFoundError("File not found"))
+
+        # Act
+        response = await async_client.patch(
+            f"/api/automation/v1/{automation.id}",
+            json={"prompt": "Updated prompt"},
+        )
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+        assert data["prompt"] == "Updated prompt"
+        assert data["tarball_path"] == original_tarball_path
+        preset_store.write_stream.assert_not_called()
+
+    async def test_failed_update_does_not_delete_current_tarball(
+        self, async_client, async_session, preset_store
+    ):
+        """A request that fails after regeneration keeps the current tarball.
+
+        The superseded object may only be removed once the transaction commits.
+        Deleting it earlier meant a later failure rolled the automation back to
+        a tarball reference whose object was already destroyed, permanently
+        breaking every future dispatch (OSS-9505).
+        """
+        # Arrange — fail the request after the tarball has been regenerated.
+        automation = await _seed_prompt_preset_automation(
+            async_session, preset_store, "Original prompt"
+        )
+        old_upload_id = parse_internal_upload_id(automation.tarball_path)
+        assert old_upload_id is not None
+        old_storage_path = _build_storage_path(TEST_ORG_ID, TEST_USER_ID, old_upload_id)
+
+        # Act
+        with patch(
+            "openhands.automation.router.mark_git_sync_dirty",
+            AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            with pytest.raises(RuntimeError):
+                await async_client.patch(
+                    f"/api/automation/v1/{automation.id}",
+                    json={"prompt": "Updated prompt"},
+                )
+
+        # Assert — the object the automation still points at survives.
+        assert old_storage_path in preset_store._storage
 
     async def test_update_automation_timeout(self, async_client, async_session):
         """Can update automation timeout."""

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -17,6 +17,7 @@ from openhands.automation.storage import (
     FileStore,
     GoogleCloudFileStore,
     LocalFileStore,
+    ObjectNotFoundError,
     S3FileStore,
     get_file_store,
 )
@@ -231,6 +232,44 @@ class TestGoogleCloudFileStore:
             # Verify the path is prefixed
             mock_bucket.blob.assert_called_once_with("automation/test/path.txt")
             mock_blob.delete.assert_called_once()
+
+    def test_read_not_found(self):
+        """Read raises ObjectNotFoundError when the blob doesn't exist."""
+        from google.cloud.exceptions import NotFound
+
+        settings = make_gcs_settings()
+        with patch("openhands.automation.storage.google_cloud.storage") as mock_storage:
+            mock_client = MagicMock()
+            mock_bucket = MagicMock()
+            mock_blob = MagicMock()
+
+            mock_storage.Client.return_value = mock_client
+            mock_client.bucket.return_value = mock_bucket
+            mock_bucket.blob.return_value = mock_blob
+            mock_blob.download_as_bytes.side_effect = NotFound("blob missing")
+
+            store = GoogleCloudFileStore(settings)
+            with pytest.raises(ObjectNotFoundError, match="File not found"):
+                store.read("test/nonexistent.txt")
+
+    def test_delete_not_found(self):
+        """Delete raises ObjectNotFoundError when the blob doesn't exist."""
+        from google.cloud.exceptions import NotFound
+
+        settings = make_gcs_settings()
+        with patch("openhands.automation.storage.google_cloud.storage") as mock_storage:
+            mock_client = MagicMock()
+            mock_bucket = MagicMock()
+            mock_blob = MagicMock()
+
+            mock_storage.Client.return_value = mock_client
+            mock_client.bucket.return_value = mock_bucket
+            mock_bucket.blob.return_value = mock_blob
+            mock_blob.delete.side_effect = NotFound("blob missing")
+
+            store = GoogleCloudFileStore(settings)
+            with pytest.raises(ObjectNotFoundError, match="File not found"):
+                store.delete("test/nonexistent.txt")
 
     def test_emulator_creates_bucket(self):
         """When using emulator, bucket is created if it doesn't exist."""

--- a/tests/test_storage_local.py
+++ b/tests/test_storage_local.py
@@ -12,7 +12,11 @@ from unittest.mock import patch
 import pytest
 
 from openhands.automation.config import StorageSettings, clear_config_cache
-from openhands.automation.storage import LocalFileStore, get_file_store
+from openhands.automation.storage import (
+    LocalFileStore,
+    ObjectNotFoundError,
+    get_file_store,
+)
 from openhands.automation.storage.google_cloud import (
     BUCKET_PREFIX,
     FileSizeLimitExceeded,
@@ -97,10 +101,10 @@ class TestLocalFileStore:
         assert isinstance(result, bytes)
 
     def test_read_not_found(self, tmp_path: Path):
-        """Read raises FileNotFoundError when file doesn't exist."""
+        """Read raises ObjectNotFoundError when file doesn't exist."""
         store = LocalFileStore(tmp_path)
 
-        with pytest.raises(FileNotFoundError, match="File not found"):
+        with pytest.raises(ObjectNotFoundError, match="File not found"):
             store.read("nonexistent.txt")
 
     def test_list_files(self, tmp_path: Path):

--- a/tests/test_storage_s3.py
+++ b/tests/test_storage_s3.py
@@ -13,7 +13,7 @@ import botocore.exceptions
 import pytest
 
 from openhands.automation.config import StorageSettings
-from openhands.automation.storage import S3FileStore
+from openhands.automation.storage import ObjectNotFoundError, S3FileStore
 from openhands.automation.storage.google_cloud import (
     BUCKET_PREFIX,
     FileSizeLimitExceeded,
@@ -113,7 +113,7 @@ class TestS3FileStore:
             )
 
     def test_read_not_found(self):
-        """Read raises FileNotFoundError when key doesn't exist."""
+        """Read raises ObjectNotFoundError when key doesn't exist."""
         settings = make_s3_settings()
         with patch("openhands.automation.storage.s3.boto3") as mock_boto3:
             mock_client = MagicMock()
@@ -124,8 +124,29 @@ class TestS3FileStore:
             mock_boto3.client.return_value = mock_client
 
             store = S3FileStore(settings)
-            with pytest.raises(FileNotFoundError, match="File not found"):
+            with pytest.raises(ObjectNotFoundError, match="File not found"):
                 store.read("test/nonexistent.txt")
+
+    def test_read_transient_error_is_not_object_not_found(self):
+        """A transient S3 error must not be reported as a confirmed absence.
+
+        Callers treat ObjectNotFoundError as permanent (e.g. the dispatcher
+        disables the automation), so a 5xx from a flapping backend must stay a
+        plain FileNotFoundError.
+        """
+        settings = make_s3_settings()
+        with patch("openhands.automation.storage.s3.boto3") as mock_boto3:
+            mock_client = MagicMock()
+            error_response = {"Error": {"Code": "ServiceUnavailable"}}
+            mock_client.get_object.side_effect = botocore.exceptions.ClientError(
+                error_response, "GetObject"
+            )
+            mock_boto3.client.return_value = mock_client
+
+            store = S3FileStore(settings)
+            with pytest.raises(FileNotFoundError) as exc_info:
+                store.read("test/path.txt")
+            assert not isinstance(exc_info.value, ObjectNotFoundError)
 
     def test_list(self):
         """List files under a prefix, with automation prefix added and stripped."""
@@ -179,7 +200,7 @@ class TestS3FileStore:
             )
 
     def test_delete_not_found(self):
-        """Delete raises FileNotFoundError when key doesn't exist."""
+        """Delete raises ObjectNotFoundError when key doesn't exist."""
         settings = make_s3_settings()
         with patch("openhands.automation.storage.s3.boto3") as mock_boto3:
             mock_client = MagicMock()
@@ -190,7 +211,7 @@ class TestS3FileStore:
             mock_boto3.client.return_value = mock_client
 
             store = S3FileStore(settings)
-            with pytest.raises(FileNotFoundError, match="File not found"):
+            with pytest.raises(ObjectNotFoundError, match="File not found"):
                 store.delete("test/nonexistent.txt")
 
     def test_endpoint_creates_bucket_when_auto_create_enabled(self):

--- a/tests/test_storage_s3_integration.py
+++ b/tests/test_storage_s3_integration.py
@@ -16,7 +16,7 @@ import pytest
 from testcontainers.minio import MinioContainer
 
 from openhands.automation.config import StorageSettings
-from openhands.automation.storage import S3FileStore
+from openhands.automation.storage import ObjectNotFoundError, S3FileStore
 from openhands.automation.storage.google_cloud import FileSizeLimitExceeded
 
 
@@ -107,8 +107,8 @@ class TestS3FileStoreIntegration:
         assert result == b"new content"
 
     def test_read_nonexistent_file(self, s3_store):
-        """Reading non-existent file raises FileNotFoundError."""
-        with pytest.raises(FileNotFoundError):
+        """Reading non-existent file raises ObjectNotFoundError."""
+        with pytest.raises(ObjectNotFoundError):
             s3_store.read("test/nonexistent.txt")
 
     def test_delete_file(self, s3_store):
@@ -122,8 +122,8 @@ class TestS3FileStoreIntegration:
             s3_store.read(test_path)
 
     def test_delete_nonexistent_file(self, s3_store):
-        """Deleting non-existent file raises FileNotFoundError."""
-        with pytest.raises(FileNotFoundError):
+        """Deleting non-existent file raises ObjectNotFoundError."""
+        with pytest.raises(ObjectNotFoundError):
             s3_store.delete("test/never_existed.txt")
 
     def test_list_files(self, s3_store):


### PR DESCRIPTION
## Summary

Automation "run now" failing with an opaque `Internal error` that repeated on every schedule tick because the automation's tarball object was missing from MinIO while its `TarballUpload` row survived. This lands fix (2) from the issue in its narrowed form and fix (1) at both delete-before-commit sites; fix (3) (MinIO durability) is infra-side and not part of this repo.

Supersedes the draft #336, which caught bare `FileNotFoundError` and is marked "do not merge as-is" for the over-trigger described below.

## The bug

Two independent defects, both verified against `main`:

1. **A missing tarball object was treated as transient, opaquely.** `_download_internal_tarball` already raises `TarballNotFoundError` when the upload _row_ is missing, but the subsequent `store.read(...)` was unguarded. A missing _object_ surfaced as plain `FileNotFoundError`, sailed past the `except PermanentDispatchError` handler in dispatch step 4, and landed in `_execute_run_safe`: the run was marked FAILED with the literal string `"Internal error"` and the automation stayed enabled, re-failing forever (12 and 16 consecutive failures for the two affected C24 automations).
   Catching bare `FileNotFoundError` is not a safe fix: `s3.py::_handle_client_error` maps **every** `ClientError` to `FileNotFoundError` — `NoSuchBucket`, `AccessDenied`, and a catch-all covering 5xx / `SlowDown` / expired credentials. On C24's OOM-crash-looping MinIO, a read landing during a restart would permanently disable a healthy automation.
2. **Superseded tarball objects were deleted before the transaction committed.** Both `regenerate_preset_prompt_tarball` (prompt edits) and the git-sync import's `_delete_superseded_upload` destroyed the old storage object and then soft-deleted its row inside a transaction that commits later. Any post-delete rollback reverted the soft-delete and the `tarball_path` update but not the storage delete, leaving a live `COMPLETED` upload row and an automation pointing at an object that no longer exists — exactly the failure state in (1). A related latent bug: `except FileNotFoundError: return None` around the regeneration read meant a _transient_ storage error during a prompt edit returned HTTP 200 with the `prompt` column updated while the tarball silently kept the old baked prompt.

## The fix

**Storage layer** — new `ObjectNotFoundError(FileNotFoundError)`, raised only at confirmed-absence sites: the S3 `404`/`NoSuchKey` branch, the local store's missing file, and both GCS `NotFound` handlers. All other storage errors keep raising plain `FileNotFoundError`, and the seven existing `except FileNotFoundError` handlers keep working unchanged via the parent class.

**Dispatcher** — the tarball read catches `ObjectNotFoundError` and re-raises it as `TarballNotFoundError` (already a `PermanentDispatchError`): the run fails with an `error_detail` naming the missing storage path and the remedy, and the automation is disabled instead of retrying a permanently unreadable object. Transient storage errors keep today's behavior (fail, stay enabled, retry).

**Prompt edits** — the superseded row is soft-deleted in-transaction; the object delete moves to a FastAPI background task. `update_automation` declares `Depends(get_session, scope="function")`: with the default request scope, background tasks run _before_ the dependency-teardown commit (verified against FastAPI 0.136 / Starlette sources), which would reintroduce the bug. Function scope makes the order handler → commit → response → delete, and a commit failure means the delete never runs. The regeneration guard is narrowed to `ObjectNotFoundError`, so a transient storage error now fails the edit (500, rollback) instead of silently keeping the old prompt.

**Git sync** — `_delete_superseded_upload` becomes soft-delete-and-queue; a per-directory savepoint rollback discards its queued entries; the queue is drained best-effort only after the cycle's import commit succeeds.

In both deferred paths the worst case (a crash between commit and delete) leaks an orphaned object whose row is already soft-deleted — recoverable and identifiable, unlike the previous worst case of destroying an object a live row still points at.

## Tests

Nine new tests plus five tightened assertions, all extending existing files. Verified to fail with the source changes selectively reverted (the one exception, `test_transient_storage_error_is_not_reclassified`, guards against the #336-style over-broad fix rather than against `main`):

- `test_storage_s3.py` — `NoSuchKey`/`404` now assert `ObjectNotFoundError`; new test pins that a transient `ServiceUnavailable` error is **not** `ObjectNotFoundError`.
- `test_storage_local.py`, `test_storage.py` (GCS mocks), `test_storage_s3_integration.py` (real MinIO) — confirmed-absence sites assert `ObjectNotFoundError`.
- `test_disable_automation.py` — live `COMPLETED` row with a missing object raises `TarballNotFoundError` (cause chained); a transient storage error propagates unreclassified.
- `test_router.py` — a request failing after regeneration leaves the current tarball object intact; a transient storage error fails the edit instead of silently succeeding; a confirmed-missing source tarball still skips regeneration with a 200.
- `test_git_sync.py` — superseding an upload leaves its object intact until the cycle commits; the lifecycle test now also asserts the object is removed after a successful cycle.

## Validation

- `uv run pre-commit run --all-files` — ruff format, ruff lint, pycodestyle, pyright all pass.
- `uv run python -m pytest tests/` (Docker up, so the Postgres/MinIO testcontainer suites run): **1333 passed, 1 failed** — the failure (`test_create_automation_shares_template_identity_with_presets`, a telemetry distinct-id assertion) reproduces identically on clean `main` and is unrelated to this change.