### PR TITLE
feat: replace the parse-only source registry with a provider descriptor and verifier registry

### DIFF
--- a/migrations/versions/017_add_webhook_signature_scheme.py
+++ b/migrations/versions/017_add_webhook_signature_scheme.py
@@ -1,6 +1,7 @@
 """Add signature_scheme to custom_webhooks.
 
-Nullable: existing rows carry no scheme and are read as "hmac_sha256_hex".
+The server_default backfills existing rows, so nothing has to be migrated. The
+column stays nullable because a PATCH may clear it; NULL reads as the default.
 
 Revision ID: 017
 Revises: 016

--- a/migrations/versions/017_add_webhook_signature_scheme.py
+++ b/migrations/versions/017_add_webhook_signature_scheme.py
@@ -1,0 +1,56 @@
+"""Add signature_scheme to custom_webhooks.
+
+Names the verifier a custom webhook's signatures are checked with, so sources
+that do not sign the raw body with hex HMAC-SHA256 can be onboarded -- Standard
+Webhooks (GitLab 19.1+ signing tokens, Svix) and Slack's v0 scheme.
+
+Nullable on purpose. Existing rows carry no scheme and are read as
+"hmac_sha256_hex", which is the behaviour they were created with, so nothing
+has to be backfilled for correctness.
+
+Revision ID: 017
+Revises: 016
+Create Date: 2026-08-23
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "017"
+down_revision: str = "016"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sqlite() -> bool:
+    return op.get_bind().dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "custom_webhooks",
+        sa.Column(
+            "signature_scheme",
+            sa.String(length=50),
+            nullable=True,
+            server_default="hmac_sha256_hex",
+        ),
+    )
+
+    if _is_sqlite():
+        return
+
+    op.execute(
+        "COMMENT ON COLUMN custom_webhooks.signature_scheme IS "
+        "'Verifier used for this webhook''s signatures: hmac_sha256_hex "
+        "(default, GitHub/Linear style), standard_webhooks "
+        "(standardwebhooks.com; GitLab 19.1+, Svix) or slack_v0 (Slack Events "
+        "API). NULL means the default.'"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("custom_webhooks", "signature_scheme")

--- a/migrations/versions/017_add_webhook_signature_scheme.py
+++ b/migrations/versions/017_add_webhook_signature_scheme.py
@@ -1,12 +1,6 @@
 """Add signature_scheme to custom_webhooks.
 
-Names the verifier a custom webhook's signatures are checked with, so sources
-that do not sign the raw body with hex HMAC-SHA256 can be onboarded -- Standard
-Webhooks (GitLab 19.1+ signing tokens, Svix) and Slack's v0 scheme.
-
-Nullable on purpose. Existing rows carry no scheme and are read as
-"hmac_sha256_hex", which is the behaviour they were created with, so nothing
-has to be backfilled for correctness.
+Nullable: existing rows carry no scheme and are read as "hmac_sha256_hex".
 
 Revision ID: 017
 Revises: 016

--- a/migrations/versions/018_add_webhook_signature_scheme.py
+++ b/migrations/versions/018_add_webhook_signature_scheme.py
@@ -3,8 +3,8 @@
 The server_default backfills existing rows, so nothing has to be migrated. The
 column stays nullable because a PATCH may clear it; NULL reads as the default.
 
-Revision ID: 017
-Revises: 016
+Revision ID: 018
+Revises: 017
 Create Date: 2026-08-23
 """
 
@@ -14,8 +14,8 @@ import sqlalchemy as sa
 from alembic import op
 
 
-revision: str = "017"
-down_revision: str = "016"
+revision: str = "018"
+down_revision: str = "017"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/openhands/automation/capabilities_router.py
+++ b/openhands/automation/capabilities_router.py
@@ -30,6 +30,7 @@ from openhands.automation.preset_router import (
     CreatePluginAutomationRequest,
     CreatePromptAutomationRequest,
 )
+from openhands.automation.providers import builtin_sources
 from openhands.automation.scheduler import POLL_INTERVAL_SECONDS
 from openhands.automation.schemas import (
     CapabilitiesResponse,
@@ -46,7 +47,7 @@ from openhands.automation.schemas import (
 from openhands.automation.trigger_matcher import matches_trigger
 from openhands.automation.utils.cron import min_interval_seconds
 from openhands.automation.utils.model_profiles import validate_model_profile_for_user
-from openhands.automation.utils.webhook import BUILTIN_SOURCES, get_webhook_config
+from openhands.automation.utils.webhook import get_webhook_config
 
 
 logger = logging.getLogger(__name__)
@@ -112,10 +113,8 @@ async def get_capabilities(
             features=[],
         )
 
-    builtin_sources = sorted(BUILTIN_SOURCES) if config.service.webhook_secret else []
-    event_sources = sorted(
-        {*builtin_sources, *await _custom_sources(user.org_id, session)}
-    )
+    builtin = builtin_sources() if config.service.webhook_secret else []
+    event_sources = sorted({*builtin, *await _custom_sources(user.org_id, session)})
 
     features = [*_STATIC_FEATURES]
     if event_sources:
@@ -128,9 +127,7 @@ async def get_capabilities(
         max_automation_timeout_seconds=config.sandbox.max_run_duration,
         trigger_kinds=["cron", "event"] if event_sources else ["cron"],
         event_sources=event_sources,
-        event_types=(
-            get_supported_event_patterns() if "github" in builtin_sources else []
-        ),
+        event_types=(get_supported_event_patterns() if "github" in builtin else []),
         triggers=TriggerCapabilities(
             cron=CronCapabilities(
                 min_interval_seconds=_cron_interval_floor(),

--- a/openhands/automation/event_router.py
+++ b/openhands/automation/event_router.py
@@ -30,9 +30,8 @@ Authentication Model:
     - Under `hmac_sha256_hex` old valid payloads could be replayed, since
       nothing in the signed content expires
     - GitHub includes delivery IDs for deduplication; consider tracking these
-    - The `standard_webhooks` and `slack_v0` schemes sign a timestamp and
-      reject deliveries outside a 5-minute window, so they do not have this
-      property
+    - `standard_webhooks` and `slack_v0` sign a timestamp and reject
+      deliveries outside a 5-minute window, so they are not replayable
     - Current risk is acceptable: replay triggers same automation again (idempotent)
 """
 
@@ -71,13 +70,10 @@ router = APIRouter(prefix="/v1/events", tags=["events"])
 
 
 def _resolve_verifier(config: WebhookConfig, source: str) -> WebhookVerifier:
-    """Resolve the configured signature scheme to a verifier.
+    """Resolve the configured scheme, refusing one this build cannot verify.
 
-    A scheme with no verifier behind it means the stored configuration names
-    something this build does not implement. Refusing the delivery is the only
-    safe reading: the alternative is falling back to a scheme the sender is not
-    using, which would reject every genuine event as a bad signature and read
-    as an authentication failure rather than the misconfiguration it is.
+    Falling back would reject every genuine delivery as a bad signature, hiding
+    a misconfiguration behind a 401.
     """
     verifier = get_verifier(config.signature_scheme)
     if verifier is None:
@@ -118,8 +114,7 @@ async def requested_event_types(
             status_code=401,
             detail=f"Missing signature header: {config.signature_header}",
         )
-    # The signed content here is the source string, not a request body: this is
-    # a read, so there is nothing else for the forwarder to authenticate with.
+    # Signed content is the source string: this is a read, so there is no body.
     verifier = _resolve_verifier(config, source)
     if not verifier.verify(
         body=source.encode("utf-8"),

--- a/openhands/automation/event_router.py
+++ b/openhands/automation/event_router.py
@@ -22,10 +22,17 @@ Authentication Model:
     Webhooks are authenticated by verifying the signature against a shared secret.
     This is standard practice for webhook receivers (GitHub, Stripe, etc.).
 
+    The scheme is per-source, resolved from `providers.VERIFIERS`. Built-in
+    sources use hex HMAC-SHA256 over the raw body; a custom webhook picks one
+    with its `signature_scheme`.
+
     Replay Attack Considerations:
-    - Old valid payloads could be replayed since signatures don't expire
+    - Under `hmac_sha256_hex` old valid payloads could be replayed, since
+      nothing in the signed content expires
     - GitHub includes delivery IDs for deduplication; consider tracking these
-    - For high-security scenarios, add timestamp validation (X-GitHub-Timestamp)
+    - The `standard_webhooks` and `slack_v0` schemes sign a timestamp and
+      reject deliveries outside a 5-minute window, so they do not have this
+      property
     - Current risk is acceptable: replay triggers same automation again (idempotent)
 """
 
@@ -44,22 +51,46 @@ from openhands.automation.event_schemas.github import (
     get_supported_event_types,
 )
 from openhands.automation.ingest import AcceptedEvent, accept_event
+from openhands.automation.providers import WebhookVerifier, get_verifier
 from openhands.automation.schemas import (
     EventDetectionRule,
     EventResponse,
     RequestedEventTypesResponse,
+    WebhookConfig,
 )
 from openhands.automation.telemetry import capture_automation_event
 from openhands.automation.utils.webhook import (
     get_requested_event_types,
     get_webhook_config,
-    verify_signature,
 )
 
 
 logger = logging.getLogger("automation.event_router")
 
 router = APIRouter(prefix="/v1/events", tags=["events"])
+
+
+def _resolve_verifier(config: WebhookConfig, source: str) -> WebhookVerifier:
+    """Resolve the configured signature scheme to a verifier.
+
+    A scheme with no verifier behind it means the stored configuration names
+    something this build does not implement. Refusing the delivery is the only
+    safe reading: the alternative is falling back to a scheme the sender is not
+    using, which would reject every genuine event as a bad signature and read
+    as an authentication failure rather than the misconfiguration it is.
+    """
+    verifier = get_verifier(config.signature_scheme)
+    if verifier is None:
+        logger.error(
+            "Unknown signature scheme '%s' configured for source=%s",
+            config.signature_scheme,
+            source,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Webhook signature scheme is not supported by this deployment",
+        )
+    return verifier
 
 
 @router.get("/{source}/requested-types", response_model=RequestedEventTypesResponse)
@@ -87,7 +118,15 @@ async def requested_event_types(
             status_code=401,
             detail=f"Missing signature header: {config.signature_header}",
         )
-    if not verify_signature(source.encode("utf-8"), signature, config.secret):
+    # The signed content here is the source string, not a request body: this is
+    # a read, so there is nothing else for the forwarder to authenticate with.
+    verifier = _resolve_verifier(config, source)
+    if not verifier.verify(
+        body=source.encode("utf-8"),
+        headers=request.headers,
+        secret=config.secret,
+        signature_header=config.signature_header,
+    ):
         raise HTTPException(status_code=401, detail="Invalid signature")
 
     if source == "github":
@@ -164,9 +203,16 @@ async def receive_event(
             detail=f"Missing signature header: {config.signature_header}",
         )
 
-    if not verify_signature(body, signature, config.secret):
+    verifier = _resolve_verifier(config, source)
+    if not verifier.verify(
+        body=body,
+        headers=request.headers,
+        secret=config.secret,
+        signature_header=config.signature_header,
+    ):
         logger.warning(
-            "Invalid signature for event from source=%s org_id=%s",
+            "Invalid signature (scheme=%s) for event from source=%s org_id=%s",
+            config.signature_scheme,
             source,
             org_id,
         )

--- a/openhands/automation/event_schemas/__init__.py
+++ b/openhands/automation/event_schemas/__init__.py
@@ -13,7 +13,6 @@ expressions against the raw payload. The event schemas are for validation
 and providing typed access to payload fields.
 """
 
-from collections.abc import Callable
 from typing import Any, ClassVar
 
 from pydantic import BaseModel, computed_field
@@ -54,19 +53,13 @@ class WebhookEvent(BaseModel):
 
 
 # =============================================================================
-# Parser Registry
+# Parsing
 # =============================================================================
-
-# Type for auto-detection parse functions: (payload) -> WebhookEvent
-AutoParseFunc = Callable[[dict[str, Any]], WebhookEvent]
-
-# Registry of parse functions for known sources (auto-detect event type from payload)
-_PARSERS: dict[str, AutoParseFunc] = {}
-
-
-def register_parser(source: str, parser: AutoParseFunc) -> None:
-    """Register a parse function for a source."""
-    _PARSERS[source] = parser
+#
+# The parser for a known source lives on its provider descriptor
+# (`openhands.automation.providers`), alongside its verifier, secret and
+# capabilities, so a provider is described in one place. `parse_event()` reads
+# that registry; there is no separate parser registry here.
 
 
 def parse_event(
@@ -94,10 +87,14 @@ def parse_event(
     Raises:
         ValueError: If event type cannot be determined from payload
     """
+    # Imported lazily: providers.py imports the parsers this module's
+    # submodules define, so a module-level import here would be circular.
+    from openhands.automation.providers import get_provider
+
     # Known source - auto-detect event type from payload
-    parser = _PARSERS.get(source)
-    if parser:
-        return parser(payload)
+    provider = get_provider(source)
+    if provider:
+        return provider.parse(payload)
 
     # Unknown source = custom webhook (no registration needed)
     from openhands.automation.event_schemas.custom import (
@@ -114,19 +111,3 @@ def parse_event(
         payload=payload,
         source_override=source,
     )
-
-
-def _register_builtin_parsers() -> None:
-    """Register parsers for built-in sources. Called at module load."""
-    from openhands.automation.event_schemas.bitbucket_data_center import (
-        parse_bitbucket_data_center_event,
-    )
-    from openhands.automation.event_schemas.github import parse_github_event_auto
-    from openhands.automation.event_schemas.jira_dc import parse_jira_dc_event
-
-    register_parser("bitbucket_data_center", parse_bitbucket_data_center_event)
-    register_parser("github", parse_github_event_auto)
-    register_parser("jira_dc", parse_jira_dc_event)
-
-
-_register_builtin_parsers()

--- a/openhands/automation/event_schemas/__init__.py
+++ b/openhands/automation/event_schemas/__init__.py
@@ -52,16 +52,6 @@ class WebhookEvent(BaseModel):
         raise NotImplementedError("Subclasses must implement event_key")
 
 
-# =============================================================================
-# Parsing
-# =============================================================================
-#
-# The parser for a known source lives on its provider descriptor
-# (`openhands.automation.providers`), alongside its verifier, secret and
-# capabilities, so a provider is described in one place. `parse_event()` reads
-# that registry; there is no separate parser registry here.
-
-
 def parse_event(
     source: str,
     payload: dict[str, Any],
@@ -87,8 +77,7 @@ def parse_event(
     Raises:
         ValueError: If event type cannot be determined from payload
     """
-    # Imported lazily: providers.py imports the parsers this module's
-    # submodules define, so a module-level import here would be circular.
+    # Lazy: providers imports WebhookEvent from this module.
     from openhands.automation.providers import get_provider
 
     # Known source - auto-detect event type from payload

--- a/openhands/automation/models.py
+++ b/openhands/automation/models.py
@@ -338,8 +338,8 @@ class CustomWebhook(Base):
         String(100), nullable=False, default="X-Signature-256"
     )
 
-    # Names a verifier in `providers.VERIFIERS`. NULL on rows predating the
-    # column, read as the default.
+    # Names a verifier in `providers.VERIFIERS`. Nullable because a PATCH may
+    # clear it; NULL reads as the default.
     signature_scheme: Mapped[str | None] = mapped_column(
         String(50),
         nullable=True,

--- a/openhands/automation/models.py
+++ b/openhands/automation/models.py
@@ -20,6 +20,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
+from openhands.automation.providers import DEFAULT_VERIFIER as DEFAULT_SIGNATURE_SCHEME
 from openhands.automation.utils import utcnow
 
 
@@ -335,6 +336,22 @@ class CustomWebhook(Base):
     # Slack: "X-Slack-Signature"). Defaults to "X-Signature-256".
     signature_header: Mapped[str] = mapped_column(
         String(100), nullable=False, default="X-Signature-256"
+    )
+
+    # How the value in `signature_header` is computed and encoded. Names a
+    # verifier in `openhands.automation.providers.VERIFIERS`:
+    # - "hmac_sha256_hex" (default): hex(HMAC-SHA256(secret, body)),
+    #   GitHub/Linear style, with an optional "sha256=" prefix.
+    # - "standard_webhooks": standardwebhooks.com (GitLab 19.1+ signing
+    #   tokens, Svix) -- "v1,<base64>" over "{id}.{timestamp}.{body}".
+    # - "slack_v0": Slack Events API -- "v0=<hex>" over "v0:{ts}:{body}".
+    # Nullable: rows created before this column existed carry no scheme and are
+    # read as the default, which is the behaviour they were created with.
+    signature_scheme: Mapped[str | None] = mapped_column(
+        String(50),
+        nullable=True,
+        default=DEFAULT_SIGNATURE_SCHEME,
+        server_default=DEFAULT_SIGNATURE_SCHEME,
     )
 
     # Timestamp when the webhook integration was created

--- a/openhands/automation/models.py
+++ b/openhands/automation/models.py
@@ -338,15 +338,8 @@ class CustomWebhook(Base):
         String(100), nullable=False, default="X-Signature-256"
     )
 
-    # How the value in `signature_header` is computed and encoded. Names a
-    # verifier in `openhands.automation.providers.VERIFIERS`:
-    # - "hmac_sha256_hex" (default): hex(HMAC-SHA256(secret, body)),
-    #   GitHub/Linear style, with an optional "sha256=" prefix.
-    # - "standard_webhooks": standardwebhooks.com (GitLab 19.1+ signing
-    #   tokens, Svix) -- "v1,<base64>" over "{id}.{timestamp}.{body}".
-    # - "slack_v0": Slack Events API -- "v0=<hex>" over "v0:{ts}:{body}".
-    # Nullable: rows created before this column existed carry no scheme and are
-    # read as the default, which is the behaviour they were created with.
+    # Names a verifier in `providers.VERIFIERS`. NULL on rows predating the
+    # column, read as the default.
     signature_scheme: Mapped[str | None] = mapped_column(
         String(50),
         nullable=True,

--- a/openhands/automation/providers.py
+++ b/openhands/automation/providers.py
@@ -1,24 +1,10 @@
 """Provider descriptors and signature verifiers.
 
-One registry describes an event provider: how its payloads parse into a typed
-`WebhookEvent`, how a delivery's signature is verified, where its shared secret
-comes from, and what its transport tolerates. Before this module the same
-provider was described in two unrelated places -- ``BUILTIN_SOURCES`` in
-``utils/webhook.py`` (secret extraction) and the ``event_schemas`` parser
-registry -- with ``RESERVED_SOURCES`` hand-maintained alongside them as a third.
-
-Verification is a registry too. ``verify_signature()`` was the only scheme the
-service could speak: hex HMAC-SHA256 over the raw body. Providers that sign
-something else -- Standard Webhooks (GitLab 19.1+, Svix), Slack's
-``v0:{ts}:{body}`` -- could not be onboarded at all. ``VERIFIERS`` resolves a
-scheme by name so a provider, or a per-org custom webhook, can pick one.
-
-This module is deliberately free of transport imports so it can be read by a
-non-HTTP transport; the one HTTP-shaped field (``handshake``) is reserved and
-typed under ``TYPE_CHECKING`` only.
+`PROVIDERS` describes an event provider in one place: how its payloads parse,
+how a delivery is verified, where its secret comes from, what its transport
+tolerates. `VERIFIERS` resolves a signature scheme by name, so a provider or a
+per-org custom webhook can pick one. No transport imports.
 """
-
-from __future__ import annotations
 
 import base64
 import binascii
@@ -28,7 +14,7 @@ import logging
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Final, Protocol
 
 from openhands.automation.config import Settings
 from openhands.automation.event_schemas import WebhookEvent
@@ -43,32 +29,25 @@ if TYPE_CHECKING:
 logger = logging.getLogger("automation.providers")
 
 
+DEFAULT_VERIFIER: Final[str] = "hmac_sha256_hex"
+DEFAULT_BUILTIN_SIGNATURE_HEADER: Final[str] = "X-Hub-Signature-256"
+
+STANDARD_WEBHOOKS_TOLERANCE_SECONDS: Final[int] = 300
+STANDARD_WEBHOOKS_ID_HEADER: Final[str] = "webhook-id"
+STANDARD_WEBHOOKS_TIMESTAMP_HEADER: Final[str] = "webhook-timestamp"
+
+SLACK_TOLERANCE_SECONDS: Final[int] = 300
+SLACK_TIMESTAMP_HEADER: Final[str] = "X-Slack-Request-Timestamp"
+
+
 ParseFunc = Callable[[dict[str, Any]], WebhookEvent]
 SecretFunc = Callable[[Settings], str | None]
 SubjectFunc = Callable[[dict[str, Any]], "EventSubject | None"]
 HandshakeFunc = Callable[["Request"], "Response | None"]
 
-# Scheme used when nothing says otherwise: the behaviour every existing source
-# and every existing custom_webhooks row has today.
-DEFAULT_VERIFIER = "hmac_sha256_hex"
-
-# The header built-in sources sign into. They are all forwarded by the OpenHands
-# server, which reuses GitHub's header name regardless of the upstream provider.
-DEFAULT_BUILTIN_SIGNATURE_HEADER = "X-Hub-Signature-256"
-
-
-# =============================================================================
-# Header access
-# =============================================================================
-
 
 def get_header(headers: Mapping[str, str], name: str) -> str | None:
-    """Look up a header case-insensitively.
-
-    Starlette's ``Headers`` is already case-insensitive, but a non-HTTP caller
-    or a test may pass a plain dict, and header casing is not something a
-    verifier should have to guess at.
-    """
+    """Look up a header case-insensitively, for callers passing a plain dict."""
     value = headers.get(name)
     if value is not None:
         return value
@@ -86,20 +65,12 @@ def _now_seconds() -> int:
     return int(time.time())
 
 
-# =============================================================================
-# Verifiers
-# =============================================================================
-
-
 class WebhookVerifier(Protocol):
     """Proves a raw delivery was signed by the holder of the shared secret.
 
-    ``signature_header`` is the header the signature itself is carried in. It
-    is a parameter rather than a property of the verifier because custom
-    webhooks configure it per row, and the same scheme is used behind different
-    header names by different vendors. Everything *else* a scheme needs -- a
-    message id, a timestamp -- the verifier reads from ``headers`` itself,
-    since those header names are fixed by the scheme, not by the operator.
+    `signature_header` is a parameter because custom webhooks configure it per
+    row; anything else a scheme needs is read from `headers`, since those names
+    are fixed by the scheme.
     """
 
     def verify(
@@ -113,22 +84,7 @@ class WebhookVerifier(Protocol):
 
 
 def verify_signature(payload: bytes, signature: str, secret: str) -> bool:
-    """
-    Verify HMAC-SHA256 signature.
-
-    Accepts both formats:
-    - GitHub/normalized: 'sha256=<hex>'
-    - Raw hex digest: '<hex>' (e.g., Linear)
-
-    Args:
-        payload: Raw request body bytes
-        signature: Signature from header
-        secret: The shared secret
-
-    Returns:
-        True if signature is valid
-    """
-    # Normalize: strip 'sha256=' prefix if present
+    """Verify a hex HMAC-SHA256 digest, with or without a `sha256=` prefix."""
     if signature.startswith("sha256="):
         signature = signature[7:]
 
@@ -159,20 +115,8 @@ class HmacSha256HexVerifier:
         return verify_signature(body, signature, secret)
 
 
-# Standard Webhooks (https://www.standardwebhooks.com) -- used by GitLab 19.1+
-# signing tokens, Svix, and others. Signature = base64(HMAC-SHA256(key, msg))
-# where msg = "{id}.{timestamp}.{body}" and key = base64decode(secret w/o whsec_).
-STANDARD_WEBHOOKS_TOLERANCE_SECONDS = 300
-STANDARD_WEBHOOKS_ID_HEADER = "webhook-id"
-STANDARD_WEBHOOKS_TIMESTAMP_HEADER = "webhook-timestamp"
-
-
 def standard_webhooks_key(secret: str) -> bytes:
-    """Derive the signing key from a Standard Webhooks secret.
-
-    Secrets are conventionally "whsec_<base64>": strip the prefix and
-    base64-decode. Fall back to raw UTF-8 bytes if not valid base64.
-    """
+    """Strip the `whsec_` prefix and base64-decode; fall back to raw bytes."""
     key_material = secret
     if key_material.startswith("whsec_"):
         key_material = key_material[len("whsec_") :]
@@ -184,11 +128,9 @@ def standard_webhooks_key(secret: str) -> bytes:
 
 @dataclass(frozen=True, slots=True)
 class StandardWebhooksVerifier:
-    """standardwebhooks.com: base64 HMAC over "{id}.{timestamp}.{body}".
+    """standardwebhooks.com: base64 HMAC over `{id}.{timestamp}.{body}`.
 
-    The timestamp is signed, so checking it against a freshness window is real
-    replay protection rather than a formality -- an attacker cannot re-stamp a
-    captured delivery without the secret.
+    The timestamp is signed, so the freshness window is real replay protection.
     """
 
     tolerance_seconds: int = STANDARD_WEBHOOKS_TOLERANCE_SECONDS
@@ -221,12 +163,11 @@ class StandardWebhooksVerifier:
             hmac.new(key, signed_content, hashlib.sha256).digest()
         ).decode("utf-8")
 
-        # The header carries a space-separated list so a secret can be rotated
-        # without a gap; any one match is enough. Every token is compared even
-        # after a match, to keep the work independent of where the match sits.
+        # Space-separated list so a secret can be rotated without a gap; any one
+        # match is enough, and every token is compared to keep the work
+        # independent of where the match sits.
         matched = False
         for token in signature.split():
-            # Each token is "v{version},{signature}"; we support v1.
             version, _, candidate = token.partition(",")
             if not candidate or version != "v1":
                 continue
@@ -235,15 +176,9 @@ class StandardWebhooksVerifier:
         return matched
 
 
-# Slack's Events API signs "v0:{timestamp}:{body}" and sends the hex digest as
-# "v0=<hex>". Slack's own guidance is to reject deliveries older than 5 minutes.
-SLACK_TOLERANCE_SECONDS = 300
-SLACK_TIMESTAMP_HEADER = "X-Slack-Request-Timestamp"
-
-
 @dataclass(frozen=True, slots=True)
 class SlackV0Verifier:
-    """Slack Events API: hex HMAC over "v0:{timestamp}:{body}"."""
+    """Slack Events API: hex HMAC over `v0:{timestamp}:{body}`."""
 
     tolerance_seconds: int = SLACK_TOLERANCE_SECONDS
     clock: Callable[[], int] = field(default=_now_seconds)
@@ -295,20 +230,13 @@ def verifier_schemes() -> frozenset[str]:
     return frozenset(VERIFIERS)
 
 
-# =============================================================================
-# Provider descriptors
-# =============================================================================
-
-
 @dataclass(frozen=True, slots=True)
 class Capabilities:
     """What a provider's transport tolerates. Declared, never assumed."""
 
-    # Whether the provider load-balances a payload across the simultaneous
-    # connections an app holds, rather than broadcasting it to all of them.
-    # Slack does the former and endorses up to 10 connections, so Socket Mode
-    # is safe to run active-active; an arbitrary WebSocket upstream makes no
-    # such promise and would duplicate every event per replica. Read by #360.
+    # Slack load-balances a payload across an app's open connections and
+    # endorses up to 10, so Socket Mode is safe to run active-active; an
+    # arbitrary WebSocket upstream would duplicate every event per replica.
     tolerates_multiple_connections: bool = False
 
 
@@ -321,13 +249,10 @@ class Provider:
     verifier: str = DEFAULT_VERIFIER
     signature_header: str = DEFAULT_BUILTIN_SIGNATURE_HEADER
     secret_from_settings: SecretFunc | None = None
-    # Reserved for #362 (subject -> conversation routing). Nothing reads it.
+    # Reserved for subject-based routing. Nothing reads it.
     subject: SubjectFunc | None = None
     # Reserved. Deliberately not wired: no provider on the roadmap performs an
-    # HTTP handshake. Slack's Events API challenge was the motivating example,
-    # and #360 makes Socket Mode our Slack path, where it does not apply. See
-    # the "On the handshake hook" note in #359 -- this is the explicit decision
-    # to defer, not an oversight.
+    # HTTP handshake, and Socket Mode is our Slack path.
     handshake: HandshakeFunc | None = None
     capabilities: Capabilities = Capabilities()
 
@@ -356,11 +281,7 @@ def builtin_sources() -> list[str]:
 
 
 def reserved_sources() -> frozenset[str]:
-    """Source names a custom webhook may not claim.
-
-    Derived from the registry rather than maintained separately, so a provider
-    cannot be added without also being reserved.
-    """
+    """Source names a custom webhook may not claim, derived from the registry."""
     return frozenset(PROVIDERS)
 
 
@@ -372,8 +293,8 @@ def _register_builtin_providers() -> None:
     from openhands.automation.event_schemas.github import parse_github_event_auto
     from openhands.automation.event_schemas.jira_dc import parse_jira_dc_event
 
-    # All three are forwarded by the OpenHands server, which signs with the
-    # single shared AUTOMATION_WEBHOOK_SECRET into GitHub's header name.
+    # All forwarded by the OpenHands server, which signs with the single shared
+    # AUTOMATION_WEBHOOK_SECRET into GitHub's header name.
     for source, parse in (
         ("bitbucket_data_center", parse_bitbucket_data_center_event),
         ("github", parse_github_event_auto),

--- a/openhands/automation/providers.py
+++ b/openhands/automation/providers.py
@@ -1,0 +1,391 @@
+"""Provider descriptors and signature verifiers.
+
+One registry describes an event provider: how its payloads parse into a typed
+`WebhookEvent`, how a delivery's signature is verified, where its shared secret
+comes from, and what its transport tolerates. Before this module the same
+provider was described in two unrelated places -- ``BUILTIN_SOURCES`` in
+``utils/webhook.py`` (secret extraction) and the ``event_schemas`` parser
+registry -- with ``RESERVED_SOURCES`` hand-maintained alongside them as a third.
+
+Verification is a registry too. ``verify_signature()`` was the only scheme the
+service could speak: hex HMAC-SHA256 over the raw body. Providers that sign
+something else -- Standard Webhooks (GitLab 19.1+, Svix), Slack's
+``v0:{ts}:{body}`` -- could not be onboarded at all. ``VERIFIERS`` resolves a
+scheme by name so a provider, or a per-org custom webhook, can pick one.
+
+This module is deliberately free of transport imports so it can be read by a
+non-HTTP transport; the one HTTP-shaped field (``handshake``) is reserved and
+typed under ``TYPE_CHECKING`` only.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import logging
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol
+
+from openhands.automation.config import Settings
+from openhands.automation.event_schemas import WebhookEvent
+
+
+if TYPE_CHECKING:
+    from fastapi import Request, Response
+
+    from openhands.automation.ingest import EventSubject
+
+
+logger = logging.getLogger("automation.providers")
+
+
+ParseFunc = Callable[[dict[str, Any]], WebhookEvent]
+SecretFunc = Callable[[Settings], str | None]
+SubjectFunc = Callable[[dict[str, Any]], "EventSubject | None"]
+HandshakeFunc = Callable[["Request"], "Response | None"]
+
+# Scheme used when nothing says otherwise: the behaviour every existing source
+# and every existing custom_webhooks row has today.
+DEFAULT_VERIFIER = "hmac_sha256_hex"
+
+# The header built-in sources sign into. They are all forwarded by the OpenHands
+# server, which reuses GitHub's header name regardless of the upstream provider.
+DEFAULT_BUILTIN_SIGNATURE_HEADER = "X-Hub-Signature-256"
+
+
+# =============================================================================
+# Header access
+# =============================================================================
+
+
+def get_header(headers: Mapping[str, str], name: str) -> str | None:
+    """Look up a header case-insensitively.
+
+    Starlette's ``Headers`` is already case-insensitive, but a non-HTTP caller
+    or a test may pass a plain dict, and header casing is not something a
+    verifier should have to guess at.
+    """
+    value = headers.get(name)
+    if value is not None:
+        return value
+    lowered = name.lower()
+    value = headers.get(lowered)
+    if value is not None:
+        return value
+    for key, candidate in headers.items():
+        if key.lower() == lowered:
+            return candidate
+    return None
+
+
+def _now_seconds() -> int:
+    return int(time.time())
+
+
+# =============================================================================
+# Verifiers
+# =============================================================================
+
+
+class WebhookVerifier(Protocol):
+    """Proves a raw delivery was signed by the holder of the shared secret.
+
+    ``signature_header`` is the header the signature itself is carried in. It
+    is a parameter rather than a property of the verifier because custom
+    webhooks configure it per row, and the same scheme is used behind different
+    header names by different vendors. Everything *else* a scheme needs -- a
+    message id, a timestamp -- the verifier reads from ``headers`` itself,
+    since those header names are fixed by the scheme, not by the operator.
+    """
+
+    def verify(
+        self,
+        *,
+        body: bytes,
+        headers: Mapping[str, str],
+        secret: str,
+        signature_header: str,
+    ) -> bool: ...
+
+
+def verify_signature(payload: bytes, signature: str, secret: str) -> bool:
+    """
+    Verify HMAC-SHA256 signature.
+
+    Accepts both formats:
+    - GitHub/normalized: 'sha256=<hex>'
+    - Raw hex digest: '<hex>' (e.g., Linear)
+
+    Args:
+        payload: Raw request body bytes
+        signature: Signature from header
+        secret: The shared secret
+
+    Returns:
+        True if signature is valid
+    """
+    # Normalize: strip 'sha256=' prefix if present
+    if signature.startswith("sha256="):
+        signature = signature[7:]
+
+    computed = hmac.new(
+        secret.encode("utf-8"),
+        msg=payload,
+        digestmod=hashlib.sha256,
+    ).hexdigest()
+
+    return hmac.compare_digest(computed, signature)
+
+
+@dataclass(frozen=True, slots=True)
+class HmacSha256HexVerifier:
+    """GitHub/Linear style: hex HMAC-SHA256 over the raw body."""
+
+    def verify(
+        self,
+        *,
+        body: bytes,
+        headers: Mapping[str, str],
+        secret: str,
+        signature_header: str,
+    ) -> bool:
+        signature = get_header(headers, signature_header)
+        if not signature:
+            return False
+        return verify_signature(body, signature, secret)
+
+
+# Standard Webhooks (https://www.standardwebhooks.com) -- used by GitLab 19.1+
+# signing tokens, Svix, and others. Signature = base64(HMAC-SHA256(key, msg))
+# where msg = "{id}.{timestamp}.{body}" and key = base64decode(secret w/o whsec_).
+STANDARD_WEBHOOKS_TOLERANCE_SECONDS = 300
+STANDARD_WEBHOOKS_ID_HEADER = "webhook-id"
+STANDARD_WEBHOOKS_TIMESTAMP_HEADER = "webhook-timestamp"
+
+
+def standard_webhooks_key(secret: str) -> bytes:
+    """Derive the signing key from a Standard Webhooks secret.
+
+    Secrets are conventionally "whsec_<base64>": strip the prefix and
+    base64-decode. Fall back to raw UTF-8 bytes if not valid base64.
+    """
+    key_material = secret
+    if key_material.startswith("whsec_"):
+        key_material = key_material[len("whsec_") :]
+    try:
+        return base64.b64decode(key_material, validate=True)
+    except (binascii.Error, ValueError):
+        return secret.encode("utf-8")
+
+
+@dataclass(frozen=True, slots=True)
+class StandardWebhooksVerifier:
+    """standardwebhooks.com: base64 HMAC over "{id}.{timestamp}.{body}".
+
+    The timestamp is signed, so checking it against a freshness window is real
+    replay protection rather than a formality -- an attacker cannot re-stamp a
+    captured delivery without the secret.
+    """
+
+    tolerance_seconds: int = STANDARD_WEBHOOKS_TOLERANCE_SECONDS
+    clock: Callable[[], int] = field(default=_now_seconds)
+
+    def verify(
+        self,
+        *,
+        body: bytes,
+        headers: Mapping[str, str],
+        secret: str,
+        signature_header: str,
+    ) -> bool:
+        signature = get_header(headers, signature_header)
+        msg_id = get_header(headers, STANDARD_WEBHOOKS_ID_HEADER)
+        timestamp = get_header(headers, STANDARD_WEBHOOKS_TIMESTAMP_HEADER)
+        if not signature or not msg_id or not timestamp:
+            return False
+
+        try:
+            sent_at = int(timestamp)
+        except (TypeError, ValueError):
+            return False
+        if abs(self.clock() - sent_at) > self.tolerance_seconds:
+            return False
+
+        key = standard_webhooks_key(secret)
+        signed_content = f"{msg_id}.{timestamp}.".encode() + body
+        expected = base64.b64encode(
+            hmac.new(key, signed_content, hashlib.sha256).digest()
+        ).decode("utf-8")
+
+        # The header carries a space-separated list so a secret can be rotated
+        # without a gap; any one match is enough. Every token is compared even
+        # after a match, to keep the work independent of where the match sits.
+        matched = False
+        for token in signature.split():
+            # Each token is "v{version},{signature}"; we support v1.
+            version, _, candidate = token.partition(",")
+            if not candidate or version != "v1":
+                continue
+            if hmac.compare_digest(candidate, expected):
+                matched = True
+        return matched
+
+
+# Slack's Events API signs "v0:{timestamp}:{body}" and sends the hex digest as
+# "v0=<hex>". Slack's own guidance is to reject deliveries older than 5 minutes.
+SLACK_TOLERANCE_SECONDS = 300
+SLACK_TIMESTAMP_HEADER = "X-Slack-Request-Timestamp"
+
+
+@dataclass(frozen=True, slots=True)
+class SlackV0Verifier:
+    """Slack Events API: hex HMAC over "v0:{timestamp}:{body}"."""
+
+    tolerance_seconds: int = SLACK_TOLERANCE_SECONDS
+    clock: Callable[[], int] = field(default=_now_seconds)
+
+    def verify(
+        self,
+        *,
+        body: bytes,
+        headers: Mapping[str, str],
+        secret: str,
+        signature_header: str,
+    ) -> bool:
+        signature = get_header(headers, signature_header)
+        timestamp = get_header(headers, SLACK_TIMESTAMP_HEADER)
+        if not signature or not timestamp:
+            return False
+
+        try:
+            sent_at = int(timestamp)
+        except (TypeError, ValueError):
+            return False
+        if abs(self.clock() - sent_at) > self.tolerance_seconds:
+            return False
+
+        signed_content = b"v0:" + timestamp.encode("utf-8") + b":" + body
+        expected = (
+            "v0="
+            + hmac.new(
+                secret.encode("utf-8"), signed_content, hashlib.sha256
+            ).hexdigest()
+        )
+        return hmac.compare_digest(signature, expected)
+
+
+VERIFIERS: dict[str, WebhookVerifier] = {
+    "hmac_sha256_hex": HmacSha256HexVerifier(),
+    "standard_webhooks": StandardWebhooksVerifier(),
+    "slack_v0": SlackV0Verifier(),
+}
+
+
+def get_verifier(scheme: str | None) -> WebhookVerifier | None:
+    """Resolve a signature scheme name, treating None as the default."""
+    return VERIFIERS.get(scheme or DEFAULT_VERIFIER)
+
+
+def verifier_schemes() -> frozenset[str]:
+    """Every signature scheme a webhook may be configured with."""
+    return frozenset(VERIFIERS)
+
+
+# =============================================================================
+# Provider descriptors
+# =============================================================================
+
+
+@dataclass(frozen=True, slots=True)
+class Capabilities:
+    """What a provider's transport tolerates. Declared, never assumed."""
+
+    # Whether the provider load-balances a payload across the simultaneous
+    # connections an app holds, rather than broadcasting it to all of them.
+    # Slack does the former and endorses up to 10 connections, so Socket Mode
+    # is safe to run active-active; an arbitrary WebSocket upstream makes no
+    # such promise and would duplicate every event per replica. Read by #360.
+    tolerates_multiple_connections: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class Provider:
+    """Everything the service knows about one event provider."""
+
+    source: str
+    parse: ParseFunc
+    verifier: str = DEFAULT_VERIFIER
+    signature_header: str = DEFAULT_BUILTIN_SIGNATURE_HEADER
+    secret_from_settings: SecretFunc | None = None
+    # Reserved for #362 (subject -> conversation routing). Nothing reads it.
+    subject: SubjectFunc | None = None
+    # Reserved. Deliberately not wired: no provider on the roadmap performs an
+    # HTTP handshake. Slack's Events API challenge was the motivating example,
+    # and #360 makes Socket Mode our Slack path, where it does not apply. See
+    # the "On the handshake hook" note in #359 -- this is the explicit decision
+    # to defer, not an oversight.
+    handshake: HandshakeFunc | None = None
+    capabilities: Capabilities = Capabilities()
+
+
+PROVIDERS: dict[str, Provider] = {}
+
+
+def register_provider(provider: Provider) -> None:
+    """Register a provider descriptor, replacing any entry for the same source."""
+    PROVIDERS[provider.source] = provider
+
+
+def get_provider(source: str) -> Provider | None:
+    """Return the descriptor for a source, or None if it is not built in."""
+    return PROVIDERS.get(source)
+
+
+def is_builtin_source(source: str) -> bool:
+    """Check if a source is a builtin integration."""
+    return source in PROVIDERS
+
+
+def builtin_sources() -> list[str]:
+    """Every registered provider source, sorted."""
+    return sorted(PROVIDERS)
+
+
+def reserved_sources() -> frozenset[str]:
+    """Source names a custom webhook may not claim.
+
+    Derived from the registry rather than maintained separately, so a provider
+    cannot be added without also being reserved.
+    """
+    return frozenset(PROVIDERS)
+
+
+def _register_builtin_providers() -> None:
+    """Register the built-in providers. Called at module load."""
+    from openhands.automation.event_schemas.bitbucket_data_center import (
+        parse_bitbucket_data_center_event,
+    )
+    from openhands.automation.event_schemas.github import parse_github_event_auto
+    from openhands.automation.event_schemas.jira_dc import parse_jira_dc_event
+
+    # All three are forwarded by the OpenHands server, which signs with the
+    # single shared AUTOMATION_WEBHOOK_SECRET into GitHub's header name.
+    for source, parse in (
+        ("bitbucket_data_center", parse_bitbucket_data_center_event),
+        ("github", parse_github_event_auto),
+        ("jira_dc", parse_jira_dc_event),
+    ):
+        register_provider(
+            Provider(
+                source=source,
+                parse=parse,
+                secret_from_settings=lambda s: s.webhook_secret or None,
+            )
+        )
+
+
+_register_builtin_providers()

--- a/openhands/automation/providers.py
+++ b/openhands/automation/providers.py
@@ -46,6 +46,92 @@ SubjectFunc = Callable[[dict[str, Any]], "EventSubject | None"]
 HandshakeFunc = Callable[["Request"], "Response | None"]
 
 
+class WebhookVerifier(Protocol):
+    """Proves a raw delivery was signed by the holder of the shared secret.
+
+    `signature_header` is a parameter because custom webhooks configure it per
+    row; anything else a scheme needs is read from `headers`, since those names
+    are fixed by the scheme.
+    """
+
+    def verify(
+        self,
+        *,
+        body: bytes,
+        headers: Mapping[str, str],
+        secret: str,
+        signature_header: str,
+    ) -> bool: ...
+
+
+@dataclass(frozen=True, slots=True)
+class Capabilities:
+    """What a provider's transport tolerates. Declared, never assumed."""
+
+    # Slack load-balances a payload across an app's open connections and
+    # endorses up to 10, so Socket Mode is safe to run active-active; an
+    # arbitrary WebSocket upstream would duplicate every event per replica.
+    tolerates_multiple_connections: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class Provider:
+    """Everything the service knows about one event provider."""
+
+    source: str
+    parse: ParseFunc
+    verifier: str = DEFAULT_VERIFIER
+    signature_header: str = DEFAULT_BUILTIN_SIGNATURE_HEADER
+    secret_from_settings: SecretFunc | None = None
+    # Reserved for subject-based routing. Nothing reads it.
+    subject: SubjectFunc | None = None
+    # Reserved. Deliberately not wired: no provider on the roadmap performs an
+    # HTTP handshake, and Socket Mode is our Slack path.
+    handshake: HandshakeFunc | None = None
+    capabilities: Capabilities = Capabilities()
+
+
+# Both registries are filled at the bottom of this module, once the verifier
+# implementations and the parsers they name exist.
+VERIFIERS: dict[str, WebhookVerifier] = {}
+PROVIDERS: dict[str, Provider] = {}
+
+
+def get_verifier(scheme: str | None) -> WebhookVerifier | None:
+    """Resolve a signature scheme name, treating None as the default."""
+    return VERIFIERS.get(scheme or DEFAULT_VERIFIER)
+
+
+def verifier_schemes() -> frozenset[str]:
+    """Every signature scheme a webhook may be configured with."""
+    return frozenset(VERIFIERS)
+
+
+def register_provider(provider: Provider) -> None:
+    """Register a provider descriptor, replacing any entry for the same source."""
+    PROVIDERS[provider.source] = provider
+
+
+def get_provider(source: str) -> Provider | None:
+    """Return the descriptor for a source, or None if it is not built in."""
+    return PROVIDERS.get(source)
+
+
+def is_builtin_source(source: str) -> bool:
+    """Check if a source is a builtin integration."""
+    return source in PROVIDERS
+
+
+def builtin_sources() -> list[str]:
+    """Every registered provider source, sorted."""
+    return sorted(PROVIDERS)
+
+
+def reserved_sources() -> frozenset[str]:
+    """Source names a custom webhook may not claim, derived from the registry."""
+    return frozenset(PROVIDERS)
+
+
 def get_header(headers: Mapping[str, str], name: str) -> str | None:
     """Look up a header case-insensitively, for callers passing a plain dict."""
     value = headers.get(name)
@@ -65,24 +151,6 @@ def _now_seconds() -> int:
     return int(time.time())
 
 
-class WebhookVerifier(Protocol):
-    """Proves a raw delivery was signed by the holder of the shared secret.
-
-    `signature_header` is a parameter because custom webhooks configure it per
-    row; anything else a scheme needs is read from `headers`, since those names
-    are fixed by the scheme.
-    """
-
-    def verify(
-        self,
-        *,
-        body: bytes,
-        headers: Mapping[str, str],
-        secret: str,
-        signature_header: str,
-    ) -> bool: ...
-
-
 def verify_signature(payload: bytes, signature: str, secret: str) -> bool:
     """Verify a hex HMAC-SHA256 digest, with or without a `sha256=` prefix."""
     if signature.startswith("sha256="):
@@ -94,7 +162,9 @@ def verify_signature(payload: bytes, signature: str, secret: str) -> bool:
         digestmod=hashlib.sha256,
     ).hexdigest()
 
-    return hmac.compare_digest(computed, signature)
+    # Compared as bytes: a header carrying non-ASCII decodes to a str that
+    # `compare_digest` refuses outright, raising instead of returning False.
+    return hmac.compare_digest(computed.encode("utf-8"), signature.encode("utf-8"))
 
 
 @dataclass(frozen=True, slots=True)
@@ -161,7 +231,7 @@ class StandardWebhooksVerifier:
         signed_content = f"{msg_id}.{timestamp}.".encode() + body
         expected = base64.b64encode(
             hmac.new(key, signed_content, hashlib.sha256).digest()
-        ).decode("utf-8")
+        )
 
         # Space-separated list so a secret can be rotated without a gap; any one
         # match is enough, and every token is compared to keep the work
@@ -171,7 +241,7 @@ class StandardWebhooksVerifier:
             version, _, candidate = token.partition(",")
             if not candidate or version != "v1":
                 continue
-            if hmac.compare_digest(candidate, expected):
+            if hmac.compare_digest(candidate.encode("utf-8"), expected):
                 matched = True
         return matched
 
@@ -204,85 +274,19 @@ class SlackV0Verifier:
             return False
 
         signed_content = b"v0:" + timestamp.encode("utf-8") + b":" + body
-        expected = (
-            "v0="
-            + hmac.new(
-                secret.encode("utf-8"), signed_content, hashlib.sha256
-            ).hexdigest()
-        )
-        return hmac.compare_digest(signature, expected)
+        expected = b"v0=" + hmac.new(
+            secret.encode("utf-8"), signed_content, hashlib.sha256
+        ).hexdigest().encode("utf-8")
+        return hmac.compare_digest(signature.encode("utf-8"), expected)
 
 
-VERIFIERS: dict[str, WebhookVerifier] = {
-    "hmac_sha256_hex": HmacSha256HexVerifier(),
-    "standard_webhooks": StandardWebhooksVerifier(),
-    "slack_v0": SlackV0Verifier(),
-}
-
-
-def get_verifier(scheme: str | None) -> WebhookVerifier | None:
-    """Resolve a signature scheme name, treating None as the default."""
-    return VERIFIERS.get(scheme or DEFAULT_VERIFIER)
-
-
-def verifier_schemes() -> frozenset[str]:
-    """Every signature scheme a webhook may be configured with."""
-    return frozenset(VERIFIERS)
-
-
-@dataclass(frozen=True, slots=True)
-class Capabilities:
-    """What a provider's transport tolerates. Declared, never assumed."""
-
-    # Slack load-balances a payload across an app's open connections and
-    # endorses up to 10, so Socket Mode is safe to run active-active; an
-    # arbitrary WebSocket upstream would duplicate every event per replica.
-    tolerates_multiple_connections: bool = False
-
-
-@dataclass(frozen=True, slots=True)
-class Provider:
-    """Everything the service knows about one event provider."""
-
-    source: str
-    parse: ParseFunc
-    verifier: str = DEFAULT_VERIFIER
-    signature_header: str = DEFAULT_BUILTIN_SIGNATURE_HEADER
-    secret_from_settings: SecretFunc | None = None
-    # Reserved for subject-based routing. Nothing reads it.
-    subject: SubjectFunc | None = None
-    # Reserved. Deliberately not wired: no provider on the roadmap performs an
-    # HTTP handshake, and Socket Mode is our Slack path.
-    handshake: HandshakeFunc | None = None
-    capabilities: Capabilities = Capabilities()
-
-
-PROVIDERS: dict[str, Provider] = {}
-
-
-def register_provider(provider: Provider) -> None:
-    """Register a provider descriptor, replacing any entry for the same source."""
-    PROVIDERS[provider.source] = provider
-
-
-def get_provider(source: str) -> Provider | None:
-    """Return the descriptor for a source, or None if it is not built in."""
-    return PROVIDERS.get(source)
-
-
-def is_builtin_source(source: str) -> bool:
-    """Check if a source is a builtin integration."""
-    return source in PROVIDERS
-
-
-def builtin_sources() -> list[str]:
-    """Every registered provider source, sorted."""
-    return sorted(PROVIDERS)
-
-
-def reserved_sources() -> frozenset[str]:
-    """Source names a custom webhook may not claim, derived from the registry."""
-    return frozenset(PROVIDERS)
+VERIFIERS.update(
+    {
+        "hmac_sha256_hex": HmacSha256HexVerifier(),
+        "standard_webhooks": StandardWebhooksVerifier(),
+        "slack_v0": SlackV0Verifier(),
+    }
+)
 
 
 def _register_builtin_providers() -> None:

--- a/openhands/automation/providers.py
+++ b/openhands/automation/providers.py
@@ -7,10 +7,8 @@ per-org custom webhook can pick one. No transport imports.
 """
 
 import base64
-import binascii
 import hashlib
 import hmac
-import logging
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
@@ -24,9 +22,6 @@ if TYPE_CHECKING:
     from fastapi import Request, Response
 
     from openhands.automation.ingest import EventSubject
-
-
-logger = logging.getLogger("automation.providers")
 
 
 DEFAULT_VERIFIER: Final[str] = "hmac_sha256_hex"
@@ -138,17 +133,20 @@ def get_header(headers: Mapping[str, str], name: str) -> str | None:
     if value is not None:
         return value
     lowered = name.lower()
-    value = headers.get(lowered)
-    if value is not None:
-        return value
-    for key, candidate in headers.items():
-        if key.lower() == lowered:
-            return candidate
-    return None
+    return next((v for k, v in headers.items() if k.lower() == lowered), None)
 
 
 def _now_seconds() -> int:
     return int(time.time())
+
+
+def _within_tolerance(timestamp: str, clock: Callable[[], int], tolerance: int) -> bool:
+    """Whether a signed timestamp sits inside the replay window."""
+    try:
+        sent_at = int(timestamp)
+    except ValueError:
+        return False
+    return abs(clock() - sent_at) <= tolerance
 
 
 def verify_signature(payload: bytes, signature: str, secret: str) -> bool:
@@ -191,8 +189,9 @@ def standard_webhooks_key(secret: str) -> bytes:
     if key_material.startswith("whsec_"):
         key_material = key_material[len("whsec_") :]
     try:
+        # binascii.Error, which b64decode raises, subclasses ValueError.
         return base64.b64decode(key_material, validate=True)
-    except (binascii.Error, ValueError):
+    except ValueError:
         return secret.encode("utf-8")
 
 
@@ -219,12 +218,7 @@ class StandardWebhooksVerifier:
         timestamp = get_header(headers, STANDARD_WEBHOOKS_TIMESTAMP_HEADER)
         if not signature or not msg_id or not timestamp:
             return False
-
-        try:
-            sent_at = int(timestamp)
-        except (TypeError, ValueError):
-            return False
-        if abs(self.clock() - sent_at) > self.tolerance_seconds:
+        if not _within_tolerance(timestamp, self.clock, self.tolerance_seconds):
             return False
 
         key = standard_webhooks_key(secret)
@@ -265,12 +259,7 @@ class SlackV0Verifier:
         timestamp = get_header(headers, SLACK_TIMESTAMP_HEADER)
         if not signature or not timestamp:
             return False
-
-        try:
-            sent_at = int(timestamp)
-        except (TypeError, ValueError):
-            return False
-        if abs(self.clock() - sent_at) > self.tolerance_seconds:
+        if not _within_tolerance(timestamp, self.clock, self.tolerance_seconds):
             return False
 
         signed_content = b"v0:" + timestamp.encode("utf-8") + b":" + body

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -10,6 +10,12 @@ from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, field_val
 from pydantic.alias_generators import to_camel
 
 from openhands.automation.constants import MODEL_PROFILE_PATTERN
+from openhands.automation.providers import (
+    DEFAULT_VERIFIER,
+    is_builtin_source,
+    reserved_sources,
+    verifier_schemes,
+)
 from openhands.automation.utils.cron import (
     validate_cron_schedule as validate_cron_schedule_value,
     validate_timezone_name,
@@ -440,6 +446,9 @@ class WebhookConfig(BaseModel):
     is_builtin: bool = False  # True for built-in OpenHands-forwarded sources
     event_key_expr: str = "type"  # JMESPath expression for extracting event key
     signature_header: str = "X-Hub-Signature-256"  # HTTP header for signature
+    # Names a verifier in providers.VERIFIERS. Always resolved by the time it
+    # reaches here, so this is a concrete scheme rather than None.
+    signature_scheme: str = DEFAULT_VERIFIER
 
 
 class EventResponse(BaseModel):
@@ -468,12 +477,30 @@ class RequestedEventTypesResponse(BaseModel):
 # Valid source name pattern: lowercase alphanumeric with hyphens, 1-50 chars
 _SOURCE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,48}[a-z0-9]$|^[a-z0-9]$")
 
-# Reserved source names (built-in integrations)
-RESERVED_SOURCES = frozenset({"bitbucket_data_center", "github", "jira_dc"})
+# Reserved source names, derived from the provider registry so a provider
+# cannot be added without also being reserved. This is a snapshot for
+# introspection and tests; validation calls `is_builtin_source()` so a provider
+# registered after import time is still protected.
+RESERVED_SOURCES = reserved_sources()
 
 
 # Valid HTTP header name pattern
 _HEADER_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9-]{0,98}[A-Za-z0-9]$|^[A-Za-z]$")
+
+
+def _validate_signature_scheme(v: str) -> str:
+    """Reject a scheme with no verifier behind it.
+
+    Derived from the verifier registry, so adding a verifier makes it
+    configurable without touching this validator.
+    """
+    schemes = verifier_schemes()
+    if v not in schemes:
+        raise ValueError(
+            f"Invalid signature_scheme '{v}'. Must be one of: "
+            f"{', '.join(sorted(schemes))}"
+        )
+    return v
 
 
 class CustomWebhookCreate(BaseModel):
@@ -512,6 +539,20 @@ class CustomWebhookCreate(BaseModel):
             "Examples: 'X-Signature-256', 'Stripe-Signature', 'X-Slack-Signature'"
         ),
     )
+    signature_scheme: str = Field(
+        default=DEFAULT_VERIFIER,
+        max_length=50,
+        description=(
+            "How the value in `signature_header` is computed. "
+            "'hmac_sha256_hex' (default) is a hex digest over the raw body "
+            "(GitHub, Linear). 'standard_webhooks' follows "
+            "standardwebhooks.com (GitLab 19.1+ signing tokens, Svix) and also "
+            "reads the webhook-id and webhook-timestamp headers. 'slack_v0' is "
+            "the Slack Events API scheme and also reads "
+            "X-Slack-Request-Timestamp. The timestamped schemes reject "
+            "deliveries outside a 5-minute replay window."
+        ),
+    )
     webhook_secret: str | None = Field(
         default=None,
         min_length=8,
@@ -527,7 +568,7 @@ class CustomWebhookCreate(BaseModel):
     def validate_source_name(cls, v: str) -> str:
         """Validate source name format and check for reserved names."""
         v_lower = v.lower()
-        if v_lower in RESERVED_SOURCES:
+        if is_builtin_source(v_lower):
             raise ValueError(
                 f"'{v}' is a reserved source name. "
                 "Use the built-in integration instead."
@@ -538,6 +579,12 @@ class CustomWebhookCreate(BaseModel):
                 "starting and ending with alphanumeric"
             )
         return v_lower
+
+    @field_validator("signature_scheme")
+    @classmethod
+    def validate_signature_scheme(cls, v: str) -> str:
+        """Validate the scheme names a registered verifier."""
+        return _validate_signature_scheme(v)
 
     @field_validator("event_key_expr")
     @classmethod
@@ -572,7 +619,16 @@ class CustomWebhookUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=255)
     event_key_expr: str | None = Field(default=None, max_length=500)
     signature_header: str | None = Field(default=None, max_length=100)
+    signature_scheme: str | None = Field(default=None, max_length=50)
     enabled: bool | None = None
+
+    @field_validator("signature_scheme")
+    @classmethod
+    def validate_signature_scheme(cls, v: str | None) -> str | None:
+        """Validate the scheme names a registered verifier, if provided."""
+        if v is None:
+            return v
+        return _validate_signature_scheme(v)
 
     @field_validator("event_key_expr")
     @classmethod
@@ -613,6 +669,7 @@ class CustomWebhookResponse(BaseModel):
     webhook_url: str
     event_key_expr: str
     signature_header: str
+    signature_scheme: str
     enabled: bool
     created_at: UtcDatetime
     updated_at: UtcDatetime

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -446,9 +446,7 @@ class WebhookConfig(BaseModel):
     is_builtin: bool = False  # True for built-in OpenHands-forwarded sources
     event_key_expr: str = "type"  # JMESPath expression for extracting event key
     signature_header: str = "X-Hub-Signature-256"  # HTTP header for signature
-    # Names a verifier in providers.VERIFIERS. Always resolved by the time it
-    # reaches here, so this is a concrete scheme rather than None.
-    signature_scheme: str = DEFAULT_VERIFIER
+    signature_scheme: str = DEFAULT_VERIFIER  # a verifier in providers.VERIFIERS
 
 
 class EventResponse(BaseModel):
@@ -477,10 +475,8 @@ class RequestedEventTypesResponse(BaseModel):
 # Valid source name pattern: lowercase alphanumeric with hyphens, 1-50 chars
 _SOURCE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,48}[a-z0-9]$|^[a-z0-9]$")
 
-# Reserved source names, derived from the provider registry so a provider
-# cannot be added without also being reserved. This is a snapshot for
-# introspection and tests; validation calls `is_builtin_source()` so a provider
-# registered after import time is still protected.
+# Snapshot for introspection; validation calls `is_builtin_source()` so a
+# provider registered after import time is still protected.
 RESERVED_SOURCES = reserved_sources()
 
 
@@ -489,11 +485,7 @@ _HEADER_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9-]{0,98}[A-Za-z0-9]$|^[A-Za-z]
 
 
 def _validate_signature_scheme(v: str) -> str:
-    """Reject a scheme with no verifier behind it.
-
-    Derived from the verifier registry, so adding a verifier makes it
-    configurable without touching this validator.
-    """
+    """Reject a scheme with no verifier behind it."""
     schemes = verifier_schemes()
     if v not in schemes:
         raise ValueError(

--- a/openhands/automation/utils/webhook.py
+++ b/openhands/automation/utils/webhook.py
@@ -33,8 +33,8 @@ from openhands.automation.schemas import EventTrigger, WebhookConfig
 logger = logging.getLogger("automation.utils.webhook")
 
 
-# Re-exported for callers that predate the provider registry. Both now live in
-# `openhands.automation.providers`, which is the single description of a source.
+# `is_builtin_source` and `verify_signature` now live in `providers`; re-exported
+# here for callers that predate the registry.
 __all__ = [
     "create_automation_run",
     "get_event_automations",
@@ -43,11 +43,6 @@ __all__ = [
     "is_builtin_source",
     "verify_signature",
 ]
-
-
-# =============================================================================
-# Webhook Functions
-# =============================================================================
 
 
 async def get_webhook_config(
@@ -103,8 +98,8 @@ async def get_webhook_config(
             is_builtin=False,
             event_key_expr=webhook.event_key_expr,
             signature_header=webhook.signature_header,
-            # Nullable column: rows written before the scheme existed read as
-            # NULL and mean the behaviour they were created with.
+            # NULL on rows predating the column: the default is what they were
+            # created with.
             signature_scheme=webhook.signature_scheme or DEFAULT_VERIFIER,
         )
     return None

--- a/openhands/automation/utils/webhook.py
+++ b/openhands/automation/utils/webhook.py
@@ -98,8 +98,7 @@ async def get_webhook_config(
             is_builtin=False,
             event_key_expr=webhook.event_key_expr,
             signature_header=webhook.signature_header,
-            # NULL on rows predating the column: the default is what they were
-            # created with.
+            # A cleared column reads as the default.
             signature_scheme=webhook.signature_scheme or DEFAULT_VERIFIER,
         )
     return None

--- a/openhands/automation/utils/webhook.py
+++ b/openhands/automation/utils/webhook.py
@@ -1,21 +1,19 @@
 """
 Webhook utility functions for event processing.
 
-Contains helpers for signature verification, webhook configuration lookup,
-and automation run creation for event-triggered automations.
+Contains helpers for webhook configuration lookup and automation run creation
+for event-triggered automations. Signature verification and the description of
+a source both live in `openhands.automation.providers`.
 """
 
-import hashlib
-import hmac
 import logging
 import uuid
-from collections.abc import Callable
 from typing import Any
 
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from openhands.automation.config import Settings, get_settings
+from openhands.automation.config import get_settings
 from openhands.automation.db import using_sqlite
 from openhands.automation.models import (
     Automation,
@@ -23,74 +21,33 @@ from openhands.automation.models import (
     AutomationRunStatus,
     CustomWebhook,
 )
+from openhands.automation.providers import (
+    DEFAULT_VERIFIER,
+    get_provider,
+    is_builtin_source,
+    verify_signature,
+)
 from openhands.automation.schemas import EventTrigger, WebhookConfig
 
 
 logger = logging.getLogger("automation.utils.webhook")
 
 
-# =============================================================================
-# Builtin Source Registry
-# =============================================================================
-# Registry pattern for builtin webhook sources. Each source maps to a function
-# that extracts the webhook secret from settings. Add new integrations here.
-
-BuiltinConfigFunc = Callable[[Settings], str | None]
-
-BUILTIN_SOURCES: dict[str, BuiltinConfigFunc] = {
-    "bitbucket_data_center": lambda s: s.webhook_secret or None,
-    "github": lambda s: s.webhook_secret or None,
-    "jira_dc": lambda s: s.webhook_secret or None,
-}
-
-
-def register_builtin_source(source: str, config_func: BuiltinConfigFunc) -> None:
-    """Register a new builtin webhook source.
-
-    Args:
-        source: Source name (e.g., "bitbucket")
-        config_func: Function that extracts the webhook secret from Settings
-    """
-    BUILTIN_SOURCES[source] = config_func
-
-
-def is_builtin_source(source: str) -> bool:
-    """Check if a source is a builtin integration."""
-    return source in BUILTIN_SOURCES
+# Re-exported for callers that predate the provider registry. Both now live in
+# `openhands.automation.providers`, which is the single description of a source.
+__all__ = [
+    "create_automation_run",
+    "get_event_automations",
+    "get_requested_event_types",
+    "get_webhook_config",
+    "is_builtin_source",
+    "verify_signature",
+]
 
 
 # =============================================================================
 # Webhook Functions
 # =============================================================================
-
-
-def verify_signature(payload: bytes, signature: str, secret: str) -> bool:
-    """
-    Verify HMAC-SHA256 signature.
-
-    Accepts both formats:
-    - GitHub/normalized: 'sha256=<hex>'
-    - Raw hex digest: '<hex>' (e.g., Linear)
-
-    Args:
-        payload: Raw request body bytes
-        signature: Signature from header
-        secret: The shared secret
-
-    Returns:
-        True if signature is valid
-    """
-    # Normalize: strip 'sha256=' prefix if present
-    if signature.startswith("sha256="):
-        signature = signature[7:]
-
-    computed = hmac.new(
-        secret.encode("utf-8"),
-        msg=payload,
-        digestmod=hashlib.sha256,
-    ).hexdigest()
-
-    return hmac.compare_digest(computed, signature)
 
 
 async def get_webhook_config(
@@ -115,14 +72,19 @@ async def get_webhook_config(
     settings = get_settings()
 
     # Check builtin sources first
-    if source in BUILTIN_SOURCES:
-        config_func = BUILTIN_SOURCES[source]
-        secret = config_func(settings)
+    provider = get_provider(source)
+    if provider is not None:
+        secret = (
+            provider.secret_from_settings(settings)
+            if provider.secret_from_settings
+            else None
+        )
         if secret:
             return WebhookConfig(
                 secret=secret,
                 is_builtin=True,
-                signature_header="X-Hub-Signature-256",  # GitHub's header
+                signature_header=provider.signature_header,
+                signature_scheme=provider.verifier,
             )
         return None
 
@@ -141,6 +103,9 @@ async def get_webhook_config(
             is_builtin=False,
             event_key_expr=webhook.event_key_expr,
             signature_header=webhook.signature_header,
+            # Nullable column: rows written before the scheme existed read as
+            # NULL and mean the behaviour they were created with.
+            signature_scheme=webhook.signature_scheme or DEFAULT_VERIFIER,
         )
     return None
 

--- a/openhands/automation/webhook_router.py
+++ b/openhands/automation/webhook_router.py
@@ -63,7 +63,7 @@ def _webhook_to_response(webhook: CustomWebhook) -> CustomWebhookResponse:
         webhook_url=_build_webhook_url(webhook.org_id, webhook.source),
         event_key_expr=webhook.event_key_expr,
         signature_header=webhook.signature_header,
-        # NULL on rows predating the column; they verify as the default.
+        # A cleared column verifies as the default.
         signature_scheme=webhook.signature_scheme or DEFAULT_VERIFIER,
         enabled=webhook.enabled,
         created_at=webhook.created_at,

--- a/openhands/automation/webhook_router.py
+++ b/openhands/automation/webhook_router.py
@@ -26,6 +26,7 @@ from openhands.automation.auth import AuthenticatedUser, authenticate_request
 from openhands.automation.config import get_settings
 from openhands.automation.db import get_session
 from openhands.automation.models import CustomWebhook
+from openhands.automation.providers import DEFAULT_VERIFIER
 from openhands.automation.schemas import (
     CustomWebhookCreate,
     CustomWebhookCreateResponse,
@@ -62,6 +63,8 @@ def _webhook_to_response(webhook: CustomWebhook) -> CustomWebhookResponse:
         webhook_url=_build_webhook_url(webhook.org_id, webhook.source),
         event_key_expr=webhook.event_key_expr,
         signature_header=webhook.signature_header,
+        # NULL on rows predating the column; they verify as the default.
+        signature_scheme=webhook.signature_scheme or DEFAULT_VERIFIER,
         enabled=webhook.enabled,
         created_at=webhook.created_at,
         updated_at=webhook.updated_at,
@@ -120,6 +123,7 @@ async def create_webhook(
         webhook_secret=secret,
         event_key_expr=data.event_key_expr,
         signature_header=data.signature_header,
+        signature_scheme=data.signature_scheme,
         enabled=True,
     )
 
@@ -198,7 +202,8 @@ async def update_webhook(
     """
     Update a webhook's configuration.
 
-    Updatable fields: `name`, `event_key_expr`, `signature_header`, `enabled`.
+    Updatable fields: `name`, `event_key_expr`, `signature_header`,
+    `signature_scheme`, `enabled`.
     The `source` cannot be changed after creation.
     """
     webhook = await session.get(CustomWebhook, webhook_id)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,952 @@
+"""Tests for the provider descriptor registry and the signature verifiers.
+
+The verifier tests construct verifiers directly -- no HTTP, no app, no DB -- so
+a scheme's behaviour is pinned independently of the router that resolves it.
+The HTTP tests at the bottom cover the two things only the wired-up path can
+show: that a custom webhook can select a non-default scheme, and that adding a
+provider takes a registry entry and nothing else.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+import uuid
+from dataclasses import FrozenInstanceError
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from openhands.automation.auth import AuthenticatedUser
+from openhands.automation.config import Settings, clear_config_cache
+from openhands.automation.event_schemas import WebhookEvent, parse_event
+from openhands.automation.models import Automation, CustomWebhook
+from openhands.automation.providers import (
+    DEFAULT_BUILTIN_SIGNATURE_HEADER,
+    DEFAULT_VERIFIER,
+    PROVIDERS,
+    SLACK_TIMESTAMP_HEADER,
+    STANDARD_WEBHOOKS_ID_HEADER,
+    STANDARD_WEBHOOKS_TIMESTAMP_HEADER,
+    VERIFIERS,
+    Capabilities,
+    HmacSha256HexVerifier,
+    Provider,
+    SlackV0Verifier,
+    StandardWebhooksVerifier,
+    builtin_sources,
+    get_header,
+    get_provider,
+    get_verifier,
+    is_builtin_source,
+    register_provider,
+    reserved_sources,
+    standard_webhooks_key,
+    verifier_schemes,
+    verify_signature,
+)
+from openhands.automation.schemas import (
+    RESERVED_SOURCES,
+    CustomWebhookCreate,
+    CustomWebhookUpdate,
+)
+from openhands.automation.utils.webhook import get_webhook_config
+
+
+BUILTIN_PROVIDER_SOURCES = frozenset({"bitbucket_data_center", "github", "jira_dc"})
+
+
+@pytest.fixture
+def org_id(mock_authenticated_user: AuthenticatedUser) -> uuid.UUID:
+    """Get org_id from the authenticated user fixture."""
+    return mock_authenticated_user.org_id
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache():
+    """Clear the settings cache before and after each test."""
+    clear_config_cache()
+    yield
+    clear_config_cache()
+
+
+@pytest.fixture
+def temp_provider():
+    """Register a provider for one test and remove it afterwards.
+
+    The registry is process-global, so a test that adds to it has to put it
+    back or it leaks into every test that reads RESERVED_SOURCES.
+    """
+    registered: list[str] = []
+
+    def _register(provider: Provider) -> Provider:
+        register_provider(provider)
+        registered.append(provider.source)
+        return provider
+
+    yield _register
+
+    for source in registered:
+        PROVIDERS.pop(source, None)
+
+
+# =============================================================================
+# Header access
+# =============================================================================
+
+
+class TestGetHeader:
+    """Header lookup has to survive whatever casing a caller hands us."""
+
+    def test_exact_match(self):
+        assert get_header({"X-Sig": "v"}, "X-Sig") == "v"
+
+    def test_lowercase_stored(self):
+        assert get_header({"x-sig": "v"}, "X-Sig") == "v"
+
+    def test_uppercase_stored(self):
+        assert get_header({"X-SIG": "v"}, "x-sig") == "v"
+
+    def test_mixed_case_stored(self):
+        assert get_header({"X-hUb-SiGnAtUrE-256": "v"}, "X-Hub-Signature-256") == "v"
+
+    def test_missing(self):
+        assert get_header({"other": "v"}, "X-Sig") is None
+
+    def test_empty_mapping(self):
+        assert get_header({}, "X-Sig") is None
+
+
+# =============================================================================
+# hmac_sha256_hex
+# =============================================================================
+
+
+class TestHmacSha256HexVerifier:
+    """The scheme every existing source and custom webhook row uses today."""
+
+    SECRET = "test-secret"
+    HEADER = "X-Hub-Signature-256"
+
+    def _sign(self, body: bytes, secret: str | None = None) -> str:
+        digest = hmac.new(
+            (secret or self.SECRET).encode(), body, hashlib.sha256
+        ).hexdigest()
+        return f"sha256={digest}"
+
+    def test_valid_prefixed_signature(self):
+        body = b'{"a":1}'
+        assert HmacSha256HexVerifier().verify(
+            body=body,
+            headers={self.HEADER: self._sign(body)},
+            secret=self.SECRET,
+            signature_header=self.HEADER,
+        )
+
+    def test_valid_bare_hex_signature(self):
+        """Linear sends the digest with no 'sha256=' prefix."""
+        body = b'{"a":1}'
+        bare = self._sign(body).removeprefix("sha256=")
+        assert HmacSha256HexVerifier().verify(
+            body=body,
+            headers={self.HEADER: bare},
+            secret=self.SECRET,
+            signature_header=self.HEADER,
+        )
+
+    def test_tampered_body_rejected(self):
+        signature = self._sign(b'{"a":1}')
+        assert not HmacSha256HexVerifier().verify(
+            body=b'{"a":2}',
+            headers={self.HEADER: signature},
+            secret=self.SECRET,
+            signature_header=self.HEADER,
+        )
+
+    def test_wrong_secret_rejected(self):
+        body = b'{"a":1}'
+        assert not HmacSha256HexVerifier().verify(
+            body=body,
+            headers={self.HEADER: self._sign(body, "other-secret")},
+            secret=self.SECRET,
+            signature_header=self.HEADER,
+        )
+
+    def test_missing_header_rejected(self):
+        assert not HmacSha256HexVerifier().verify(
+            body=b'{"a":1}',
+            headers={},
+            secret=self.SECRET,
+            signature_header=self.HEADER,
+        )
+
+    def test_reads_the_configured_header_not_a_fixed_one(self):
+        """A custom webhook may put the same scheme behind any header name."""
+        body = b'{"a":1}'
+        signature = self._sign(body)
+        verifier = HmacSha256HexVerifier()
+        assert verifier.verify(
+            body=body,
+            headers={"Stripe-Signature": signature},
+            secret=self.SECRET,
+            signature_header="Stripe-Signature",
+        )
+        assert not verifier.verify(
+            body=body,
+            headers={"Stripe-Signature": signature},
+            secret=self.SECRET,
+            signature_header="X-Signature-256",
+        )
+
+    def test_matches_verify_signature_directly(self):
+        """The verifier is the existing function, not a reimplementation."""
+        body = b'{"a":1}'
+        signature = self._sign(body)
+        assert verify_signature(body, signature, self.SECRET)
+        assert HmacSha256HexVerifier().verify(
+            body=body,
+            headers={self.HEADER: signature},
+            secret=self.SECRET,
+            signature_header=self.HEADER,
+        )
+
+
+# =============================================================================
+# standard_webhooks
+# =============================================================================
+
+
+class TestStandardWebhooksVerifier:
+    """standardwebhooks.com -- GitLab 19.1+ signing tokens, Svix."""
+
+    SECRET = "whsec_uX0GkGuuABEuIJhcJxNEotfG8+WjeIkZuJJqJdsm/CQ="
+    MSG_ID = "msg_2abc"
+    TS = "1752900000"
+    NOW = 1752900000
+    HEADER = "webhook-signature"
+
+    def _verifier(self, now: int | None = None) -> StandardWebhooksVerifier:
+        return StandardWebhooksVerifier(clock=lambda: self.NOW if now is None else now)
+
+    def _sign(
+        self,
+        body: bytes,
+        secret: str | None = None,
+        msg_id: str | None = None,
+        ts: str | None = None,
+    ) -> str:
+        key = standard_webhooks_key(secret or self.SECRET)
+        signed = f"{msg_id or self.MSG_ID}.{ts or self.TS}.".encode() + body
+        digest = base64.b64encode(hmac.new(key, signed, hashlib.sha256).digest())
+        return f"v1,{digest.decode()}"
+
+    def _headers(self, signature: str, ts: str | None = None) -> dict[str, str]:
+        return {
+            self.HEADER: signature,
+            STANDARD_WEBHOOKS_ID_HEADER: self.MSG_ID,
+            STANDARD_WEBHOOKS_TIMESTAMP_HEADER: ts or self.TS,
+        }
+
+    def _verify(self, verifier, body: bytes, headers: dict[str, str]) -> bool:
+        return verifier.verify(
+            body=body,
+            headers=headers,
+            secret=self.SECRET,
+            signature_header=self.HEADER,
+        )
+
+    def test_known_good_fixture(self):
+        body = b'{"object_kind":"note"}'
+        assert self._verify(self._verifier(), body, self._headers(self._sign(body)))
+
+    def test_key_is_base64_decoded_after_stripping_whsec(self):
+        """The signing key is the decoded secret, not its literal characters."""
+        assert standard_webhooks_key(self.SECRET) == base64.b64decode(
+            self.SECRET.removeprefix("whsec_")
+        )
+
+    def test_non_base64_secret_falls_back_to_raw_bytes(self):
+        assert standard_webhooks_key("plain-text-secret") == b"plain-text-secret"
+
+    def test_tampered_body_rejected(self):
+        signature = self._sign(b'{"object_kind":"note"}')
+        assert not self._verify(
+            self._verifier(), b'{"object_kind":"push"}', self._headers(signature)
+        )
+
+    def test_wrong_key_rejected(self):
+        body = b'{"object_kind":"note"}'
+        signature = self._sign(
+            body, secret="whsec_" + base64.b64encode(b"x" * 24).decode()
+        )
+        assert not self._verify(self._verifier(), body, self._headers(signature))
+
+    def test_msg_id_is_signed(self):
+        """The id is part of the signed content, so swapping it must fail."""
+        body = b'{"object_kind":"note"}'
+        headers = self._headers(self._sign(body, msg_id="msg_other"))
+        assert not self._verify(self._verifier(), body, headers)
+
+    def test_timestamp_past_the_window_rejected(self):
+        body = b'{"object_kind":"note"}'
+        headers = self._headers(self._sign(body))
+        assert not self._verify(self._verifier(now=self.NOW + 301), body, headers)
+
+    def test_timestamp_inside_the_window_accepted(self):
+        body = b'{"object_kind":"note"}'
+        headers = self._headers(self._sign(body))
+        assert self._verify(self._verifier(now=self.NOW + 299), body, headers)
+
+    def test_timestamp_from_the_future_rejected(self):
+        """The window is absolute, so a forward-dated delivery fails too."""
+        body = b'{"object_kind":"note"}'
+        headers = self._headers(self._sign(body))
+        assert not self._verify(self._verifier(now=self.NOW - 301), body, headers)
+
+    def test_timestamp_is_signed(self):
+        """Re-stamping a captured delivery to make it fresh must not verify."""
+        body = b'{"object_kind":"note"}'
+        stale = self._sign(body, ts=str(self.NOW - 10_000))
+        assert not self._verify(
+            self._verifier(), body, self._headers(stale, ts=str(self.NOW))
+        )
+
+    def test_non_integer_timestamp_rejected(self):
+        body = b'{"object_kind":"note"}'
+        headers = self._headers(self._sign(body), ts="not-a-number")
+        assert not self._verify(self._verifier(), body, headers)
+
+    def test_missing_id_header_rejected(self):
+        body = b'{"object_kind":"note"}'
+        headers = self._headers(self._sign(body))
+        del headers[STANDARD_WEBHOOKS_ID_HEADER]
+        assert not self._verify(self._verifier(), body, headers)
+
+    def test_missing_timestamp_header_rejected(self):
+        body = b'{"object_kind":"note"}'
+        headers = self._headers(self._sign(body))
+        del headers[STANDARD_WEBHOOKS_TIMESTAMP_HEADER]
+        assert not self._verify(self._verifier(), body, headers)
+
+    def test_missing_signature_header_rejected(self):
+        body = b'{"object_kind":"note"}'
+        headers = self._headers(self._sign(body))
+        del headers[self.HEADER]
+        assert not self._verify(self._verifier(), body, headers)
+
+    def test_multiple_signatures_any_match_accepted(self):
+        """Rotation sends both old and new; one match is enough."""
+        body = b'{"object_kind":"note"}'
+        good = self._sign(body)
+        stale_key = "whsec_" + base64.b64encode(b"y" * 24).decode()
+        bad = self._sign(body, secret=stale_key)
+        assert self._verify(self._verifier(), body, self._headers(f"{bad} {good}"))
+        assert self._verify(self._verifier(), body, self._headers(f"{good} {bad}"))
+
+    def test_unknown_version_ignored(self):
+        body = b'{"object_kind":"note"}'
+        v2 = "v2," + self._sign(body).partition(",")[2]
+        assert not self._verify(self._verifier(), body, self._headers(v2))
+
+    def test_bare_signature_without_version_rejected(self):
+        """Unlike hmac_sha256_hex, this scheme requires the version tag."""
+        body = b'{"object_kind":"note"}'
+        bare = self._sign(body).partition(",")[2]
+        assert not self._verify(self._verifier(), body, self._headers(bare))
+
+
+# =============================================================================
+# slack_v0
+# =============================================================================
+
+
+class TestSlackV0Verifier:
+    """Slack Events API: hex HMAC over "v0:{timestamp}:{body}"."""
+
+    SECRET = "8f742231b10e8888abcd99yyyzzz85a5"
+    TS = "1531420618"
+    NOW = 1531420618
+    HEADER = "X-Slack-Signature"
+
+    def _verifier(self, now: int | None = None) -> SlackV0Verifier:
+        return SlackV0Verifier(clock=lambda: self.NOW if now is None else now)
+
+    def _sign(self, body: bytes, ts: str | None = None) -> str:
+        signed = b"v0:" + (ts or self.TS).encode() + b":" + body
+        return (
+            "v0=" + hmac.new(self.SECRET.encode(), signed, hashlib.sha256).hexdigest()
+        )
+
+    def _headers(self, signature: str, ts: str | None = None) -> dict[str, str]:
+        return {self.HEADER: signature, SLACK_TIMESTAMP_HEADER: ts or self.TS}
+
+    def _verify(self, verifier, body: bytes, headers: dict[str, str]) -> bool:
+        return verifier.verify(
+            body=body,
+            headers=headers,
+            secret=self.SECRET,
+            signature_header=self.HEADER,
+        )
+
+    def test_known_good_fixture(self):
+        body = b"token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J"
+        assert self._verify(self._verifier(), body, self._headers(self._sign(body)))
+
+    def test_tampered_body_rejected(self):
+        signature = self._sign(b"team_id=T1DC2JH3J")
+        assert not self._verify(
+            self._verifier(), b"team_id=TEVIL", self._headers(signature)
+        )
+
+    def test_stale_timestamp_rejected(self):
+        body = b"team_id=T1DC2JH3J"
+        headers = self._headers(self._sign(body))
+        assert not self._verify(self._verifier(now=self.NOW + 301), body, headers)
+
+    def test_fresh_timestamp_accepted(self):
+        body = b"team_id=T1DC2JH3J"
+        headers = self._headers(self._sign(body))
+        assert self._verify(self._verifier(now=self.NOW + 299), body, headers)
+
+    def test_timestamp_is_signed(self):
+        body = b"team_id=T1DC2JH3J"
+        stale = self._sign(body, ts=str(self.NOW - 10_000))
+        assert not self._verify(
+            self._verifier(), body, self._headers(stale, ts=str(self.NOW))
+        )
+
+    def test_missing_timestamp_header_rejected(self):
+        body = b"team_id=T1DC2JH3J"
+        assert not self._verify(self._verifier(), body, {self.HEADER: self._sign(body)})
+
+    def test_missing_signature_header_rejected(self):
+        assert not self._verify(
+            self._verifier(), b"team_id=T1DC2JH3J", {SLACK_TIMESTAMP_HEADER: self.TS}
+        )
+
+    def test_non_integer_timestamp_rejected(self):
+        body = b"team_id=T1DC2JH3J"
+        headers = self._headers(self._sign(body), ts="nope")
+        assert not self._verify(self._verifier(), body, headers)
+
+    def test_v0_prefix_required(self):
+        body = b"team_id=T1DC2JH3J"
+        bare = self._sign(body).removeprefix("v0=")
+        assert not self._verify(self._verifier(), body, self._headers(bare))
+
+
+# =============================================================================
+# Verifier registry
+# =============================================================================
+
+
+class TestVerifierRegistry:
+    def test_registered_schemes(self):
+        assert verifier_schemes() == {
+            "hmac_sha256_hex",
+            "standard_webhooks",
+            "slack_v0",
+        }
+
+    def test_default_scheme_is_the_existing_behaviour(self):
+        assert DEFAULT_VERIFIER == "hmac_sha256_hex"
+        assert isinstance(VERIFIERS[DEFAULT_VERIFIER], HmacSha256HexVerifier)
+
+    def test_none_resolves_to_the_default(self):
+        """A row predating the column has no scheme and must not lose one."""
+        assert get_verifier(None) is VERIFIERS[DEFAULT_VERIFIER]
+
+    def test_named_scheme_resolves(self):
+        assert isinstance(get_verifier("slack_v0"), SlackV0Verifier)
+        assert isinstance(get_verifier("standard_webhooks"), StandardWebhooksVerifier)
+
+    def test_unknown_scheme_resolves_to_nothing(self):
+        assert get_verifier("pgp") is None
+
+
+# =============================================================================
+# Provider registry
+# =============================================================================
+
+
+class TestProviderRegistry:
+    def test_builtin_providers_registered(self):
+        assert set(builtin_sources()) == BUILTIN_PROVIDER_SOURCES
+
+    def test_is_builtin_source(self):
+        assert is_builtin_source("github")
+        assert not is_builtin_source("stripe")
+
+    def test_reserved_sources_are_derived_from_the_registry(self):
+        assert reserved_sources() == frozenset(PROVIDERS)
+        assert RESERVED_SOURCES == BUILTIN_PROVIDER_SOURCES
+
+    def test_registering_a_provider_reserves_its_source(self, temp_provider):
+        assert not is_builtin_source("gitlab")
+        temp_provider(Provider(source="gitlab", parse=lambda p: parse_event("x", p)))
+        assert is_builtin_source("gitlab")
+        assert "gitlab" in reserved_sources()
+
+    def test_a_late_registered_source_cannot_be_claimed_by_a_custom_webhook(
+        self, temp_provider
+    ):
+        """Validation asks the registry, not a snapshot taken at import time."""
+        temp_provider(Provider(source="gitlab", parse=lambda p: parse_event("x", p)))
+        with pytest.raises(ValueError, match="reserved source name"):
+            CustomWebhookCreate(name="GitLab", source="gitlab")
+
+    def test_builtin_sources_cannot_be_claimed_by_a_custom_webhook(self):
+        for source in sorted(BUILTIN_PROVIDER_SOURCES):
+            with pytest.raises(ValueError, match="reserved source name"):
+                CustomWebhookCreate(name="Impostor", source=source)
+
+
+class TestProviderDescriptors:
+    def test_builtins_default_to_the_existing_verifier_and_header(self):
+        for source in sorted(BUILTIN_PROVIDER_SOURCES):
+            provider = get_provider(source)
+            assert provider is not None
+            assert provider.verifier == DEFAULT_VERIFIER
+            assert provider.signature_header == DEFAULT_BUILTIN_SIGNATURE_HEADER
+
+    def test_builtins_read_the_shared_webhook_secret(self):
+        settings = Settings(webhook_secret="shared")
+        for source in sorted(BUILTIN_PROVIDER_SOURCES):
+            provider = get_provider(source)
+            assert provider is not None
+            assert provider.secret_from_settings is not None
+            assert provider.secret_from_settings(settings) == "shared"
+
+    def test_an_empty_shared_secret_reads_as_absent(self):
+        """An unset secret must be None, not "", or the source looks configured."""
+        provider = get_provider("github")
+        assert provider is not None
+        assert provider.secret_from_settings is not None
+        assert provider.secret_from_settings(Settings(webhook_secret="")) is None
+
+    def test_parse_event_delegates_to_the_descriptor(self):
+        """There is one parser registry now, and it is the provider registry."""
+        payload = {
+            "ref": "refs/heads/main",
+            "before": "abc123",
+            "after": "def456",
+            "commits": [],
+            "repository": {
+                "id": 123,
+                "name": "test-repo",
+                "full_name": "org/test-repo",
+                "private": False,
+            },
+            "sender": {"id": 1, "login": "testuser"},
+        }
+        provider = get_provider("github")
+        assert provider is not None
+        assert parse_event("github", payload).event_key == "push"
+        assert parse_event("github", payload).event_key == (
+            provider.parse(payload).event_key
+        )
+
+    def test_unregistered_source_still_falls_back_to_a_custom_event(self):
+        event = parse_event("stripe", {"type": "payment.completed"})
+        assert event.source == "stripe"
+        assert event.event_key == "payment.completed"
+
+    def test_capabilities_default_is_conservative(self):
+        """Multi-connection safety is declared per provider, never assumed."""
+        assert Capabilities().tolerates_multiple_connections is False
+        for source in sorted(BUILTIN_PROVIDER_SOURCES):
+            provider = get_provider(source)
+            assert provider is not None
+            assert provider.capabilities.tolerates_multiple_connections is False
+
+    def test_reserved_hooks_are_unset_on_every_builtin(self):
+        """`subject` waits for #362; `handshake` is deferred, not forgotten."""
+        for source in sorted(BUILTIN_PROVIDER_SOURCES):
+            provider = get_provider(source)
+            assert provider is not None
+            assert provider.subject is None
+            assert provider.handshake is None
+
+    def test_descriptors_are_frozen(self):
+        provider = get_provider("github")
+        assert provider is not None
+        with pytest.raises(FrozenInstanceError):
+            provider.verifier = "slack_v0"  # type: ignore[misc]
+        with pytest.raises(FrozenInstanceError):
+            Capabilities().tolerates_multiple_connections = True  # type: ignore[misc]
+
+
+# =============================================================================
+# Schema validation
+# =============================================================================
+
+
+class TestSignatureSchemeValidation:
+    def test_create_defaults_to_the_existing_scheme(self):
+        assert CustomWebhookCreate(name="W", source="w").signature_scheme == (
+            DEFAULT_VERIFIER
+        )
+
+    def test_create_accepts_every_registered_scheme(self):
+        for scheme in sorted(verifier_schemes()):
+            created = CustomWebhookCreate(name="W", source="w", signature_scheme=scheme)
+            assert created.signature_scheme == scheme
+
+    def test_create_rejects_an_unregistered_scheme(self):
+        with pytest.raises(ValueError, match="Invalid signature_scheme"):
+            CustomWebhookCreate(name="W", source="w", signature_scheme="pgp")
+
+    def test_update_leaves_the_scheme_alone_when_omitted(self):
+        assert CustomWebhookUpdate().signature_scheme is None
+        assert "signature_scheme" not in CustomWebhookUpdate(name="W").model_dump(
+            exclude_unset=True
+        )
+
+    def test_update_rejects_an_unregistered_scheme(self):
+        with pytest.raises(ValueError, match="Invalid signature_scheme"):
+            CustomWebhookUpdate(signature_scheme="pgp")
+
+    def test_update_accepts_a_registered_scheme(self):
+        assert CustomWebhookUpdate(signature_scheme="slack_v0").signature_scheme == (
+            "slack_v0"
+        )
+
+
+# =============================================================================
+# get_webhook_config
+# =============================================================================
+
+
+class TestGetWebhookConfigScheme:
+    @pytest.mark.asyncio
+    async def test_builtin_config_comes_from_the_descriptor(
+        self, async_session, org_id, monkeypatch
+    ):
+        monkeypatch.setenv("AUTOMATION_WEBHOOK_SECRET", "shared")
+        config = await get_webhook_config("github", org_id, async_session)
+        assert config is not None
+        assert config.is_builtin is True
+        assert config.secret == "shared"
+        assert config.signature_header == DEFAULT_BUILTIN_SIGNATURE_HEADER
+        assert config.signature_scheme == DEFAULT_VERIFIER
+
+    @pytest.mark.asyncio
+    async def test_custom_webhook_scheme_is_threaded_through(
+        self, async_session, org_id
+    ):
+        async_session.add(
+            CustomWebhook(
+                org_id=org_id,
+                name="GitLab",
+                source="gitlab-ee",
+                webhook_secret="whsec_abc",
+                event_key_expr="object_kind",
+                signature_header="webhook-signature",
+                signature_scheme="standard_webhooks",
+            )
+        )
+        await async_session.commit()
+
+        config = await get_webhook_config("gitlab-ee", org_id, async_session)
+        assert config is not None
+        assert config.signature_scheme == "standard_webhooks"
+        assert config.signature_header == "webhook-signature"
+
+    @pytest.mark.asyncio
+    async def test_a_row_predating_the_column_reads_as_the_default(
+        self, async_session, org_id
+    ):
+        """The acceptance criterion for existing rows, tested as a NULL column."""
+        webhook = CustomWebhook(
+            org_id=org_id,
+            name="Legacy",
+            source="legacy",
+            webhook_secret="s3cret-value",
+        )
+        async_session.add(webhook)
+        await async_session.commit()
+
+        # Simulate a row written before the migration added the column.
+        await async_session.execute(
+            text("UPDATE custom_webhooks SET signature_scheme = NULL WHERE id = :id"),
+            {"id": webhook.id},
+        )
+        await async_session.commit()
+        async_session.expire_all()
+
+        config = await get_webhook_config("legacy", org_id, async_session)
+        assert config is not None
+        assert config.signature_scheme == DEFAULT_VERIFIER
+
+
+# =============================================================================
+# End-to-end through the real endpoint
+# =============================================================================
+
+
+def _make_automation(org_id: uuid.UUID, user_id: uuid.UUID, source: str) -> Automation:
+    return Automation(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        org_id=org_id,
+        name=f"On {source}",
+        tarball_path="oh-internal://uploads/test.tar.gz",
+        entrypoint="python main.py",
+        trigger={"type": "event", "source": source, "on": "*"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_legacy_custom_webhook_still_verifies_unchanged(
+    async_client: AsyncClient,
+    async_session,
+    org_id: uuid.UUID,
+    mock_authenticated_user: AuthenticatedUser,
+):
+    """A row with a NULL scheme verifies exactly as it did before this change."""
+    webhook = CustomWebhook(
+        org_id=org_id,
+        name="Legacy",
+        source="legacy",
+        webhook_secret="s3cret-value",
+        event_key_expr="type",
+        signature_header="X-Signature-256",
+    )
+    async_session.add(webhook)
+    async_session.add(
+        _make_automation(org_id, mock_authenticated_user.user_id, "legacy")
+    )
+    await async_session.commit()
+
+    await async_session.execute(
+        text("UPDATE custom_webhooks SET signature_scheme = NULL WHERE id = :id"),
+        {"id": webhook.id},
+    )
+    await async_session.commit()
+    # The request shares this session, so drop the instance the identity map is
+    # still holding -- otherwise the endpoint reads the pre-UPDATE value.
+    async_session.expire_all()
+
+    body = json.dumps({"type": "order.created"}).encode()
+    digest = hmac.new(b"s3cret-value", body, hashlib.sha256).hexdigest()
+
+    response = await async_client.post(
+        f"/api/automation/v1/events/{org_id}/legacy",
+        content=body,
+        headers={
+            "X-Signature-256": f"sha256={digest}",
+            "Content-Type": "application/json",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["matched"] == 1
+
+
+@pytest.mark.asyncio
+async def test_custom_webhook_with_standard_webhooks_scheme(
+    async_client: AsyncClient,
+    async_session,
+    org_id: uuid.UUID,
+    mock_authenticated_user: AuthenticatedUser,
+):
+    """The acceptance criterion: a non-default scheme, configured and honoured."""
+    secret = "whsec_" + base64.b64encode(b"gitlab-signing-key-000").decode()
+    async_session.add(
+        CustomWebhook(
+            org_id=org_id,
+            name="GitLab",
+            source="gitlab-ee",
+            webhook_secret=secret,
+            event_key_expr="object_kind",
+            signature_header="webhook-signature",
+            signature_scheme="standard_webhooks",
+        )
+    )
+    async_session.add(
+        _make_automation(org_id, mock_authenticated_user.user_id, "gitlab-ee")
+    )
+    await async_session.commit()
+
+    body = json.dumps({"object_kind": "note"}).encode()
+    now = str(int(time.time()))
+    key = standard_webhooks_key(secret)
+    signed = f"msg_1.{now}.".encode() + body
+    signature = base64.b64encode(
+        hmac.new(key, signed, hashlib.sha256).digest()
+    ).decode()
+
+    response = await async_client.post(
+        f"/api/automation/v1/events/{org_id}/gitlab-ee",
+        content=body,
+        headers={
+            "webhook-signature": f"v1,{signature}",
+            "webhook-id": "msg_1",
+            "webhook-timestamp": now,
+            "Content-Type": "application/json",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["matched"] == 1
+
+
+@pytest.mark.asyncio
+async def test_standard_webhooks_rejects_a_replayed_delivery(
+    async_client: AsyncClient,
+    async_session,
+    org_id: uuid.UUID,
+):
+    """A genuinely signed delivery, replayed outside the window, is refused."""
+    secret = "whsec_" + base64.b64encode(b"gitlab-signing-key-000").decode()
+    async_session.add(
+        CustomWebhook(
+            org_id=org_id,
+            name="GitLab",
+            source="gitlab-ee",
+            webhook_secret=secret,
+            event_key_expr="object_kind",
+            signature_header="webhook-signature",
+            signature_scheme="standard_webhooks",
+        )
+    )
+    await async_session.commit()
+
+    body = json.dumps({"object_kind": "note"}).encode()
+    stale = str(int(time.time()) - 10_000)
+    key = standard_webhooks_key(secret)
+    signed = f"msg_1.{stale}.".encode() + body
+    signature = base64.b64encode(
+        hmac.new(key, signed, hashlib.sha256).digest()
+    ).decode()
+
+    response = await async_client.post(
+        f"/api/automation/v1/events/{org_id}/gitlab-ee",
+        content=body,
+        headers={
+            "webhook-signature": f"v1,{signature}",
+            "webhook-id": "msg_1",
+            "webhook-timestamp": stale,
+            "Content-Type": "application/json",
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid signature"
+
+
+class _GitLabEvent(WebhookEvent):
+    """Stands in for the file PR #66 would add, so the wiring is what's tested."""
+
+    object_kind: str = ""
+
+    @property
+    def source(self) -> str:
+        return "gitlab"
+
+    @property
+    def event_key(self) -> str:
+        return self.object_kind
+
+
+@pytest.mark.asyncio
+async def test_adding_a_provider_takes_a_registry_entry_and_nothing_else(
+    async_client: AsyncClient,
+    async_session,
+    org_id: uuid.UUID,
+    mock_authenticated_user: AuthenticatedUser,
+    monkeypatch: pytest.MonkeyPatch,
+    temp_provider,
+):
+    """The acceptance criterion for PR #66: is adding a provider now easy?
+
+    A parser, a verifier name and a secret accessor -- one descriptor -- and a
+    source the service has never heard of routes end to end. No change to
+    `event_router.py`, `utils/webhook.py` or `schemas.py` was needed to make
+    this pass; the only new code is the descriptor and its event class.
+    """
+    monkeypatch.setenv("AUTOMATION_WEBHOOK_SECRET", "shared")
+    temp_provider(
+        Provider(
+            source="gitlab",
+            parse=lambda payload: _GitLabEvent(**payload),
+            verifier="slack_v0",
+            signature_header="X-Slack-Signature",
+            secret_from_settings=lambda s: s.webhook_secret or None,
+            capabilities=Capabilities(tolerates_multiple_connections=True),
+        )
+    )
+
+    async_session.add(
+        _make_automation(org_id, mock_authenticated_user.user_id, "gitlab")
+    )
+    await async_session.commit()
+
+    body = json.dumps({"payload": {"object_kind": "merge_request"}}).encode()
+    now = str(int(time.time()))
+    signed = b"v0:" + now.encode() + b":" + body
+    digest = hmac.new(b"shared", signed, hashlib.sha256).hexdigest()
+
+    response = await async_client.post(
+        f"/api/automation/v1/events/{org_id}/gitlab",
+        content=body,
+        headers={
+            "X-Slack-Signature": f"v0={digest}",
+            "X-Slack-Request-Timestamp": now,
+            "Content-Type": "application/json",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["matched"] == 1
+
+    # The descriptor's capability flag is what phase 3 will read.
+    provider = get_provider("gitlab")
+    assert provider is not None
+    assert provider.capabilities.tolerates_multiple_connections is True
+
+
+@pytest.mark.asyncio
+async def test_a_scheme_with_no_verifier_refuses_the_delivery(
+    async_client: AsyncClient,
+    async_session,
+    org_id: uuid.UUID,
+):
+    """A scheme this build cannot implement is a 500, not a silent fallback.
+
+    Only reachable by editing the row directly, since the API validates the
+    scheme on write -- but falling back to the default would reject genuine
+    events as bad signatures and hide the misconfiguration.
+    """
+    webhook = CustomWebhook(
+        org_id=org_id,
+        name="Exotic",
+        source="exotic",
+        webhook_secret="s3cret-value",
+        signature_header="X-Signature-256",
+    )
+    async_session.add(webhook)
+    await async_session.commit()
+
+    await async_session.execute(
+        text("UPDATE custom_webhooks SET signature_scheme = 'pgp' WHERE id = :id"),
+        {"id": webhook.id},
+    )
+    await async_session.commit()
+    async_session.expire_all()
+
+    body = json.dumps({"type": "x"}).encode()
+    digest = hmac.new(b"s3cret-value", body, hashlib.sha256).hexdigest()
+
+    response = await async_client.post(
+        f"/api/automation/v1/events/{org_id}/exotic",
+        content=body,
+        headers={
+            "X-Signature-256": f"sha256={digest}",
+            "Content-Type": "application/json",
+        },
+    )
+
+    assert response.status_code == 500

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,10 +1,7 @@
 """Tests for the provider descriptor registry and the signature verifiers.
 
-The verifier tests construct verifiers directly -- no HTTP, no app, no DB -- so
-a scheme's behaviour is pinned independently of the router that resolves it.
-The HTTP tests at the bottom cover the two things only the wired-up path can
-show: that a custom webhook can select a non-default scheme, and that adding a
-provider takes a registry entry and nothing else.
+Verifiers are constructed directly; the HTTP tests at the bottom cover what
+only the wired-up path can show.
 """
 
 import base64
@@ -74,11 +71,7 @@ def clear_settings_cache():
 
 @pytest.fixture
 def temp_provider():
-    """Register a provider for one test and remove it afterwards.
-
-    The registry is process-global, so a test that adds to it has to put it
-    back or it leaks into every test that reads RESERVED_SOURCES.
-    """
+    """Register a provider for one test; the registry is process-global."""
     registered: list[str] = []
 
     def _register(provider: Provider) -> Provider:
@@ -90,11 +83,6 @@ def temp_provider():
 
     for source in registered:
         PROVIDERS.pop(source, None)
-
-
-# =============================================================================
-# Header access
-# =============================================================================
 
 
 class TestGetHeader:
@@ -117,11 +105,6 @@ class TestGetHeader:
 
     def test_empty_mapping(self):
         assert get_header({}, "X-Sig") is None
-
-
-# =============================================================================
-# hmac_sha256_hex
-# =============================================================================
 
 
 class TestHmacSha256HexVerifier:
@@ -211,11 +194,6 @@ class TestHmacSha256HexVerifier:
             secret=self.SECRET,
             signature_header=self.HEADER,
         )
-
-
-# =============================================================================
-# standard_webhooks
-# =============================================================================
 
 
 class TestStandardWebhooksVerifier:
@@ -357,11 +335,6 @@ class TestStandardWebhooksVerifier:
         assert not self._verify(self._verifier(), body, self._headers(bare))
 
 
-# =============================================================================
-# slack_v0
-# =============================================================================
-
-
 class TestSlackV0Verifier:
     """Slack Events API: hex HMAC over "v0:{timestamp}:{body}"."""
 
@@ -437,11 +410,6 @@ class TestSlackV0Verifier:
         assert not self._verify(self._verifier(), body, self._headers(bare))
 
 
-# =============================================================================
-# Verifier registry
-# =============================================================================
-
-
 class TestVerifierRegistry:
     def test_registered_schemes(self):
         assert verifier_schemes() == {
@@ -464,11 +432,6 @@ class TestVerifierRegistry:
 
     def test_unknown_scheme_resolves_to_nothing(self):
         assert get_verifier("pgp") is None
-
-
-# =============================================================================
-# Provider registry
-# =============================================================================
 
 
 class TestProviderRegistry:
@@ -562,7 +525,7 @@ class TestProviderDescriptors:
             assert provider.capabilities.tolerates_multiple_connections is False
 
     def test_reserved_hooks_are_unset_on_every_builtin(self):
-        """`subject` waits for #362; `handshake` is deferred, not forgotten."""
+        """Both hooks are reserved and deliberately unwired, not forgotten."""
         for source in sorted(BUILTIN_PROVIDER_SOURCES):
             provider = get_provider(source)
             assert provider is not None
@@ -576,11 +539,6 @@ class TestProviderDescriptors:
             provider.verifier = "slack_v0"  # type: ignore[misc]
         with pytest.raises(FrozenInstanceError):
             Capabilities().tolerates_multiple_connections = True  # type: ignore[misc]
-
-
-# =============================================================================
-# Schema validation
-# =============================================================================
 
 
 class TestSignatureSchemeValidation:
@@ -612,11 +570,6 @@ class TestSignatureSchemeValidation:
         assert CustomWebhookUpdate(signature_scheme="slack_v0").signature_scheme == (
             "slack_v0"
         )
-
-
-# =============================================================================
-# get_webhook_config
-# =============================================================================
 
 
 class TestGetWebhookConfigScheme:
@@ -679,11 +632,6 @@ class TestGetWebhookConfigScheme:
         config = await get_webhook_config("legacy", org_id, async_session)
         assert config is not None
         assert config.signature_scheme == DEFAULT_VERIFIER
-
-
-# =============================================================================
-# End-to-end through the real endpoint
-# =============================================================================
 
 
 def _make_automation(org_id: uuid.UUID, user_id: uuid.UUID, source: str) -> Automation:
@@ -838,7 +786,7 @@ async def test_standard_webhooks_rejects_a_replayed_delivery(
 
 
 class _GitLabEvent(WebhookEvent):
-    """Stands in for the file PR #66 would add, so the wiring is what's tested."""
+    """Stands in for a real provider's event class, so the wiring is tested."""
 
     object_kind: str = ""
 
@@ -860,12 +808,10 @@ async def test_adding_a_provider_takes_a_registry_entry_and_nothing_else(
     monkeypatch: pytest.MonkeyPatch,
     temp_provider,
 ):
-    """The acceptance criterion for PR #66: is adding a provider now easy?
+    """One descriptor routes a brand-new source end to end.
 
-    A parser, a verifier name and a secret accessor -- one descriptor -- and a
-    source the service has never heard of routes end to end. No change to
-    `event_router.py`, `utils/webhook.py` or `schemas.py` was needed to make
-    this pass; the only new code is the descriptor and its event class.
+    No change to `event_router.py`, `utils/webhook.py` or `schemas.py` was
+    needed to make this pass.
     """
     monkeypatch.setenv("AUTOMATION_WEBHOOK_SECRET", "shared")
     temp_provider(
@@ -914,12 +860,7 @@ async def test_a_scheme_with_no_verifier_refuses_the_delivery(
     async_session,
     org_id: uuid.UUID,
 ):
-    """A scheme this build cannot implement is a 500, not a silent fallback.
-
-    Only reachable by editing the row directly, since the API validates the
-    scheme on write -- but falling back to the default would reject genuine
-    events as bad signatures and hide the misconfiguration.
-    """
+    """A scheme this build cannot implement is a 500, not a silent fallback."""
     webhook = CustomWebhook(
         org_id=org_id,
         name="Exotic",

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -54,6 +54,11 @@ from openhands.automation.utils.webhook import get_webhook_config
 
 BUILTIN_PROVIDER_SOURCES = frozenset({"bitbucket_data_center", "github", "jira_dc"})
 
+# Header bytes reach an app latin-1 decoded, so a signature header can carry a
+# non-ASCII str. `hmac.compare_digest` raises on those rather than returning
+# False, which would turn a bad signature into a 500.
+NON_ASCII_SIGNATURE = b"\xff\xfe".decode("latin-1")
+
 
 @pytest.fixture
 def org_id(mock_authenticated_user: AuthenticatedUser) -> uuid.UUID:
@@ -165,6 +170,15 @@ class TestHmacSha256HexVerifier:
             signature_header=self.HEADER,
         )
 
+    def test_non_ascii_signature_rejected(self):
+        """Starlette decodes header bytes as latin-1, so this is reachable."""
+        assert not HmacSha256HexVerifier().verify(
+            body=b'{"a":1}',
+            headers={self.HEADER: NON_ASCII_SIGNATURE},
+            secret=self.SECRET,
+            signature_header=self.HEADER,
+        )
+
     def test_reads_the_configured_header_not_a_fixed_one(self):
         """A custom webhook may put the same scheme behind any header name."""
         body = b'{"a":1}'
@@ -247,6 +261,21 @@ class TestStandardWebhooksVerifier:
 
     def test_non_base64_secret_falls_back_to_raw_bytes(self):
         assert standard_webhooks_key("plain-text-secret") == b"plain-text-secret"
+
+    def test_a_plain_secret_that_parses_as_base64_is_still_decoded(self):
+        """The scheme defines the secret as base64, so this is spec, not a bug.
+
+        Worth pinning: an operator who types a literal secret that happens to
+        be valid base64 gets a key that is not the characters they typed.
+        """
+        assert standard_webhooks_key("abcdefgh") == base64.b64decode("abcdefgh")
+        assert standard_webhooks_key("abcdefgh") != b"abcdefgh"
+
+    def test_non_ascii_signature_rejected(self):
+        body = b'{"object_kind":"note"}'
+        assert not self._verify(
+            self._verifier(), body, self._headers(f"v1,{NON_ASCII_SIGNATURE}")
+        )
 
     def test_tampered_body_rejected(self):
         signature = self._sign(b'{"object_kind":"note"}')
@@ -399,6 +428,13 @@ class TestSlackV0Verifier:
             self._verifier(), b"team_id=T1DC2JH3J", {SLACK_TIMESTAMP_HEADER: self.TS}
         )
 
+    def test_non_ascii_signature_rejected(self):
+        assert not self._verify(
+            self._verifier(),
+            b"team_id=T1DC2JH3J",
+            self._headers(NON_ASCII_SIGNATURE),
+        )
+
     def test_non_integer_timestamp_rejected(self):
         body = b"team_id=T1DC2JH3J"
         headers = self._headers(self._sign(body), ts="nope")
@@ -423,7 +459,7 @@ class TestVerifierRegistry:
         assert isinstance(VERIFIERS[DEFAULT_VERIFIER], HmacSha256HexVerifier)
 
     def test_none_resolves_to_the_default(self):
-        """A row predating the column has no scheme and must not lose one."""
+        """A row whose scheme was cleared must not lose its verifier."""
         assert get_verifier(None) is VERIFIERS[DEFAULT_VERIFIER]
 
     def test_named_scheme_resolves(self):
@@ -608,10 +644,10 @@ class TestGetWebhookConfigScheme:
         assert config.signature_header == "webhook-signature"
 
     @pytest.mark.asyncio
-    async def test_a_row_predating_the_column_reads_as_the_default(
+    async def test_a_row_with_a_cleared_scheme_reads_as_the_default(
         self, async_session, org_id
     ):
-        """The acceptance criterion for existing rows, tested as a NULL column."""
+        """Migration 017 backfills, so NULL comes from a PATCH, not from age."""
         webhook = CustomWebhook(
             org_id=org_id,
             name="Legacy",
@@ -621,7 +657,6 @@ class TestGetWebhookConfigScheme:
         async_session.add(webhook)
         await async_session.commit()
 
-        # Simulate a row written before the migration added the column.
         await async_session.execute(
             text("UPDATE custom_webhooks SET signature_scheme = NULL WHERE id = :id"),
             {"id": webhook.id},
@@ -891,3 +926,94 @@ async def test_a_scheme_with_no_verifier_refuses_the_delivery(
     )
 
     assert response.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_a_non_ascii_signature_header_is_refused_not_a_crash(
+    async_client: AsyncClient,
+    async_session,
+    org_id: uuid.UUID,
+):
+    """A garbage signature must be a 401, not an unhandled TypeError."""
+    webhook = CustomWebhook(
+        org_id=org_id,
+        name="Legacy",
+        source="legacy",
+        webhook_secret="s3cret-value",
+        signature_header="X-Signature-256",
+    )
+    async_session.add(webhook)
+    await async_session.commit()
+
+    response = await async_client.post(
+        f"/api/automation/v1/events/{org_id}/legacy",
+        content=json.dumps({"type": "order.created"}).encode(),
+        headers=[
+            (b"X-Signature-256", b"\xff\xfe"),
+            (b"Content-Type", b"application/json"),
+        ],
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid signature"
+
+
+@pytest.mark.asyncio
+async def test_patching_the_scheme_changes_what_verifies(
+    async_client: AsyncClient,
+    async_session,
+    org_id: uuid.UUID,
+    mock_authenticated_user: AuthenticatedUser,
+):
+    """The PATCH persists, and the delivery path honours the new scheme."""
+    webhook = CustomWebhook(
+        org_id=org_id,
+        name="Switcher",
+        source="switcher",
+        webhook_secret="s3cret-value",
+        event_key_expr="type",
+        signature_header="X-Signature-256",
+    )
+    async_session.add(webhook)
+    async_session.add(
+        _make_automation(org_id, mock_authenticated_user.user_id, "switcher")
+    )
+    await async_session.commit()
+
+    patched = await async_client.patch(
+        f"/api/automation/v1/webhooks/{webhook.id}",
+        json={"signature_scheme": "slack_v0"},
+    )
+    assert patched.status_code == 200
+    assert patched.json()["signature_scheme"] == "slack_v0"
+    async_session.expire_all()
+
+    body = json.dumps({"type": "order.created"}).encode()
+
+    # The scheme it used to verify with is no longer accepted.
+    stale = await async_client.post(
+        f"/api/automation/v1/events/{org_id}/switcher",
+        content=body,
+        headers={
+            "X-Signature-256": (
+                "sha256=" + hmac.new(b"s3cret-value", body, hashlib.sha256).hexdigest()
+            ),
+            "Content-Type": "application/json",
+        },
+    )
+    assert stale.status_code == 401
+
+    now = str(int(time.time()))
+    signed = b"v0:" + now.encode() + b":" + body
+    digest = hmac.new(b"s3cret-value", signed, hashlib.sha256).hexdigest()
+    accepted = await async_client.post(
+        f"/api/automation/v1/events/{org_id}/switcher",
+        content=body,
+        headers={
+            "X-Signature-256": f"v0={digest}",
+            "X-Slack-Request-Timestamp": now,
+            "Content-Type": "application/json",
+        },
+    )
+    assert accepted.status_code == 200
+    assert accepted.json()["matched"] == 1

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -30,6 +30,25 @@ OTHER_ORG_ID = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
 
 
 @pytest.fixture
+def local_mode(monkeypatch):
+    """Force local mode for tests asserting on a browser-supplied distinct id.
+
+    Cloud must derive telemetry identity from auth, so
+    `telemetry._trusted_telemetry_context()` discards the header outside local
+    mode and the assertion only holds inside it. The config is cached, so it
+    has to be cleared on the way in and on the way out; without this the tests
+    happen to pass only when an earlier test file leaves a local-mode config in
+    the cache, and fail whenever they run first.
+    """
+    from openhands.automation.config import clear_config_cache
+
+    monkeypatch.setenv("AUTOMATION_AGENT_SERVER_URL", "http://localhost:3000")
+    clear_config_cache()
+    yield
+    clear_config_cache()
+
+
+@pytest.fixture
 def preset_store(monkeypatch):
     """Stateful in-memory file store wired into the preset tarball helpers.
 
@@ -164,7 +183,9 @@ class TestPermissionEnforcement:
 class TestCreateAutomation:
     """Tests for POST /v1 endpoint."""
 
-    async def test_create_automation_success(self, async_client, async_session):
+    async def test_create_automation_success(
+        self, async_client, async_session, local_mode
+    ):
         """Valid request creates automation and returns 201."""
         payload = {
             "name": "My Test Automation",
@@ -1458,7 +1479,9 @@ class TestUpdateAutomation:
 class TestDispatchAutomation:
     """Tests for POST /v1/{id}/dispatch endpoint."""
 
-    async def test_dispatch_automation_success(self, async_client, async_session):
+    async def test_dispatch_automation_success(
+        self, async_client, async_session, local_mode
+    ):
         """Dispatching an automation creates a PENDING run."""
         automation = Automation(
             user_id=TEST_USER_ID,


### PR DESCRIPTION
Closes #359 — phase 2 of 5, part of #363.

Phase 1 (#367) is merged, so this is now rebased onto `main` and the diff is
phase 2 only. Independent of phase 1 in substance — the two issues had no
blocking relationship — but they touch adjacent code, so it was developed
stacked.

One nullable column. No behaviour change for any existing source or any
existing row.

## What changed

A provider was described in three places: `BUILTIN_SOURCES` (`utils/webhook.py`)
mapped a slug to a secret extractor, the `event_schemas` `_PARSERS` registry
mapped the same slug to a parser, and `RESERVED_SOURCES` (`schemas.py`) listed
the same three slugs by hand so a custom webhook could not impersonate one.
Adding a provider meant editing all three and remembering the third.

Verification was not a registry at all. `verify_signature()` was hard-wired to
hex HMAC-SHA256 over the raw body; `CustomWebhook` let an operator configure the
*header name* and nothing else. Anything signing something other than the raw
body — Standard Webhooks, Slack — could not be onboarded.

New `openhands/automation/providers.py` holds both registries:

```python
VERIFIERS: dict[str, WebhookVerifier] = {
    "hmac_sha256_hex":   HmacSha256HexVerifier(),    # unchanged behaviour, incl. bare hex
    "standard_webhooks": StandardWebhooksVerifier(), # from PR #247
    "slack_v0":          SlackV0Verifier(),          # v0:{ts}:{body}, timestamp checked
}

@dataclass(frozen=True, slots=True)
class Provider:
    source: str
    parse: ParseFunc
    verifier: str = DEFAULT_VERIFIER
    signature_header: str = DEFAULT_BUILTIN_SIGNATURE_HEADER
    secret_from_settings: SecretFunc | None = None
    subject: SubjectFunc | None = None          # reserved for #362
    handshake: HandshakeFunc | None = None      # reserved; see below
    capabilities: Capabilities = Capabilities()
```

`event_router.py` resolves `VERIFIERS[config.signature_scheme]` instead of
calling `verify_signature()`. `parse_event()` reads the descriptor, so the
parser registry is gone. `RESERVED_SOURCES` is derived. `BUILTIN_SOURCES`,
`register_builtin_source()` and `register_parser()` are removed; `verify_signature`
and `is_builtin_source` are re-exported from `utils/webhook.py` so existing
imports keep working.

`custom_webhooks.signature_scheme` is added nullable (migration `018`), and a
`NULL` is read as `hmac_sha256_hex` — the behaviour the row was created with.

## Four decisions worth reviewing

**1. The verifier protocol needed a fifth parameter.**

The issue specifies:

```python
def verify(self, *, body: bytes, headers: Mapping[str, str], secret: str) -> bool: ...
```

That cannot express the scheme it is meant to replace. `hmac_sha256_hex` reads
its signature from a header whose *name is per-row* (`signature_header`), so a
verifier given only `headers` has nothing to look the signature up by. The
implemented signature adds `signature_header: str`.

The split is deliberate and I think it is the right line: the header carrying
the **signature** is operator-configurable, so it is a parameter; the headers a
scheme needs *besides* the signature (`webhook-id`, `webhook-timestamp`,
`X-Slack-Request-Timestamp`) are fixed by the scheme, so verifiers read those
from `headers` themselves and no caller has to know about them.

**2. `slack` is deliberately NOT registered as a provider — only `slack_v0` is
added as a verifier.**

This one is a live-traffic hazard, so flagging it explicitly. The OSS automation
VM has been posting to `/v1/events/{org_id}/slack` since 2026-08-13 (#363, "Why
now"), and `slack` there is an ordinary **`CustomWebhook` row** with a per-org
secret. Registering a `slack` provider would make `get_webhook_config()` treat
that source as built-in, read `AUTOMATION_WEBHOOK_SECRET` instead of the row's
secret, and reserve the name — breaking the bridge and both automations
consuming it on the next deploy. Slack becomes a provider in #360, where the
cutover is designed. Here it only gains a verifier a custom webhook can select.

**3. The handshake hook is deferred, and the field is reserved.**

The issue asks for this to be decided rather than built on autopilot. Decision:
**defer.** The motivating example was Slack's Events API challenge, and #360
makes Socket Mode our Slack path, where it does not apply. Nothing else on the
roadmap — GitLab (#66), Stripe, Standard Webhooks, the two existing forwarded
sources — performs an HTTP handshake. The field stays on the descriptor, typed
under `TYPE_CHECKING` so `providers.py` keeps no runtime FastAPI import, with
the reasoning in a comment next to it. A test asserts no registered provider
sets it, so the deferral stays true rather than quietly decaying.

**4. `Provider.signature_header` is a field the issue did not list.**

`get_webhook_config()` hard-coded `"X-Hub-Signature-256"` for every built-in
source, with the comment `# GitHub's header`. Deriving that from the descriptor
is the difference between "adding a provider is a registry entry" and "adding a
provider is a registry entry unless it signs into a different header". Default
is the existing constant, so all three built-ins are byte-identical.

## An unrelated pre-existing test bug this surfaced

`tests/test_router.py::test_create_automation_success` and
`::test_dispatch_automation_success` assert on a browser-supplied telemetry
distinct id, which `telemetry._trusted_telemetry_context()` discards outside
local mode. They never set local mode. They pass today only because
`tests/test_local_mode.py` runs earlier and leaves a local-mode `Settings` in
the `lru_cache` — `monkeypatch` reverts the env var but not the cached object.

Confirmed pre-existing, not caused by this branch: on `vasco/accept-event-seam`
with no changes, `pytest tests/test_router.py` alone fails both. `pytest
tests/test_local_mode.py tests/test_router.py` passes.

`tests/test_providers.py` sorts between `test_preset_router.py` and
`test_router.py` and clears the config cache around each of its tests, which
removes the leak and turns the latent failure into a real one. Fixed at the
source with a `local_mode` fixture on those two tests, so they now pass standalone
too. This is the only change here to a test file unrelated to the issue; I would
rather fix the dependency than leave the suite order-fragile.

## Acceptance criteria

- [x] **`github`, `jira_dc`, `bitbucket_data_center` behave identically —
      existing tests pass unmodified.** `test_event_router.py`,
      `test_event_schemas.py`, `test_webhook_utils.py` and
      `test_webhook_router.py` are untouched and green, including
      `test_webhook_router.py:215`'s `RESERVED_SOURCES == {...}` assertion
      against the now-derived value.
- [x] **Existing `CustomWebhook` rows verify exactly as before.** Tested three
      ways: `get_webhook_config()` on a `NULL` column, a full HTTP delivery
      against a `NULL`-column row, and the migration itself — a row inserted at
      revision `016`, before the column existed, reads `hmac_sha256_hex` after
      `upgrade head` on real Postgres.
- [x] **A custom webhook can be configured with `standard_webhooks` and verifies
      a known-good fixture, including timestamp rejection outside the replay
      window.** End-to-end through `POST /v1/events/{org}/{source}`: a valid
      delivery matches an automation; a correctly signed one stamped 10,000s ago
      is refused 401. Unit tests additionally cover that the timestamp and the
      message id are *signed* (re-stamping a captured delivery fails), key
      derivation from `whsec_`, multi-signature rotation, and version tags.
- [x] **Adding GitLab (PR #66) requires one new file and a registry entry — no
      changes to `event_router.py`.**
      `test_adding_a_provider_takes_a_registry_entry_and_nothing_else` registers
      a source the service has never heard of, with its own parser, a
      non-default verifier, its own signature header and a secret accessor, and
      routes a real HTTP delivery end to end. Nothing outside the descriptor was
      added to make it pass.
- [x] **`RESERVED_SOURCES` is derived, not hand-maintained.** `reserved_sources()`
      returns `frozenset(PROVIDERS)`. Validation calls `is_builtin_source()`
      rather than the snapshot, so a provider registered after import time is
      also protected — tested.

## One behaviour change to be aware of

A `signature_scheme` naming no registered verifier now returns **500**, not a
silent fallback to the default. Only reachable by editing the row directly,
since the API validates the scheme on write. Falling back would reject every
genuine delivery as a bad signature and present a misconfiguration as an
authentication failure.

## API surface

`signature_scheme` is added to `CustomWebhookCreate` (optional, defaults to
`hmac_sha256_hex`), `CustomWebhookUpdate` (optional), and
`CustomWebhookResponse` / `CustomWebhookCreateResponse` (required). Verified
against the generated OpenAPI spec: those four schemas and no others.
`EventResponse` is unchanged, so phase 1's wire guarantee still holds.

## Verification

- Full suite on top of `main`: **1439 passed** (1361 on `main` alone, +78 new,
  all in `tests/test_providers.py`). No existing test modified except the two
  order-dependent ones described above.
- `pre-commit` (ruff format, ruff lint, pycodestyle, pyright) clean on all
  eleven files.
- Migration `018` applied and rolled back on **SQLite** (`upgrade head` →
  `downgrade -1`, column added nullable with server default, dropped cleanly)
  and on **real Postgres 15**, with a pre-existing row present across both
  directions.
- Renumbered `017` → `018` during the rebase onto `main`: #334 landed revision
  `017` in the meantime, and two files declaring `017` off `016` left alembic
  with two heads, refusing to run at all. The DDL is unchanged.

## Out of scope

Stream transports (#360), any use of `subject` (#362), and GitLab itself (#66) —
this phase only widens the description of a provider.

