### PR TITLE
refactor: extract a transport-neutral accept_event() from the webhook handler

### DIFF
--- a/openhands/automation/event_router.py
+++ b/openhands/automation/event_router.py
@@ -43,16 +43,14 @@ from openhands.automation.event_schemas.github import (
     get_event_detection_rules,
     get_supported_event_types,
 )
+from openhands.automation.ingest import AcceptedEvent, accept_event
 from openhands.automation.schemas import (
     EventDetectionRule,
     EventResponse,
     RequestedEventTypesResponse,
 )
 from openhands.automation.telemetry import capture_automation_event
-from openhands.automation.trigger_matcher import matches_trigger
 from openhands.automation.utils.webhook import (
-    create_automation_run,
-    get_event_automations,
     get_requested_event_types,
     get_webhook_config,
     verify_signature,
@@ -243,72 +241,22 @@ async def receive_event(
         },
     )
 
-    # 6. Find matching automations
-    automations = await get_event_automations(org_id, source, session)
-    matched_automations = []
-
-    for automation, trigger in automations:
-        # Match trigger against webhook payload using JMESPath filter
-        if matches_trigger(trigger, source, event.event_key, webhook_payload):
-            matched_automations.append(automation)
-
-    logger.info(
-        "Event matched %d/%d automations for org=%s",
-        len(matched_automations),
-        len(automations),
+    # 6. Hand the authenticated, interpreted event to the transport-neutral
+    #    ingestion path, which matches triggers and creates the runs.
+    result = await accept_event(
         org_id,
-    )
-    await capture_automation_event(
-        "automation_event_matched",
+        AcceptedEvent(
+            source=source,
+            event_key=event.event_key,
+            payload=webhook_payload,
+            parsed_event=event if isinstance(event, BaseModel) else None,
+        ),
+        session,
         request=request,
-        properties={
-            "event_source": source,
-            "event_key": event.event_key,
-            "org_id": str(org_id),
-            "candidate_count": len(automations),
-            "matched_count": len(matched_automations),
-        },
     )
-
-    # 7. Create PENDING runs for matched automations
-    # For Pydantic-parsed events (GitHub), use model_dump() for typed fields
-    # For custom webhooks, use the webhook payload directly
-    event_payload = (
-        event.model_dump(mode="json")
-        if isinstance(event, BaseModel)
-        else webhook_payload
-    )
-
-    run_ids: list[str] = []
-    for automation in matched_automations:
-        run = await create_automation_run(
-            automation, session, event_payload=event_payload
-        )
-        run_ids.append(str(run.id))
-        run_properties = {
-            "trigger_source": "event",
-            "event_source": source,
-            "event_key": event.event_key,
-        }
-        await capture_automation_event(
-            "automation_run_scheduled",
-            request=request,
-            automation=automation,
-            run=run,
-            properties=run_properties,
-        )
-        await capture_automation_event(
-            "automation_run_created",
-            request=request,
-            automation=automation,
-            run=run,
-            properties=run_properties,
-        )
-
-    await session.commit()
 
     return EventResponse(
         received=True,
-        matched=len(matched_automations),
-        runs_created=run_ids,
+        matched=result.matched,
+        runs_created=result.run_ids,
     )

--- a/openhands/automation/event_router.py
+++ b/openhands/automation/event_router.py
@@ -241,8 +241,7 @@ async def receive_event(
         },
     )
 
