### PR TITLE
feat: report lifetime per-status run counts on the runs list

### DIFF
--- a/openhands/automation/router.py
+++ b/openhands/automation/router.py
@@ -403,11 +403,14 @@ async def list_automation_runs(
     # Verify the automation exists and belongs to the user
     await _get_user_automation(session, automation_id, user.user_id, user.org_id)
 
-    # Count total runs for this automation
+    # Count lifetime runs by status for this automation
     count_result = await session.execute(
-        select(func.count()).where(AutomationRun.automation_id == automation_id)
+        select(AutomationRun.status, func.count())
+        .where(AutomationRun.automation_id == automation_id)
+        .group_by(AutomationRun.status)
     )
-    total = count_result.scalar() or 0
+    status_counts = {run_status.value: count for run_status, count in count_result}
+    total = sum(status_counts.values())
 
     # Fetch paginated runs ordered by latest first
     result = await session.execute(
@@ -422,6 +425,7 @@ async def list_automation_runs(
     return AutomationRunListResponse(
         runs=[AutomationRunResponse.model_validate(r) for r in runs],
         total=total,
+        status_counts=status_counts,
     )
 
 

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -799,6 +799,9 @@ class AutomationRunListResponse(BaseModel):
 
     runs: list[AutomationRunResponse]
     total: int
+    # Lifetime run counts by status, unaffected by pagination. Sparse: only
+    # statuses with at least one run appear, so a missing key means zero.
+    status_counts: dict[RunStatus, int] = Field(default_factory=dict)
 
 
 # --- Capability and Preflight Schemas ---

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1639,6 +1639,7 @@ class TestListAutomationRuns:
         data = response.json()
         assert data["runs"] == []
         assert data["total"] == 0
+        assert data["status_counts"] == {}
 
     async def test_list_runs_returns_runs(self, async_client, async_session):
         """Listing runs after dispatch shows created runs."""
@@ -1753,6 +1754,81 @@ class TestListAutomationRuns:
         data = response.json()
         assert data["total"] == 5
         assert len(data["runs"]) == 2
+
+    async def test_list_runs_counts_by_status(self, async_client, async_session):
+        """status_counts reports lifetime per-status counts, sparsely."""
+        from openhands.automation.models import AutomationRun, AutomationRunStatus
+
+        # Arrange — runs across three statuses; CANCELLED/SKIPPED never occur.
+        automation = Automation(
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            name="Test Automation",
+            trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
+            tarball_path="s3://bucket/code.tar.gz",
+            entrypoint="uv run script.py",
+        )
+        async_session.add(automation)
+        await async_session.commit()
+        for status in [
+            AutomationRunStatus.COMPLETED,
+            AutomationRunStatus.COMPLETED,
+            AutomationRunStatus.FAILED,
+            AutomationRunStatus.PENDING,
+        ]:
+            async_session.add(AutomationRun(automation_id=automation.id, status=status))
+        await async_session.commit()
+
+        # Act
+        response = await async_client.get(f"/api/automation/v1/{automation.id}/runs")
+
+        # Assert — only statuses with runs appear, and total is their sum.
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status_counts"] == {
+            "COMPLETED": 2,
+            "FAILED": 1,
+            "PENDING": 1,
+        }
+        assert data["total"] == 4
+
+    async def test_list_runs_counts_unaffected_by_pagination(
+        self, async_client, async_session
+    ):
+        """status_counts stays lifetime-wide on a paginated page."""
+        from openhands.automation.models import AutomationRun, AutomationRunStatus
+
+        # Arrange
+        automation = Automation(
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            name="Test Automation",
+            trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
+            tarball_path="s3://bucket/code.tar.gz",
+            entrypoint="uv run script.py",
+        )
+        async_session.add(automation)
+        await async_session.commit()
+        for _ in range(3):
+            async_session.add(
+                AutomationRun(
+                    automation_id=automation.id,
+                    status=AutomationRunStatus.COMPLETED,
+                )
+            )
+        await async_session.commit()
+
+        # Act
+        response = await async_client.get(
+            f"/api/automation/v1/{automation.id}/runs",
+            params={"limit": 1, "offset": 1},
+        )
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["runs"]) == 1
+        assert data["status_counts"] == {"COMPLETED": 3}
 
     async def test_list_runs_not_found(self, async_client):
         """Listing runs for nonexistent automation returns 404."""


### PR DESCRIPTION
## Why

The Agent Canvas dashboard is adding automation value statements — "70 review sweeps completed" — backed by the lifetime COMPLETED-run count (OpenHands/OpenHands#16570). The runs list response today carries only `total` (all statuses combined) and one page of runs, so a client cannot learn the completed count without paging an automation's entire history — exactly the run-history fan-out the dashboard is trying to keep bounded.

## Summary

- `AutomationRunListResponse` gains `status_counts: dict[RunStatus, int]` — lifetime counts keyed by status, unaffected by pagination. Sparse: only statuses with at least one run appear, so when the field is present a missing key means zero.
- `list_automation_runs` swaps its `count(*)` for a single `GROUP BY status` count over the same indexed `automation_id` predicate and derives `total` as the sum — the endpoint still issues exactly one count query, and `total` is unchanged for existing consumers.

## Issue Number

Relates to OpenHands/OpenHands#16570 (frontend acceptance criteria live there; this is the backend data source).

## How to Test

1. `uv sync`
2. `uv run python -m pytest tests/test_router.py -k list_runs` — 11 tests, including the new coverage: sparse per-status counts with `total` as their sum, counts unaffected by `limit`/`offset`, and `{}` for an automation with no runs.
3. `uv run pre-commit run --files openhands/automation/router.py openhands/automation/schemas.py tests/test_router.py` (ruff format/lint, pycodestyle, pyright — all pass).
4. Manually: create an automation, dispatch a few runs, then `GET /api/automation/v1/{id}/runs` — the body now includes e.g. `"status_counts": {"COMPLETED": 2, "PENDING": 1}` alongside the existing `runs`/`total`.

## Notes

- Purely additive — no migration, no change to existing fields, and clients that predate the field ignore the extra key. The Agent Canvas consumer (companion OpenHands/OpenHands PR) treats the field's presence as authoritative and falls back gracefully when talking to an older service.
- `RunStatus` is a StrEnum, so the mapping serializes with the familiar uppercase status names as keys.
- The full `tests/test_router.py` run has 3 pre-existing failures (`test_create_automation_success`, `test_create_automation_shares_template_identity_with_presets`, `test_dispatch_automation_success`) that reproduce identically on a clean `main` checkout in this environment; this change introduces no new failures.