### PR TITLE
fix(db): honor SQLite pool settings

### DIFF
--- a/openhands/automation/db.py
+++ b/openhands/automation/db.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from fastapi import Request
-from sqlalchemy.engine import URL
+from sqlalchemy.engine import URL, make_url
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -109,7 +109,7 @@ async def create_engine(settings: ServiceSettings | None = None) -> EngineResult
     # 1. Check for explicit db_url (supports SQLite for local mode)
     if settings.db_url:
         if is_sqlite_url(settings.db_url):
-            return _create_sqlite_engine(settings.db_url)
+            return _create_sqlite_engine(settings.db_url, settings)
         # PostgreSQL URL provided directly
         engine = create_async_engine(
             settings.db_url,
@@ -148,24 +148,40 @@ async def create_engine(settings: ServiceSettings | None = None) -> EngineResult
     return EngineResult(engine=engine, is_sqlite=False)
 
 
-def _create_sqlite_engine(db_url: str) -> EngineResult:
+def _create_sqlite_engine(
+    db_url: str, settings: ServiceSettings | None = None
+) -> EngineResult:
     """Create SQLite engine for local deployments.
 
     SQLite configuration notes:
     - Uses aiosqlite driver for async support
-    - No connection pooling (SQLite handles this internally)
+    - File-backed databases use the configured connection pool limits
+    - In-memory databases retain SQLAlchemy's StaticPool defaults
     - check_same_thread=False required for async usage
     """
+    if settings is None:
+        settings = get_config().service
+
     # Ensure the URL uses aiosqlite driver
     if not db_url.startswith("sqlite+aiosqlite"):
         db_url = db_url.replace("sqlite://", "sqlite+aiosqlite://", 1)
+
+    url = make_url(db_url)
+    database = url.database or ""
+    pool_options = {}
+    if database and ":memory:" not in database and url.query.get("mode") != "memory":
+        pool_options = {
+            "pool_size": settings.db_pool_size,
+            "max_overflow": settings.db_max_overflow,
+            "pool_timeout": settings.db_pool_timeout,
+        }
 
     engine = create_async_engine(
         db_url,
         # SQLite-specific settings
         connect_args={"check_same_thread": False},
-        # No pooling for SQLite - it handles this internally
         pool_pre_ping=True,
+        **pool_options,
     )
     logger.info("Created SQLite engine: %s", db_url.split("?")[0])
     return EngineResult(engine=engine, is_sqlite=True)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -76,6 +76,61 @@ class TestSqliteModeFlag:
 class TestCreateSqliteEngine:
     """Tests for SQLite engine creation."""
 
+    @pytest.mark.asyncio
+    async def test_create_engine_uses_configured_pool_settings(self, monkeypatch):
+        """SQLite engine receives the configured pool limits."""
+        captured: dict[str, Any] = {}
+        fake_engine: Any = object()
+
+        def fake_create_async_engine(*args: Any, **kwargs: Any) -> Any:
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return fake_engine
+
+        monkeypatch.setattr(db_module, "create_async_engine", fake_create_async_engine)
+        settings = ServiceSettings(
+            db_url="sqlite+aiosqlite:///test.db",
+            db_pool_size=17,
+            db_max_overflow=4,
+            db_pool_timeout=9,
+        )
+
+        result = await db_module.create_engine(settings)
+
+        assert result.engine is fake_engine
+        assert captured["kwargs"]["pool_size"] == 17
+        assert captured["kwargs"]["max_overflow"] == 4
+        assert captured["kwargs"]["pool_timeout"] == 9
+
+    @pytest.mark.parametrize(
+        "db_url",
+        [
+            "sqlite+aiosqlite:///:memory:",
+            "sqlite+aiosqlite:///file::memory:?cache=shared&uri=true",
+            "sqlite+aiosqlite:///file:memdb1?mode=memory&cache=shared&uri=true",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_create_engine_preserves_in_memory_pool_defaults(
+        self, monkeypatch, db_url
+    ):
+        """In-memory SQLite URLs keep SQLAlchemy's StaticPool defaults."""
+        captured: dict[str, Any] = {}
+        fake_engine: Any = object()
+
+        def fake_create_async_engine(*args: Any, **kwargs: Any) -> Any:
+            captured["kwargs"] = kwargs
+            return fake_engine
+
+        monkeypatch.setattr(db_module, "create_async_engine", fake_create_async_engine)
+
+        result = await db_module.create_engine(ServiceSettings(db_url=db_url))
+
+        assert result.engine is fake_engine
+        assert "pool_size" not in captured["kwargs"]
+        assert "max_overflow" not in captured["kwargs"]
+        assert "pool_timeout" not in captured["kwargs"]
+
     def test_creates_engine_with_aiosqlite_driver(self):
         """Engine is created with aiosqlite driver."""
         result = _create_sqlite_engine("sqlite:///test.db")


### PR DESCRIPTION
HUMAN:

I tested both SQLite memory URL formats locally and ran the test suite to make sure nothing broke.

AGENT:

File-backed SQLite was silently using SQLAlchemy's 5+10 pool defaults, so changing the service's pool settings had no effect. This passes the configured size, overflow, and timeout through while leaving in-memory databases on `StaticPool`.

I covered the regular `:memory:` URL and both SQLite URI memory forms so the new kwargs don't break test or embedded setups.

Tests: `uv run pytest tests/test_db.py -q` (31 passed), Ruff format/check, and Pyright. The wider non-integration suite reached 1,439 passes; its only Postgres testcontainer setup timeout passed on an isolated rerun.

Fixes #366