### PR TITLE
test: verify event-triggered PR reviewer (ignore, will be closed)

### DIFF
--- a/AUTOMATION_EVENT_TEST.md
+++ b/AUTOMATION_EVENT_TEST.md
@@ -1,6 +1,7 @@
 # Automation event-trigger test
 
-Temporary file used to verify that the GitHub PR Reviewer automation fires from a
-`pull_request` webhook instead of its old 5-minute cron poll.
+Throwaway file verifying the OSS VM PR reviewer fires from a `pull_request` webhook.
 
-This branch and its PR are throwaway and will be closed and deleted.
+Second commit: forces a new head SHA so the reviewer re-evaluates this PR.
+
+This branch and PR will be deleted.

--- a/AUTOMATION_EVENT_TEST.md
+++ b/AUTOMATION_EVENT_TEST.md
@@ -1,0 +1,6 @@
+# Automation event-trigger test
+
+Temporary file used to verify that the GitHub PR Reviewer automation fires from a
+`pull_request` webhook instead of its old 5-minute cron poll.
+
+This branch and its PR are throwaway and will be closed and deleted.


### PR DESCRIPTION
**Automated test PR — please ignore, it will be closed shortly.**

Verifying that the GitHub PR Reviewer automation on the OSS automation VM now fires from
a `pull_request` webhook rather than its former 5-minute cron poll. Adds one throwaway
markdown file; nothing here is intended to merge.

HUMAN: This PR exists solely to exercise the event-triggered PR reviewer end to end. It
adds a single scratch markdown file and will be closed once the automation has been
observed picking it up.