-    # 6. Hand the authenticated, interpreted event to the transport-neutral
-    #    ingestion path, which matches triggers and creates the runs.
+    # 6. Match triggers and create runs (transport-neutral)
     result = await accept_event(
         org_id,
         AcceptedEvent(

--- a/openhands/automation/ingest.py
+++ b/openhands/automation/ingest.py
@@ -1,22 +1,8 @@
-"""
-Transport-neutral event ingestion.
+"""Transport-neutral event ingestion.
 
-`accept_event()` is the boundary between *how an event arrived* and *what the
-service does with it*. Everything above the boundary — reading bytes, proving
-the event is genuine, turning a provider payload into an ``event_key`` — belongs
-to the transport. Everything below it — finding the org's event automations,
-matching triggers, creating PENDING runs — is identical for every transport and
-lives here.
-
-Authentication is deliberately **not** part of this module. HTTP proves
-authenticity with an HMAC over the raw body; a Socket Mode connection proves it
-by possession of an app-level token over TLS; a poller proves it by having made
-the outbound call itself. `accept_event()` receives an already-authenticated
-event and never asks how it was authenticated. Without that rule, every
-non-HTTP transport is tempted to manufacture a signature to satisfy a check that
-does not apply to it.
-
-The only caller today is the webhook handler in `event_router.py`.
+`accept_event()` separates how an event arrived from what the service does with
+it. Transports own acquisition, authentication and interpretation; trigger
+matching and run creation live here and are shared by every transport.
 """
 
 import logging
@@ -40,40 +26,29 @@ from openhands.automation.utils.webhook import (
 logger = logging.getLogger("automation.ingest")
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class EventSubject:
-    """The external thing an event is about (a Slack thread, a pull request).
-
-    Reserved for subject -> conversation routing; nothing populates or reads it
-    yet. `key` is the value that will be stored as `subject_key`.
-    """
+    """The external thing an event is about. Reserved; nothing reads it yet."""
 
     key: str
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class AcceptedEvent:
-    """An authenticated, interpreted event, ready to be routed.
-
-    The transport owns everything that produces one of these: acquiring the
-    bytes, proving they are genuine, and deriving `event_key`.
-    """
+    """An authenticated, interpreted event, ready to be routed."""
 
     source: str
     event_key: str
-    # Raw provider payload. JMESPath trigger filters run against this.
+    # Raw provider payload; JMESPath trigger filters run on this.
     payload: dict[str, Any] = field(default_factory=dict)
     provider_event_id: str | None = None
     subject: EventSubject | None = None
     occurred_at: datetime | None = None
-    # Optional typed event, when the transport parsed the payload into a
-    # Pydantic model (the webhook handler does this via `parse_event()`). When
-    # present it — not `payload` — is what gets persisted as the run's
-    # `event_payload`, preserving the shape existing automations already see.
+    # When set, persisted as the run's event_payload in place of `payload`.
     parsed_event: BaseModel | None = None
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class AcceptResult:
     """The outcome of routing an accepted event."""
 
@@ -89,29 +64,18 @@ async def accept_event(
     *,
     request: Request | None = None,
 ) -> AcceptResult:
-    """
-    Route an already-authenticated event to the org's matching automations.
+    """Route an already-authenticated event to the org's matching automations.
 
-    Args:
-        org_id: The organization the event belongs to
-        event: The authenticated, interpreted event
-        session: Database session (committed before returning)
-        request: Originating HTTP request, for telemetry only. Non-HTTP
-                 transports omit it; every telemetry event still fires.
-
-    Returns:
-        AcceptResult with the number of matched automations and the IDs of the
-        runs created for them.
+    Commits before returning. `request` is telemetry only; non-HTTP transports
+    omit it and every telemetry event still fires.
     """
     source = event.source
     webhook_payload = event.payload
 
-    # 1. Find matching automations
     automations = await get_event_automations(org_id, source, session)
     matched_automations = []
 
     for automation, trigger in automations:
-        # Match trigger against webhook payload using JMESPath filter
         if matches_trigger(trigger, source, event.event_key, webhook_payload):
             matched_automations.append(automation)
 
@@ -133,9 +97,7 @@ async def accept_event(
         },
     )
 
-    # 2. Create PENDING runs for matched automations
-    # For Pydantic-parsed events (GitHub), use model_dump() for typed fields
-    # For custom webhooks, use the webhook payload directly
+    # Typed events (GitHub) keep their model shape; others store the payload.
     event_payload = (
         event.parsed_event.model_dump(mode="json")
         if isinstance(event.parsed_event, BaseModel)

--- a/openhands/automation/ingest.py
+++ b/openhands/automation/ingest.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from fastapi import Request
 from pydantic import BaseModel
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from openhands.automation.telemetry import capture_automation_event
 from openhands.automation.trigger_matcher import matches_trigger
@@ -63,11 +63,19 @@ async def accept_event(
     session: AsyncSession,
     *,
     request: Request | None = None,
+    session_factory: async_sessionmaker[AsyncSession] | None = None,
 ) -> AcceptResult:
     """Route an already-authenticated event to the org's matching automations.
 
-    Commits before returning. `request` is telemetry only; non-HTTP transports
-    omit it and every telemetry event still fires.
+    Commits before returning.
+
+    `request` and `session_factory` are both telemetry plumbing. Telemetry
+    resolves its distinct id from the database, and HTTP callers supply that
+    reader indirectly as `request.app.state.session_factory`; a caller that
+    passes neither drops every event silently. So non-HTTP transports must pass
+    `session_factory`. It is deliberately not `session`: telemetry writes its id
+    row, and sharing this session would move that write into the caller's
+    transaction.
     """
     source = event.source
     webhook_payload = event.payload
@@ -88,6 +96,7 @@ async def accept_event(
     await capture_automation_event(
         "automation_event_matched",
         request=request,
+        session_factory=session_factory,
         properties={
             "event_source": source,
             "event_key": event.event_key,
@@ -118,6 +127,7 @@ async def accept_event(
         await capture_automation_event(
             "automation_run_scheduled",
             request=request,
+            session_factory=session_factory,
             automation=automation,
             run=run,
             properties=run_properties,
@@ -125,6 +135,7 @@ async def accept_event(
         await capture_automation_event(
             "automation_run_created",
             request=request,
+            session_factory=session_factory,
             automation=automation,
             run=run,
             properties=run_properties,

--- a/openhands/automation/ingest.py
+++ b/openhands/automation/ingest.py
@@ -1,0 +1,176 @@
+"""
+Transport-neutral event ingestion.
+
+`accept_event()` is the boundary between *how an event arrived* and *what the
+service does with it*. Everything above the boundary — reading bytes, proving
+the event is genuine, turning a provider payload into an ``event_key`` — belongs
+to the transport. Everything below it — finding the org's event automations,
+matching triggers, creating PENDING runs — is identical for every transport and
+lives here.
+
+Authentication is deliberately **not** part of this module. HTTP proves
+authenticity with an HMAC over the raw body; a Socket Mode connection proves it
+by possession of an app-level token over TLS; a poller proves it by having made
+the outbound call itself. `accept_event()` receives an already-authenticated
+event and never asks how it was authenticated. Without that rule, every
+non-HTTP transport is tempted to manufacture a signature to satisfy a check that
+does not apply to it.
+
+The only caller today is the webhook handler in `event_router.py`.
+"""
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from fastapi import Request
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from openhands.automation.telemetry import capture_automation_event
+from openhands.automation.trigger_matcher import matches_trigger
+from openhands.automation.utils.webhook import (
+    create_automation_run,
+    get_event_automations,
+)
+
+
+logger = logging.getLogger("automation.ingest")
+
+
+@dataclass
+class EventSubject:
+    """The external thing an event is about (a Slack thread, a pull request).
+
+    Reserved for subject -> conversation routing; nothing populates or reads it
+    yet. `key` is the value that will be stored as `subject_key`.
+    """
+
+    key: str
+
+
+@dataclass
+class AcceptedEvent:
+    """An authenticated, interpreted event, ready to be routed.
+
+    The transport owns everything that produces one of these: acquiring the
+    bytes, proving they are genuine, and deriving `event_key`.
+    """
+
+    source: str
+    event_key: str
+    # Raw provider payload. JMESPath trigger filters run against this.
+    payload: dict[str, Any] = field(default_factory=dict)
+    provider_event_id: str | None = None
+    subject: EventSubject | None = None
+    occurred_at: datetime | None = None
+    # Optional typed event, when the transport parsed the payload into a
+    # Pydantic model (the webhook handler does this via `parse_event()`). When
+    # present it — not `payload` — is what gets persisted as the run's
+    # `event_payload`, preserving the shape existing automations already see.
+    parsed_event: BaseModel | None = None
+
+
+@dataclass
+class AcceptResult:
+    """The outcome of routing an accepted event."""
+
+    matched: int
+    run_ids: list[str]
+    duplicate: bool = False
+
+
+async def accept_event(
+    org_id: uuid.UUID,
+    event: AcceptedEvent,
+    session: AsyncSession,
+    *,
+    request: Request | None = None,
+) -> AcceptResult:
+    """
+    Route an already-authenticated event to the org's matching automations.
+
+    Args:
+        org_id: The organization the event belongs to
+        event: The authenticated, interpreted event
+        session: Database session (committed before returning)
+        request: Originating HTTP request, for telemetry only. Non-HTTP
+                 transports omit it; every telemetry event still fires.
+
+    Returns:
+        AcceptResult with the number of matched automations and the IDs of the
+        runs created for them.
+    """
+    source = event.source
+    webhook_payload = event.payload
+
+    # 1. Find matching automations
+    automations = await get_event_automations(org_id, source, session)
+    matched_automations = []
+
+    for automation, trigger in automations:
+        # Match trigger against webhook payload using JMESPath filter
+        if matches_trigger(trigger, source, event.event_key, webhook_payload):
+            matched_automations.append(automation)
+
+    logger.info(
+        "Event matched %d/%d automations for org=%s",
+        len(matched_automations),
+        len(automations),
+        org_id,
+    )
+    await capture_automation_event(
+        "automation_event_matched",
+        request=request,
+        properties={
+            "event_source": source,
+            "event_key": event.event_key,
+            "org_id": str(org_id),
+            "candidate_count": len(automations),
+            "matched_count": len(matched_automations),
+        },
+    )
+
+    # 2. Create PENDING runs for matched automations
+    # For Pydantic-parsed events (GitHub), use model_dump() for typed fields
+    # For custom webhooks, use the webhook payload directly
+    event_payload = (
+        event.parsed_event.model_dump(mode="json")
+        if isinstance(event.parsed_event, BaseModel)
+        else webhook_payload
+    )
+
+    run_ids: list[str] = []
+    for automation in matched_automations:
+        run = await create_automation_run(
+            automation, session, event_payload=event_payload
+        )
+        run_ids.append(str(run.id))
+        run_properties = {
+            "trigger_source": "event",
+            "event_source": source,
+            "event_key": event.event_key,
+        }
+        await capture_automation_event(
+            "automation_run_scheduled",
+            request=request,
+            automation=automation,
+            run=run,
+            properties=run_properties,
+        )
+        await capture_automation_event(
+            "automation_run_created",
+            request=request,
+            automation=automation,
+            run=run,
+            properties=run_properties,
+        )
+
+    await session.commit()
+
+    return AcceptResult(
+        matched=len(matched_automations),
+        run_ids=run_ids,
+    )

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -6,11 +6,14 @@ FastAPI app — which is the point of the seam.
 
 import uuid
 from datetime import UTC, datetime
+from typing import Any
 
 import pytest
 from sqlalchemy import select
 
+from openhands.automation import telemetry
 from openhands.automation.auth import AuthenticatedUser
+from openhands.automation.config import clear_config_cache
 from openhands.automation.event_schemas import parse_event
 from openhands.automation.ingest import (
     AcceptedEvent,
@@ -86,6 +89,37 @@ async def fetch_runs(session) -> list[AutomationRun]:
     """Return every run in the database."""
     result = await session.execute(select(AutomationRun))
     return list(result.scalars().all())
+
+
+@pytest.fixture
+def captured_telemetry(monkeypatch: pytest.MonkeyPatch):
+    """Record the events telemetry would POST instead of sending them."""
+    monkeypatch.setenv("AUTOMATION_POSTHOG_API_KEY", "phc-test-key")
+    clear_config_cache()
+
+    events: list[str] = []
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def __aenter__(self) -> "FakeClient":
+            return self
+
+        async def __aexit__(self, *args) -> bool:
+            return False
+
+        async def post(self, url: str, *, json: dict[str, Any]) -> FakeResponse:
+            events.append(str(json["event"]))
+            return FakeResponse()
+
+    monkeypatch.setattr(telemetry.httpx, "AsyncClient", FakeClient)
+    yield events
+    clear_config_cache()
 
 
 @pytest.mark.asyncio
@@ -463,6 +497,80 @@ async def test_accept_event_reserved_fields_are_ignored(
     runs = await fetch_runs(async_session)
     assert len(runs) == 1
     assert runs[0].event_payload == slack_payload
+
+
+@pytest.mark.asyncio
+async def test_accept_event_emits_telemetry_without_a_request(
+    org_id: uuid.UUID,
+    async_session,
+    async_session_factory,
+    slack_payload: dict,
+    mock_authenticated_user,
+    captured_telemetry: list[str],
+):
+    """A non-HTTP caller gets the full telemetry sequence via session_factory."""
+    async_session.add(
+        make_automation(
+            org_id,
+            mock_authenticated_user.user_id,
+            {"type": "event", "source": "slack", "on": "app_mention"},
+        )
+    )
+    await async_session.commit()
+
+    result = await accept_event(
+        org_id,
+        AcceptedEvent(
+            source="slack",
+            event_key="app_mention",
+            payload=slack_payload,
+        ),
+        async_session,
+        session_factory=async_session_factory,
+    )
+
+    assert result.matched == 1
+    assert captured_telemetry == [
+        "automation_event_matched",
+        "automation_run_scheduled",
+        "automation_run_created",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_accept_event_telemetry_needs_a_session_source(
+    org_id: uuid.UUID,
+    async_session,
+    slack_payload: dict,
+    mock_authenticated_user,
+    captured_telemetry: list[str],
+):
+    """Neither a request nor a session_factory: telemetry is silently dropped.
+
+    Routing still works, which is why this is easy to miss. Pins the reason
+    `session_factory` exists on the signature.
+    """
+    async_session.add(
+        make_automation(
+            org_id,
+            mock_authenticated_user.user_id,
+            {"type": "event", "source": "slack", "on": "app_mention"},
+        )
+    )
+    await async_session.commit()
+
+    result = await accept_event(
+        org_id,
+        AcceptedEvent(
+            source="slack",
+            event_key="app_mention",
+            payload=slack_payload,
+        ),
+        async_session,
+    )
+
+    assert result.matched == 1
+    assert captured_telemetry == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,488 @@
+"""Direct unit tests for the transport-neutral ingestion seam.
+
+Every test here constructs an `AcceptedEvent` by hand and calls `accept_event()`
+without going through HTTP — no request, no signature, no FastAPI app. That is
+the point of the seam: a non-HTTP transport can reach trigger matching and run
+creation without faking a request.
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import select
+
+from openhands.automation.auth import AuthenticatedUser
+from openhands.automation.event_schemas import parse_event
+from openhands.automation.ingest import (
+    AcceptedEvent,
+    AcceptResult,
+    EventSubject,
+    accept_event,
+)
+from openhands.automation.models import Automation, AutomationRun, AutomationRunStatus
+
+
+@pytest.fixture
+def org_id(mock_authenticated_user: AuthenticatedUser) -> uuid.UUID:
+    """Get org_id from authenticated user fixture."""
+    return mock_authenticated_user.org_id
+
+
+@pytest.fixture
+def slack_payload() -> dict:
+    """A Slack app_mention envelope, as a socket transport would receive it."""
+    return {
+        "type": "app_mention",
+        "team_id": "T06P212QSEA",
+        "channel": "C123",
+        "user": "U456",
+        "text": "<@U999> please take a look",
+        "ts": "1755000000.000100",
+    }
+
+
+@pytest.fixture
+def github_push_payload() -> dict:
+    """Sample GitHub push webhook payload (the inner payload, already unwrapped)."""
+    return {
+        "ref": "refs/heads/main",
+        "before": "abc123",
+        "after": "def456",
+        "commits": [
+            {
+                "id": "def456",
+                "message": "Test commit",
+                "author": {"name": "Test", "email": "test@example.com"},
+            }
+        ],
+        "repository": {
+            "id": 123,
+            "name": "test-repo",
+            "full_name": "org/test-repo",
+            "private": False,
+        },
+        "sender": {"id": 1, "login": "testuser"},
+    }
+
+
+def make_automation(
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    trigger: dict,
+    name: str = "Test Automation",
+) -> Automation:
+    """Build an event-triggered automation."""
+    return Automation(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        org_id=org_id,
+        name=name,
+        tarball_path="oh-internal://uploads/test.tar.gz",
+        entrypoint="python main.py",
+        trigger=trigger,
+    )
+
+
+async def fetch_runs(session) -> list[AutomationRun]:
+    """Return every run in the database."""
+    result = await session.execute(select(AutomationRun))
+    return list(result.scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_accept_event_no_automations(
+    org_id: uuid.UUID,
+    async_session,
+    slack_payload: dict,
+):
+    """With no automations configured, nothing matches and nothing is created."""
+    result = await accept_event(
+        org_id,
+        AcceptedEvent(
+            source="slack",
+            event_key="app_mention",
+            payload=slack_payload,
+        ),
+        async_session,
+    )
+
+    assert isinstance(result, AcceptResult)
+    assert result.matched == 0
+    assert result.run_ids == []
+    assert result.duplicate is False
+    assert await fetch_runs(async_session) == []
+
+
+@pytest.mark.asyncio
+async def test_accept_event_matching_automation_creates_run(
+    org_id: uuid.UUID,
+    async_session,
+    slack_payload: dict,
+    mock_authenticated_user,
+):
+    """A matching trigger produces one PENDING run, with no HTTP involved."""
+    automation = make_automation(
+        org_id,
+        mock_authenticated_user.user_id,
+        {"type": "event", "source": "slack", "on": "app_mention"},
+    )
+    async_session.add(automation)
+    await async_session.commit()
+
+    result = await accept_event(
+        org_id,
+        AcceptedEvent(
+            source="slack",
+            event_key="app_mention",
+            payload=slack_payload,
+        ),
+        async_session,
+    )
+
+    assert result.matched == 1
+    assert len(result.run_ids) == 1
+
+    runs = await fetch_runs(async_session)
+    assert len(runs) == 1
+    run = runs[0]
+    assert str(run.id) == result.run_ids[0]
+    assert run.automation_id == automation.id
+    assert run.status == AutomationRunStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_accept_event_without_parsed_event_stores_raw_payload(
+    org_id: uuid.UUID,
+    async_session,
+    slack_payload: dict,
+    mock_authenticated_user,
+):
+    """A transport that has no typed model gets its raw payload on the run."""
+    async_session.add(
+        make_automation(
+            org_id,
+            mock_authenticated_user.user_id,
+            {"type": "event", "source": "slack", "on": "app_mention"},
+        )
+    )
+    await async_session.commit()
+
+    await accept_event(
+        org_id,
+        AcceptedEvent(
+            source="slack",
+            event_key="app_mention",
+            payload=slack_payload,
+        ),
+        async_session,
+    )
+
+    runs = await fetch_runs(async_session)
+    assert runs[0].event_payload == slack_payload
+
+
+@pytest.mark.asyncio
+async def test_accept_event_with_parsed_event_stores_model_dump(
+    org_id: uuid.UUID,
+    async_session,
+    github_push_payload: dict,
+    mock_authenticated_user,
+):
+    """When the transport parsed a typed event, that model_dump is persisted.
+
+    This pins the subtle behaviour the webhook handler had before the split:
+    Pydantic-parsed events (GitHub) store `model_dump(mode="json")`, not the
+    raw provider payload.
+    """
+    async_session.add(
+        make_automation(
+            org_id,
+            mock_authenticated_user.user_id,
+            {"type": "event", "source": "github", "on": "push"},
+        )
+    )
+    await async_session.commit()
+
+    parsed = parse_event("github", github_push_payload)
+
+    await accept_event(
+        org_id,
+        AcceptedEvent(
+            source="github",
+            event_key=parsed.event_key,
+            payload=github_push_payload,
+            parsed_event=parsed,
+        ),
+        async_session,
+    )
+
+    runs = await fetch_runs(async_session)
+    assert runs[0].event_payload == parsed.model_dump(mode="json")
+    assert runs[0].event_payload != github_push_payload
+
+
+@pytest.mark.asyncio
+async def test_accept_event_filter_runs_against_raw_payload(
+    org_id: uuid.UUID,
+    async_session,
+    slack_payload: dict,
+    mock_authenticated_user,
+):
+    """JMESPath filters are evaluated against `AcceptedEvent.payload`."""
+    async_session.add(
+        make_automation(
+            org_id,
+            mock_authenticated_user.user_id,
+            {
+                "type": "event",
+                "source": "slack",
+                "on": "app_mention",
+                "filter": "team_id == 'T06P212QSEA'",
+            },
+            name="Matching filter",
+        )
+    )
+    async_session.add(
+        make_automation(
+            org_id,
+            mock_authenticated_user.user_id,
+            {
+                "type": "event",
+                "source": "slack",
+                "on": "app_mention",
+                "filter": "team_id == 'T_OTHER'",
+            },
+            name="Non-matching filter",
+        )
+    )
+    await async_session.commit()
+
+    result = await accept_event(
+        org_id,
+        AcceptedEvent(
+            source="slack",
+            event_key="app_mention",
+            payload=slack_payload,
+        ),
+        async_session,
+    )
+
+    assert result.matched == 1
+    assert len(result.run_ids) == 1
+
+
+@pytest.mark.asyncio
+async def test_accept_event_event_key_mismatch(
+    org_id: uuid.UUID,
+    async_session,
+    slack_payload: dict,
+    mock_authenticated_user,
+):
+    """An automation listening for a different event key does not match."""
+    async_session.add(
+        make_automation(
+            org_id,
+            mock_authenticated_user.user_id,
+            {"type": "event", "source": "slack", "on": "message"},
+        )
+    )
+    await async_session.commit()
+
+    result = await accept_event(
+        org_id,
+        AcceptedEvent(
+            source="slack",
+            event_key="app_mention",
+            payload=slack_payload,
+        ),
+        async_session,
+    )
+
+    assert result.matched == 0
+    assert result.run_ids == []
+    assert await fetch_runs(async_session) == []
+
+
+@pytest.mark.asyncio
+async def test_accept_event_other_source_not_matched(
+    org_id: uuid.UUID,
+    async_session,
+    slack_payload: dict,
+    mock_authenticated_user,
+):
+    """Automations for a different source are never candidates."""
+    async_session.add(
+        make_automation(
+            org_id,
+            mock_authenticated_user.user_id,
+            {"type": "event", "source": "github", "on": "push"},
+        )
+    )
+    await async_session.commit()
+
+    result = await accept_event(
+        org_id,
+        AcceptedEvent(
+            source="slack",
+            event_key="app_mention",
+            payload=slack_payload,
+        ),
+        async_session,
+    )
+
+    assert result.matched == 0
+    assert result.run_ids == []
+
+
+@pytest.mark.asyncio
+async def test_accept_event_other_org_not_matched(
+    org_id: uuid.UUID,
+    async_session,
+    slack_payload: dict,
+    mock_authenticated_user,
+):
+    """Automations belonging to another org are never candidates."""
+    async_session.add(
+        make_automation(
+            uuid.uuid4(),
+            mock_authenticated_user.user_id,
+            {"type": "event", "source": "slack", "on": "app_mention"},
+        )
+    )
+    await async_session.commit()
+
+    result = await accept_event(
+        org_id,
+        AcceptedEvent(
+            source="slack",
+            event_key="app_mention",
+            payload=slack_payload,
+        ),
+        async_session,
+    )
+
+    assert result.matched == 0
+    assert result.run_ids == []
+
+
+@pytest.mark.asyncio
+async def test_accept_event_creates_a_run_per_matched_automation(
+    org_id: uuid.UUID,
+    async_session,
+    slack_payload: dict,
+    mock_authenticated_user,
+):
+    """Every matching automation gets its own run."""
+    for i in range(3):
+        async_session.add(
+            make_automation(
+                org_id,
+                mock_authenticated_user.user_id,
+                {"type": "event", "source": "slack", "on": "app_mention"},
+                name=f"Automation {i}",
+            )
+        )
+    await async_session.commit()
+
+    result = await accept_event(
+        org_id,
+        AcceptedEvent(
+            source="slack",
+            event_key="app_mention",
+            payload=slack_payload,
+        ),
+        async_session,
+    )
+
+    assert result.matched == 3
+    assert len(set(result.run_ids)) == 3
+    assert len(await fetch_runs(async_session)) == 3
+
+
+@pytest.mark.asyncio
+async def test_accept_event_commits_runs(
+    org_id: uuid.UUID,
+    async_session_factory,
+    async_session,
+    slack_payload: dict,
+    mock_authenticated_user,
+):
+    """Runs are committed, so a separate session can see them."""
+    async_session.add(
+        make_automation(
+            org_id,
+            mock_authenticated_user.user_id,
+            {"type": "event", "source": "slack", "on": "app_mention"},
+        )
+    )
+    await async_session.commit()
+
+    result = await accept_event(
+        org_id,
+        AcceptedEvent(
+            source="slack",
+            event_key="app_mention",
+            payload=slack_payload,
+        ),
+        async_session,
+    )
+
+    async with async_session_factory() as other_session:
+        runs = await fetch_runs(other_session)
+
+    assert [str(run.id) for run in runs] == result.run_ids
+
+
+@pytest.mark.asyncio
+async def test_accept_event_reserved_fields_are_ignored(
+    org_id: uuid.UUID,
+    async_session,
+    slack_payload: dict,
+    mock_authenticated_user,
+):
+    """`provider_event_id`, `subject` and `occurred_at` are accepted but unused.
+
+    They are reserved for later phases; setting them must not change routing or
+    what is persisted today.
+    """
+    async_session.add(
+        make_automation(
+            org_id,
+            mock_authenticated_user.user_id,
+            {"type": "event", "source": "slack", "on": "app_mention"},
+        )
+    )
+    await async_session.commit()
+
+    result = await accept_event(
+        org_id,
+        AcceptedEvent(
+            source="slack",
+            event_key="app_mention",
+            payload=slack_payload,
+            provider_event_id="Ev123456",
+            subject=EventSubject(key="T06P212QSEA/C123/1755000000.000100"),
+            occurred_at=datetime(2026, 8, 23, 12, 0, tzinfo=UTC),
+        ),
+        async_session,
+    )
+
+    assert result.matched == 1
+    assert result.duplicate is False
+
+    runs = await fetch_runs(async_session)
+    assert len(runs) == 1
+    assert runs[0].event_payload == slack_payload
+
+
+@pytest.mark.asyncio
+async def test_accepted_event_defaults():
+    """Only `source` and `event_key` are required; the rest default to empty."""
+    event = AcceptedEvent(source="slack", event_key="app_mention")
+
+    assert event.payload == {}
+    assert event.provider_event_id is None
+    assert event.subject is None
+    assert event.occurred_at is None
+    assert event.parsed_event is None

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,9 +1,7 @@
-"""Direct unit tests for the transport-neutral ingestion seam.
+"""Direct unit tests for `accept_event()`.
 
-Every test here constructs an `AcceptedEvent` by hand and calls `accept_event()`
-without going through HTTP — no request, no signature, no FastAPI app. That is
-the point of the seam: a non-HTTP transport can reach trigger matching and run
-creation without faking a request.
+Every test builds an `AcceptedEvent` by hand — no request, no signature, no
+FastAPI app — which is the point of the seam.
 """
 
 import uuid
@@ -44,7 +42,7 @@ def slack_payload() -> dict:
 
 @pytest.fixture
 def github_push_payload() -> dict:
-    """Sample GitHub push webhook payload (the inner payload, already unwrapped)."""
+    """Sample GitHub push payload, already unwrapped."""
     return {
         "ref": "refs/heads/main",
         "before": "abc123",
@@ -96,7 +94,7 @@ async def test_accept_event_no_automations(
     async_session,
     slack_payload: dict,
 ):
-    """With no automations configured, nothing matches and nothing is created."""
+    """No automations configured: nothing matches, nothing is created."""
     result = await accept_event(
         org_id,
         AcceptedEvent(
@@ -158,7 +156,7 @@ async def test_accept_event_without_parsed_event_stores_raw_payload(
     slack_payload: dict,
     mock_authenticated_user,
 ):
-    """A transport that has no typed model gets its raw payload on the run."""
+    """A transport with no typed model gets its raw payload on the run."""
     async_session.add(
         make_automation(
             org_id,
@@ -189,12 +187,7 @@ async def test_accept_event_with_parsed_event_stores_model_dump(
     github_push_payload: dict,
     mock_authenticated_user,
 ):
-    """When the transport parsed a typed event, that model_dump is persisted.
-
-    This pins the subtle behaviour the webhook handler had before the split:
-    Pydantic-parsed events (GitHub) store `model_dump(mode="json")`, not the
-    raw provider payload.
-    """
+    """A typed event persists its model_dump, not the raw provider payload."""
     async_session.add(
         make_automation(
             org_id,
@@ -441,11 +434,7 @@ async def test_accept_event_reserved_fields_are_ignored(
     slack_payload: dict,
     mock_authenticated_user,
 ):
-    """`provider_event_id`, `subject` and `occurred_at` are accepted but unused.
-
-    They are reserved for later phases; setting them must not change routing or
-    what is persisted today.
-    """
+    """Setting the reserved fields changes neither routing nor what is stored."""
     async_session.add(
         make_automation(
             org_id,
@@ -478,7 +467,7 @@ async def test_accept_event_reserved_fields_are_ignored(
 
 @pytest.mark.asyncio
 async def test_accepted_event_defaults():
-    """Only `source` and `event_key` are required; the rest default to empty."""
+    """Only `source` and `event_key` are required."""
     event = AcceptedEvent(source="slack", event_key="app_mention")
 
     assert event.payload == {}
@@ -486,3 +475,29 @@ async def test_accepted_event_defaults():
     assert event.subject is None
     assert event.occurred_at is None
     assert event.parsed_event is None
+
+
+def test_dataclasses_are_frozen():
+    """The ingest dataclasses are immutable."""
+    event = AcceptedEvent(source="slack", event_key="app_mention")
+    result = AcceptResult(matched=0, run_ids=[])
+    subject = EventSubject(key="T1/C1/1.0")
+
+    for obj, attr, value in (
+        (event, "source", "github"),
+        (result, "matched", 1),
+        (subject, "key", "other"),
+    ):
+        with pytest.raises(AttributeError):
+            setattr(obj, attr, value)
+
+
+def test_dataclasses_use_slots():
+    """The ingest dataclasses use slots, so instances carry no __dict__."""
+    for obj in (
+        AcceptedEvent(source="slack", event_key="app_mention"),
+        AcceptResult(matched=0, run_ids=[]),
+        EventSubject(key="T1/C1/1.0"),
+    ):
+        assert hasattr(type(obj), "__slots__")
+        assert not hasattr(obj, "__dict__")


### PR DESCRIPTION
Closes #358 — phase 1 of 5, part of #363.

Pure refactor: no behaviour change, no schema change, no new dependencies.

## What changed

`receive_event()` was one function doing two unrelated jobs. Lines 137–244 are
HTTP-specific — they turn an untrusted request into a trustworthy, interpreted
event. Lines 246–313 are not HTTP-specific at all — they are the routing and
run-creation logic every transport needs. Because both lived in one function, a
second transport had nowhere to attach: it had to re-implement matching and run
creation (draft PR #134), or fake an HTTP request to reach them (what the OSS
VM's Slack bridge does — HMAC-signing a body and POSTing to loopback purely to
get past the handler's front half).

This adds `openhands/automation/ingest.py` with the boundary:

```python
async def accept_event(
    org_id: uuid.UUID,
    event: AcceptedEvent,
    session: AsyncSession,
    *,
    request: Request | None = None,   # telemetry only
) -> AcceptResult
```

The routing half moves there unchanged. `receive_event()` keeps acquisition,
authentication and interpretation, then calls `accept_event()` and maps
`AcceptResult` onto the existing `EventResponse`. Net effect on the router:
−65 lines, one call.

Authentication is deliberately not in this module, per the design rule in #363:
`accept_event()` receives an already-authenticated event and never asks how it
was authenticated.

## ⚠️ One correction to the issue: `accept_event()` needs a `session_factory`

Issue #358 says:

> `capture_automation_event` already accepts `request: Request | None = None`
> (`telemetry.py:391`), so non-HTTP callers simply omit it and all existing
> telemetry events keep firing. No telemetry changes are needed.

**That is not correct, and phase 3 would have shipped with no telemetry.**
Telemetry resolves a backend distinct id from the database. With no `request`,
no `session` and no `session_factory`, `get_automation_backend_distinct_id()`
returns `None` (`telemetry.py:75–77`), and `_capture_automation_event` then
returns before the PostHog POST. `capture_automation_event` swallows every
exception (`telemetry.py:395–396`), so the loss is completely silent.

Measured, calling `capture_automation_event` exactly as the seam does:

```
distinct_id with no request/session = None
distinct_id with session=           = 'automation-backend:0b72aac9-…'
posts after request=None call: []          <- all events dropped
posts after session= call:     ['automation_event_matched']
```

A transport calling `accept_event(..., request=None)` loses all three events per
run (`automation_event_matched`, `automation_run_scheduled`,
`automation_run_created`) while routing keeps working — which is exactly what
makes it easy to miss.

So `accept_event()` takes an optional `session_factory` and forwards it. The
HTTP path passes nothing and reaches the factory via
`request.app.state.session_factory` as before, so it is byte-identical.

**Why not just pass `session`?** It would work, but
`_get_or_create_backend_distinct_id` issues a raw `INSERT … ON CONFLICT DO
NOTHING` on whatever session it is handed (`telemetry.py:40–58`). Today that
runs on a *fresh* session committed immediately (`telemetry.py:79–82`). Sharing
the caller's session moves that write into the caller's transaction, and a
failure there would be hidden by the same broad `except` while poisoning the
`create_automation_run()` and `commit()` that follow.

This also means the issue's `# telemetry only` comment on `request` understates
it: `request` is load-bearing for a DB lookup, not just metadata.

## Two implementation notes worth reviewing

**1. `parsed_event` — the field the issue didn't specify, and why it's needed.**

The issue flags that `event_payload` behaviour is subtle and easy to get wrong:
`event.model_dump(mode="json")` for Pydantic-parsed events, raw
`webhook_payload` otherwise (`event_router.py:276–280`). But the proposed
`AcceptedEvent` carries only `payload` — the raw provider payload that JMESPath
filters run against — which for GitHub is *not* what gets persisted on the run.
There is no way to reproduce the existing behaviour from the six specified
fields alone.

So `AcceptedEvent` gains one additional optional field, `parsed_event`, holding
the typed `WebhookEvent` the HTTP handler already builds. All six fields from
the issue are present, in order, with the specified defaults; this is additive
and defaulted, so it doesn't change the signature for later phases. Transports
with no typed model simply omit it and their raw `payload` is persisted, which
is the documented fallback behaviour.

Worth noting for anyone checking the branch: `parse_event()` always returns a
`WebhookEvent`, which is a `BaseModel`, so the `else webhook_payload` branch is
in practice unreachable from the HTTP path today. The `isinstance` check is
preserved verbatim rather than simplified — this is a refactor, and collapsing
it would be a behaviour decision that belongs in its own change.

**2. `EventSubject` did not exist.**

It is referenced by the issue's dataclass but is defined nowhere in the repo,
and #362 (which consumes it) only describes it as producing a `subject_key`.
It is defined here minimally — a single `key: str` — so the reserved field has
a real type. Nothing populates or reads it.

## Acceptance criteria

- [x] **The existing `event_router` test suite passes unmodified.** 14/14, with
      zero changes to `tests/test_event_router.py`.
- [x] **`EventResponse` is byte-identical on the wire.** Verified by generating
      the full OpenAPI spec on `main` and on this branch and diffing them —
      identical, 160,253 bytes each.
- [x] **No schema change, no new dependency, no change to `trigger_matcher.py`,
      `create_automation_run()`, or the dispatcher.** The diff is three files:
      one new module, one new test file, and the router.
- [x] **`accept_event()` has direct unit tests that construct an `AcceptedEvent`
      without going through HTTP.** 16 tests in `tests/test_ingest.py` — no
      request, no signature, no FastAPI app. They cover no-match, match,
      per-automation run fan-out, filter evaluation against `payload`, event-key
      mismatch, source and org isolation, commit visibility from a second
      session, both `event_payload` shapes, the full telemetry sequence for a
      request-less caller, that the reserved fields change nothing, and that the
      dataclasses are frozen and slotted.

All three dataclasses are `frozen=True, slots=True`. Two caveats, since frozen
is easy to over-read: it is shallow, so `payload` and `run_ids` are still
mutable in place; and it generates a `__hash__` that raises at runtime for
`AcceptedEvent`/`AcceptResult` because of those dict/list fields. Phase 4's
dedupe should key on `provider_event_id`, not on the event object.

Full suite: 1350 passed. `pre-commit` (ruff format, ruff lint, pycodestyle,
pyright) clean on all three files.

## One question for the author

The `else webhook_payload` branch is already dead. `parse_event()` returns
`WebhookEvent` (`event_schemas/__init__.py:22`, a `BaseModel`) and
`CustomWebhookEvent` subclasses it (`custom.py:72`), so `isinstance(event,
BaseModel)` is always true. Custom webhooks today persist `{"payload": …,
"source_override": …, "event_key": …}`, **not** the raw payload that the code
comment and the issue both describe. I preserved the branch verbatim, since
collapsing it is a behaviour decision — but phases 4 and 5 should not assume the
documented behaviour is what actually happens.

## Out of scope

Deduplication, event persistence, and any new transport — phases 3 and 4 use
this seam.
