### PR TITLE
feat: allow raw automations to start disabled

### DIFF
--- a/openhands/automation/router.py
+++ b/openhands/automation/router.py
@@ -138,6 +138,7 @@ async def create_automation(
         entrypoint=body.entrypoint,
         timeout=default_automation_timeout(body.timeout),
         keep_alive=body.keep_alive,
+        enabled=body.enabled,
         telemetry_distinct_id=get_request_telemetry_context(
             request
         ).frontend_distinct_id,

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -342,6 +342,10 @@ class CreateAutomationRequest(BaseModel):
             "completion (or after post-run callbacks, when configured)."
         ),
     )
+    enabled: bool = Field(
+        default=True,
+        description="Whether the automation starts enabled.",
+    )
     template: TemplateProvenance | None = Field(
         default=None,
         description=(

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -234,6 +234,21 @@ class TestCreateAutomation:
         assert response.status_code == 201
         assert response.json()["preset_metadata"] is None
 
+    async def test_create_automation_honors_explicit_enabled_state(self, async_client):
+        """Custom SDK automations can be created disabled for a test run."""
+        payload = {
+            "name": "Test Before Enabling",
+            "trigger": {"type": "cron", "schedule": "0 9 * * 5", "timezone": "UTC"},
+            "tarball_path": "s3://bucket/path/to/code.tar.gz",
+            "entrypoint": "uv run script.py",
+            "enabled": False,
+        }
+
+        response = await async_client.post("/api/automation/v1", json=payload)
+
+        assert response.status_code == 201
+        assert response.json()["enabled"] is False
+
     async def test_create_automation_stores_template_provenance(self, async_client):
         """A catalog entry shipping its own tarball records where it came from."""
         payload = {


### PR DESCRIPTION
## Why

OpenHands/OpenHands#16567 adds a controlled test-run gate to automation creation. Raw bundle automations must be persisted as disabled before their first manual dispatch; creating them enabled and disabling them in a follow-up request leaves a race where a schedule or event can trigger untested code.

## Summary

- add an optional `enabled` field to `CreateAutomationRequest`, defaulting to `true` for backward compatibility
- pass the requested state into the persisted `Automation`
- cover explicit disabled creation while preserving the existing default-enabled behavior

## Related issue

Supports OpenHands/OpenHands#16567.

## Validation

- `uvx ruff check openhands/automation/router.py openhands/automation/schemas.py tests/test_router.py`
- `uvx ruff format --check openhands/automation/router.py openhands/automation/schemas.py tests/test_router.py`
- `python -m py_compile openhands/automation/router.py openhands/automation/schemas.py tests/test_router.py`
- `git diff --check`

The targeted pytest could not be executed on Windows because `litellm==1.93.0` publishes Linux wheels only and its source build requires an MSVC linker that is not installed. The test is included for Linux CI.
