### PR TITLE
feat: report live run phases for dashboard visibility

### DIFF
--- a/docs/run-phase-reporting.md
+++ b/docs/run-phase-reporting.md
@@ -1,0 +1,105 @@
+# Run Phase Reporting Guide
+
+This guide covers how automations report live progress phases that the dashboard shows while a run is active.
+
+## Overview
+
+While an automation run is `PENDING` or `RUNNING`, it can publish a short, human-readable "current phase" message (e.g. `Cloning repositories`, `Running QA checks`, `Posting review comments`). The dashboard and the automation detail page poll run data while a run is in flight and render the latest phase next to the run status — so users can see what a long run is doing without opening logs.
+
+Phases are **cosmetic, best-effort telemetry**:
+
+- They never affect the run outcome. A failed phase POST must never fail your automation.
+- Only the most recent phase is stored (one message per run, overwritten on each report).
+- Once the run reaches a terminal status (`COMPLETED`, `FAILED`, `CANCELLED`, `SKIPPED`), further phase reports are rejected with `409` and the UI stops rendering the phase.
+- Preset automations report standard phases automatically (environment setup, repo cloning, skill loading, agent configuration, and live agent activity). This guide is for **custom automations** that want the same visibility.
+
+## Environment Variables
+
+The dispatcher injects everything you need into the run's environment:
+
+| Variable | Description |
+|----------|-------------|
+| `AUTOMATION_PHASE_URL` | Full URL to POST phase updates to (`{service}/v1/runs/{run_id}/phase`) |
+| `AUTOMATION_CALLBACK_API_KEY` | Auth token (local / self-hosted mode) |
+| `OPENHANDS_API_KEY` | Auth token (Cloud mode) |
+| `AUTOMATION_RUN_ID` | This run's ID (informational; already encoded in the URL) |
+
+Use whichever token is present: `AUTOMATION_CALLBACK_API_KEY` in local mode, `OPENHANDS_API_KEY` in Cloud mode.
+
+## Reporting a Phase
+
+```bash
+PHASE_TOKEN="${AUTOMATION_CALLBACK_API_KEY:-${OPENHANDS_API_KEY:-}}"
+if [ -n "${AUTOMATION_PHASE_URL:-}" ] && [ -n "$PHASE_TOKEN" ]; then
+    curl -sf -m 5 -X POST "$AUTOMATION_PHASE_URL" \
+      -H "Authorization: Bearer $PHASE_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"phase": "Checking out PR #123"}' >/dev/null 2>&1 || true
+fi
+```
+
+The trailing `|| true` (and the env guards) keep the report non-fatal — recommended for every caller, especially scripts running under `set -e`.
+
+Python equivalent:
+
+```python
+import os
+
+import httpx
+
+def report_phase(message: str) -> None:
+    url = os.environ.get("AUTOMATION_PHASE_URL", "")
+    token = (
+        os.environ.get("AUTOMATION_CALLBACK_API_KEY")
+        or os.environ.get("OPENHANDS_API_KEY")
+        or ""
+    )
+    if not url or not token or not message:
+        return
+    try:
+        httpx.post(
+            url,
+            json={"phase": message[:200]},
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=5.0,
+        )
+    except Exception:
+        pass  # phases are cosmetic; never fail the run because of them
+```
+
+## API Contract
+
+`POST /v1/runs/{run_id}/phase`
+
+**Request body:**
+```json
+{"phase": "Running QA checks"}
+```
+
+- `phase` must be 1–200 characters after normalization. Control characters (including newlines) and runs of whitespace are collapsed to single spaces; leading/trailing whitespace is stripped.
+
+**Responses:**
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Phase recorded; body is the updated run |
+| `403` | Caller does not own the run's parent automation |
+| `404` | Run not found |
+| `409` | Run is already terminal (`COMPLETED`/`FAILED`/`CANCELLED`/`SKIPPED`) |
+| `422` | Invalid body (empty/whitespace-only phase, or longer than 200 chars) |
+
+A `409` near the end of a run is normal (e.g. the completion callback won the race) — ignore it.
+
+## Safety Guidelines
+
+Phase messages are rendered directly in the dashboard, so:
+
+- **Never include secrets, tokens, or credentials.** Phase text is stored in the automation service and shown in the UI.
+- **Never include raw payloads, stack traces, or customer data.** Use `error_detail` semantics (the completion callback) for failures; phases are for progress.
+- Keep messages **concise and user-facing** — a short present-tense action ("Examining the diff") reads best. Long messages are truncated by the 200-char limit.
+- Report at meaningful step boundaries, not in tight loops. One update every few seconds is plenty; only the latest message is kept.
+
+## Version Compatibility
+
+- On automation services older than the release that added this endpoint, `AUTOMATION_PHASE_URL` is not set — guard on its presence (as in the examples) and your automation degrades silently.
+- Missing phase information is always safe: the dashboard falls back to the plain run status.

--- a/migrations/versions/020_add_run_current_phase.py
+++ b/migrations/versions/020_add_run_current_phase.py
@@ -1,0 +1,42 @@
+"""Add live run progress phase.
+
+Revision ID: 020
+Revises: 019
+Create Date: 2026-08-22
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "020"
+down_revision: str = "019"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sqlite() -> bool:
+    return op.get_bind().dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "automation_runs",
+        sa.Column("current_phase", sa.String(length=200), nullable=True),
+    )
+
+    if _is_sqlite():
+        return
+
+    op.execute(
+        "COMMENT ON COLUMN automation_runs.current_phase IS "
+        "'Human-readable live progress phase reported while the run is "
+        "PENDING/RUNNING. Not cleared on completion; consumers must only "
+        "render it for in-flight runs.'"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("automation_runs", "current_phase")

--- a/migrations/versions/021_add_run_current_phase.py
+++ b/migrations/versions/021_add_run_current_phase.py
@@ -1,7 +1,7 @@
 """Add live run progress phase.
 
-Revision ID: 020
-Revises: 019
+Revision ID: 021
+Revises: 020
 Create Date: 2026-08-22
 """
 
@@ -11,8 +11,8 @@ import sqlalchemy as sa
 from alembic import op
 
 
-revision: str = "020"
-down_revision: str = "019"
+revision: str = "021"
+down_revision: str = "020"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/openhands/automation/dispatcher.py
+++ b/openhands/automation/dispatcher.py
@@ -50,6 +50,7 @@ from openhands.automation.utils.run import (
     mark_run_status,
     mark_run_terminal,
     update_bash_command_id,
+    update_run_current_phase,
     update_run_timeout_at,
     update_sandbox_id,
 )
@@ -293,6 +294,9 @@ async def _execute_run(
     callback_url = f"{settings.resolved_base_url.rstrip('/')}/v1/runs/{run_id}/complete"
     env_vars = backend.build_env_vars()
     env_vars["AUTOMATION_CALLBACK_URL"] = callback_url
+    env_vars["AUTOMATION_PHASE_URL"] = (
+        f"{settings.resolved_base_url.rstrip('/')}/v1/runs/{run_id}/phase"
+    )
     env_vars["AUTOMATION_RUN_ID"] = run_id
     env_vars["AUTOMATION_USER_ID"] = str(automation.user_id)
     env_vars["AUTOMATION_ORG_ID"] = str(automation.org_id)
@@ -438,6 +442,7 @@ async def _execute_run(
 
     # 6. Handle result
     if result.success:
+        await update_run_current_phase(session_factory, run.id, "Starting automation")
         if ctx.sandbox_id:
             await update_sandbox_id(session_factory, run.id, ctx.sandbox_id)
         if result.bash_command_id:
@@ -535,6 +540,7 @@ async def dispatch_pending_runs(
                     run,
                     AutomationRunStatus.RUNNING,
                     max_duration=timedelta(seconds=provisioning_deadline),
+                    current_phase="Preparing environment",
                 )
                 dispatched_runs.append(run)
             except Exception:

--- a/openhands/automation/models.py
+++ b/openhands/automation/models.py
@@ -164,6 +164,13 @@ class AutomationRun(Base):
     # remains PENDING/RUNNING.
     status_detail: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
 
+    # Human-readable live progress phase ("Cloning repositories", tool-call
+    # summaries, ...) written by the dispatcher and by the run's entrypoint
+    # via POST /v1/runs/{id}/phase. Only written while PENDING/RUNNING, and
+    # deliberately never cleared on completion (unlike status_detail) — the
+    # UI renders it only for in-flight runs.
+    current_phase: Mapped[str | None] = mapped_column(String(200), nullable=True)
+
     # Conversation created by the SDK script (set by completion callback)
     conversation_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
 

--- a/openhands/automation/presets/plugin/sdk_main.py
+++ b/openhands/automation/presets/plugin/sdk_main.py
@@ -69,6 +69,7 @@ import json
 import os
 import random
 import sys
+import threading
 import time
 from datetime import datetime, timezone
 
@@ -123,6 +124,60 @@ print(f"  AUTOMATION_MODEL: {model_profile or 'DEFAULT'}")
 print(f"  AUTOMATION_USER_ID: {'OK' if automation_user_id else 'NONE'}")
 print(f"  AUTOMATION_ORG_ID: {'OK' if os.environ.get('AUTOMATION_ORG_ID') else 'NONE'}")
 print(f"  AUTOMATION_RUN_ID: {os.environ.get('AUTOMATION_RUN_ID') or 'NONE'}")
+
+# --- Live phase reporting (best-effort, never fatal) -------------------------
+AUTOMATION_PHASE_URL = os.environ.get("AUTOMATION_PHASE_URL", "")
+_PHASE_TOKEN = (
+    os.environ.get("AUTOMATION_CALLBACK_API_KEY")
+    or os.environ.get("OPENHANDS_API_KEY")
+    or ""
+)
+PHASE_POST_INTERVAL_SECONDS = 4.0
+
+
+def report_phase(message: str) -> None:
+    """POST a short progress phase to the automation service. Never raises."""
+    if not AUTOMATION_PHASE_URL or not _PHASE_TOKEN or not message:
+        return
+    try:
+        import httpx  # installed alongside the SDK by setup.sh
+
+        httpx.post(
+            AUTOMATION_PHASE_URL,
+            json={"phase": message[:200]},
+            headers={"Authorization": f"Bearer {_PHASE_TOKEN}"},
+            timeout=5.0,
+        )
+    except Exception:
+        pass  # phases are cosmetic; the run must never fail because of them
+
+
+def _redact_phase(text: str) -> str:
+    """Redact secrets from a phase; drop it entirely if redaction is missing."""
+    try:
+        from openhands.sdk.utils.redact import (
+            redact_api_key_literals,
+            redact_text_secrets,
+        )
+
+        return redact_api_key_literals(redact_text_secrets(text))
+    except Exception:
+        return ""
+
+
+# Latest pending live phase; a daemon thread posts it at most once per
+# interval so the conversation event thread never blocks on network I/O.
+_live_phase: dict = {"pending": None, "posted": None, "stop": False}
+
+
+def _phase_poster() -> None:
+    while not _live_phase["stop"]:
+        time.sleep(PHASE_POST_INTERVAL_SECONDS)
+        message = _live_phase["pending"]
+        if message and message != _live_phase["posted"]:
+            _live_phase["posted"] = message
+            report_phase(message)
+
 
 # SDK imports (before workspace context so import errors are caught)
 from openhands.sdk import Conversation, RemoteConversation
@@ -239,6 +294,7 @@ else:
 with workspace_ctx as workspace:
     # -- All remaining setup happens inside the workspace context --
     # This ensures failures trigger the __exit__ callback
+    report_phase("Setting up workspace")
 
     # Parse event payload if present (for event-triggered automations)
     event_context = None
@@ -261,6 +317,7 @@ with workspace_ctx as workspace:
         with open(REPOS_CONFIG_FILE) as f:
             repos_config = json.load(f)
         if repos_config:
+            report_phase("Cloning repositories")
             clone_result = workspace.clone_repos(repos_config)
             print(f"  cloned {clone_result.success_count}/{len(repos_config)} repos")
             if clone_result.failed_repos:
@@ -271,6 +328,7 @@ with workspace_ctx as workspace:
     # Load ALL skills via workspace.load_skills_from_agent_server()
     # If repos were cloned, project skills are loaded from EACH cloned repo
     print("\n=== LOAD SKILLS ===")
+    report_phase("Loading skills")
     loaded_skills, agent_context = workspace.load_skills_from_agent_server(
         project_dirs=repo_dirs if repo_dirs else None
     )
@@ -392,6 +450,7 @@ This automation was triggered by a webhook event:
 
     # Get default agent with tools and condenser (CLI mode to disable browser)
     print("\n=== AGENT ===")
+    report_phase("Configuring agent")
     # Keep finish-tool schema wiring in sync with presets/prompt/sdk_main.py.
     agent = get_default_agent(
         llm=llm,
@@ -424,6 +483,14 @@ This automation was triggered by a webhook event:
     def event_callback(event) -> None:
         received_events.append(event)
         last_event_time["ts"] = time.time()
+        # Surface the LLM-authored ~10-word action summary as a live phase.
+        # Name-based check keeps this resilient across SDK versions.
+        if type(event).__name__ == "ActionEvent":
+            summary = getattr(event, "summary", None)
+            if isinstance(summary, str) and summary.strip():
+                redacted = _redact_phase(" ".join(summary.split()))
+                if redacted:
+                    _live_phase["pending"] = redacted[:200]
 
     # Build experiment tags (if running an A/B test)
     experiment_tags: dict[str, str] = {}
@@ -497,6 +564,9 @@ This automation was triggered by a webhook event:
         conversation.update_secrets({"AUTOMATION_SESSION_URL": session_url})
         print(f"  session URL: {session_url}")
 
+    report_phase("Agent is working on the task")
+    threading.Thread(target=_phase_poster, name="phase-poster", daemon=True).start()
+
     cost = None
     try:
         print(f"  sending prompt: {USER_PROMPT[:80]}...")
@@ -521,6 +591,7 @@ This automation was triggered by a webhook event:
         print(f"  cost: {cost}")
         print(f"  events received: {len(received_events)}")
     finally:
+        _live_phase["stop"] = True
         try:
             conversation.close()
         except Exception as e:

--- a/openhands/automation/presets/plugin/sdk_main.py
+++ b/openhands/automation/presets/plugin/sdk_main.py
@@ -126,6 +126,7 @@ print(f"  AUTOMATION_ORG_ID: {'OK' if os.environ.get('AUTOMATION_ORG_ID') else '
 print(f"  AUTOMATION_RUN_ID: {os.environ.get('AUTOMATION_RUN_ID') or 'NONE'}")
 
 # --- Live phase reporting (best-effort, never fatal) -------------------------
+# Keep this block in sync with presets/prompt/sdk_main.py.
 AUTOMATION_PHASE_URL = os.environ.get("AUTOMATION_PHASE_URL", "")
 _PHASE_TOKEN = (
     os.environ.get("AUTOMATION_CALLBACK_API_KEY")
@@ -167,6 +168,8 @@ def _redact_phase(text: str) -> str:
 
 # Latest pending live phase; a daemon thread posts it at most once per
 # interval so the conversation event thread never blocks on network I/O.
+# Deliberately unlocked: each key is a single reference read/write (atomic
+# under the GIL) and last-writer-wins is acceptable for cosmetic telemetry.
 _live_phase: dict = {"pending": None, "posted": None, "stop": False}
 
 

--- a/openhands/automation/presets/plugin/setup.sh
+++ b/openhands/automation/presets/plugin/setup.sh
@@ -34,6 +34,15 @@ if [ -z "$SDK_VERSION" ]; then
     exit 1
 fi
 
+# Best-effort progress phase for the dashboard — must never fail the setup.
+PHASE_TOKEN="${AUTOMATION_CALLBACK_API_KEY:-${OPENHANDS_API_KEY:-}}"
+if [ -n "${AUTOMATION_PHASE_URL:-}" ] && [ -n "$PHASE_TOKEN" ]; then
+    curl -sf -m 5 -X POST "$AUTOMATION_PHASE_URL" \
+      -H "Authorization: Bearer $PHASE_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"phase": "Installing dependencies"}' >/dev/null 2>&1 || true
+fi
+
 echo "[setup] Creating isolated virtual environment"
 # Pin >=3.12 so uv doesn't default to an older system Python (e.g. macOS
 # CommandLineTools 3.9), which can't satisfy openhands-sdk's requires-python.

--- a/openhands/automation/presets/prompt/sdk_main.py
+++ b/openhands/automation/presets/prompt/sdk_main.py
@@ -130,6 +130,7 @@ print(f"  AUTOMATION_ORG_ID: {'OK' if os.environ.get('AUTOMATION_ORG_ID') else '
 print(f"  AUTOMATION_RUN_ID: {os.environ.get('AUTOMATION_RUN_ID') or 'NONE'}")
 
 # --- Live phase reporting (best-effort, never fatal) -------------------------
+# Keep this block in sync with presets/plugin/sdk_main.py.
 AUTOMATION_PHASE_URL = os.environ.get("AUTOMATION_PHASE_URL", "")
 _PHASE_TOKEN = (
     os.environ.get("AUTOMATION_CALLBACK_API_KEY")
@@ -171,6 +172,8 @@ def _redact_phase(text: str) -> str:
 
 # Latest pending live phase; a daemon thread posts it at most once per
 # interval so the conversation event thread never blocks on network I/O.
+# Deliberately unlocked: each key is a single reference read/write (atomic
+# under the GIL) and last-writer-wins is acceptable for cosmetic telemetry.
 _live_phase: dict = {"pending": None, "posted": None, "stop": False}
 
 

--- a/openhands/automation/presets/prompt/sdk_main.py
+++ b/openhands/automation/presets/prompt/sdk_main.py
@@ -72,6 +72,7 @@ import inspect
 import json
 import os
 import sys
+import threading
 import time
 from datetime import datetime, timezone
 
@@ -127,6 +128,60 @@ print(f"  AUTOMATION_USER_ID: {'OK' if automation_user_id else 'NONE'}")
 print(f"  AUTOMATION_ORG_ID: {'OK' if os.environ.get('AUTOMATION_ORG_ID') else 'NONE'}")
 
 print(f"  AUTOMATION_RUN_ID: {os.environ.get('AUTOMATION_RUN_ID') or 'NONE'}")
+
+# --- Live phase reporting (best-effort, never fatal) -------------------------
+AUTOMATION_PHASE_URL = os.environ.get("AUTOMATION_PHASE_URL", "")
+_PHASE_TOKEN = (
+    os.environ.get("AUTOMATION_CALLBACK_API_KEY")
+    or os.environ.get("OPENHANDS_API_KEY")
+    or ""
+)
+PHASE_POST_INTERVAL_SECONDS = 4.0
+
+
+def report_phase(message: str) -> None:
+    """POST a short progress phase to the automation service. Never raises."""
+    if not AUTOMATION_PHASE_URL or not _PHASE_TOKEN or not message:
+        return
+    try:
+        import httpx  # installed alongside the SDK by setup.sh
+
+        httpx.post(
+            AUTOMATION_PHASE_URL,
+            json={"phase": message[:200]},
+            headers={"Authorization": f"Bearer {_PHASE_TOKEN}"},
+            timeout=5.0,
+        )
+    except Exception:
+        pass  # phases are cosmetic; the run must never fail because of them
+
+
+def _redact_phase(text: str) -> str:
+    """Redact secrets from a phase; drop it entirely if redaction is missing."""
+    try:
+        from openhands.sdk.utils.redact import (
+            redact_api_key_literals,
+            redact_text_secrets,
+        )
+
+        return redact_api_key_literals(redact_text_secrets(text))
+    except Exception:
+        return ""
+
+
+# Latest pending live phase; a daemon thread posts it at most once per
+# interval so the conversation event thread never blocks on network I/O.
+_live_phase: dict = {"pending": None, "posted": None, "stop": False}
+
+
+def _phase_poster() -> None:
+    while not _live_phase["stop"]:
+        time.sleep(PHASE_POST_INTERVAL_SECONDS)
+        message = _live_phase["pending"]
+        if message and message != _live_phase["posted"]:
+            _live_phase["posted"] = message
+            report_phase(message)
+
 
 # SDK imports (before workspace context so import errors are caught)
 from openhands.sdk import Conversation, RemoteConversation
@@ -246,6 +301,7 @@ else:
 with workspace_ctx as workspace:
     # -- All remaining setup happens inside the workspace context --
     # This ensures failures trigger the __exit__ callback
+    report_phase("Setting up workspace")
 
     # Parse event payload if present (for event-triggered automations)
     event_context = None
@@ -268,6 +324,7 @@ with workspace_ctx as workspace:
         with open(REPOS_CONFIG_FILE) as f:
             repos_config = json.load(f)
         if repos_config:
+            report_phase("Cloning repositories")
             clone_result = workspace.clone_repos(repos_config)
             print(f"  cloned {clone_result.success_count}/{len(repos_config)} repos")
             if clone_result.failed_repos:
@@ -278,6 +335,7 @@ with workspace_ctx as workspace:
     # Load ALL skills via workspace.load_skills_from_agent_server()
     # If repos were cloned, project skills are loaded from EACH cloned repo
     print("\n=== LOAD SKILLS ===")
+    report_phase("Loading skills")
     loaded_skills, agent_context = workspace.load_skills_from_agent_server(
         project_dirs=repo_dirs if repo_dirs else None
     )
@@ -361,6 +419,7 @@ This automation was triggered by a webhook event:
 
     # Get default agent with tools and condenser (CLI mode to disable browser)
     print("\n=== AGENT ===")
+    report_phase("Configuring agent")
     # Keep finish-tool schema wiring in sync with presets/plugin/sdk_main.py.
     agent = get_default_agent(
         llm=llm,
@@ -391,6 +450,14 @@ This automation was triggered by a webhook event:
     def event_callback(event) -> None:
         received_events.append(event)
         last_event_time["ts"] = time.time()
+        # Surface the LLM-authored ~10-word action summary as a live phase.
+        # Name-based check keeps this resilient across SDK versions.
+        if type(event).__name__ == "ActionEvent":
+            summary = getattr(event, "summary", None)
+            if isinstance(summary, str) and summary.strip():
+                redacted = _redact_phase(" ".join(summary.split()))
+                if redacted:
+                    _live_phase["pending"] = redacted[:200]
 
     # Cloud workspaces supply richer automation tags (for example, whether the
     # trigger was cron or webhook). Only add fallback tags in local mode.
@@ -447,6 +514,9 @@ This automation was triggered by a webhook event:
         conversation.update_secrets({"AUTOMATION_SESSION_URL": session_url})
         print(f"  session URL: {session_url}")
 
+    report_phase("Agent is working on the task")
+    threading.Thread(target=_phase_poster, name="phase-poster", daemon=True).start()
+
     cost = None
     try:
         print(f"  sending prompt: {USER_PROMPT[:80]}...")
@@ -471,6 +541,7 @@ This automation was triggered by a webhook event:
         print(f"  cost: {cost}")
         print(f"  events received: {len(received_events)}")
     finally:
+        _live_phase["stop"] = True
         try:
             conversation.close()
         except Exception as e:

--- a/openhands/automation/presets/prompt/setup.sh
+++ b/openhands/automation/presets/prompt/setup.sh
@@ -34,6 +34,15 @@ if [ -z "$SDK_VERSION" ]; then
     exit 1
 fi
 
+# Best-effort progress phase for the dashboard — must never fail the setup.
+PHASE_TOKEN="${AUTOMATION_CALLBACK_API_KEY:-${OPENHANDS_API_KEY:-}}"
+if [ -n "${AUTOMATION_PHASE_URL:-}" ] && [ -n "$PHASE_TOKEN" ]; then
+    curl -sf -m 5 -X POST "$AUTOMATION_PHASE_URL" \
+      -H "Authorization: Bearer $PHASE_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"phase": "Installing dependencies"}' >/dev/null 2>&1 || true
+fi
+
 echo "[setup] Creating isolated virtual environment"
 # Pin >=3.12 so uv doesn't default to an older system Python (e.g. macOS
 # CommandLineTools 3.9), which can't satisfy openhands-sdk's requires-python.

--- a/openhands/automation/router.py
+++ b/openhands/automation/router.py
@@ -39,6 +39,7 @@ from openhands.automation.schemas import (
     AutomationRunResponse,
     CreateAutomationRequest,
     RunCompleteRequest,
+    RunPhaseRequest,
     UpdateAutomationRequest,
 )
 from openhands.automation.storage import FileStore, get_file_store
@@ -601,6 +602,59 @@ async def complete_run(
                 )
             )
 
+    return AutomationRunResponse.model_validate(run)
+
+
+# --- Run phase reporting ---
+
+
+@router.post("/runs/{run_id}/phase")
+async def report_run_phase(
+    run_id: uuid.UUID,
+    body: RunPhaseRequest,
+    user: AuthenticatedUser = Depends(_require_manage_automations),
+    session: AsyncSession = Depends(get_session),
+) -> AutomationRunResponse:
+    """Record a live progress phase reported from inside the sandbox.
+
+    Best-effort telemetry for the dashboard: authenticated with the same
+    credentials injected into the sandbox (see ``complete_run``), the caller
+    must own the run's parent automation, and the write only lands while the
+    run is still PENDING or RUNNING (409 once terminal).
+    """
+    result = await session.execute(
+        select(AutomationRun)
+        .where(AutomationRun.id == run_id)
+        .options(selectinload(AutomationRun.automation))
+    )
+    run = result.scalars().first()
+    if run is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Run not found")
+
+    # Verify the caller owns this automation
+    automation = run.automation
+    if automation.user_id != user.user_id or automation.org_id != user.org_id:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Not your automation")
+
+    stmt = (
+        update(AutomationRun)
+        .where(
+            AutomationRun.id == run_id,
+            AutomationRun.status.in_(
+                (AutomationRunStatus.PENDING, AutomationRunStatus.RUNNING)
+            ),
+        )
+        .values(current_phase=body.phase)
+    )
+    db_result: CursorResult = await session.execute(stmt)  # type: ignore[assignment]
+    if db_result.rowcount == 0:
+        await session.refresh(run)
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail=f"Run is {run.status.value}, expected PENDING or RUNNING",
+        )
+
+    await session.refresh(run)
     return AutomationRunResponse.model_validate(run)
 
 

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -37,6 +37,9 @@ _SHELL_META_RE = re.compile(r"[;&|`$(){}<>!\\\n\r]")
 # Path traversal pattern
 _PATH_TRAVERSAL_RE = re.compile(r"(^|/)\.\.(/|$)")
 
+# Control characters (including newlines) collapsed out of run phase messages
+_PHASE_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]+")
+
 
 class CronTrigger(BaseModel):
     """Cron-based trigger configuration."""
@@ -773,6 +776,22 @@ class RunCompleteRequest(BaseModel):
             return value
 
 
+class RunPhaseRequest(BaseModel):
+    """Live progress phase reported by the automation entrypoint."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    phase: str = Field(..., min_length=1, max_length=200)
+
+    @field_validator("phase", mode="before")
+    @classmethod
+    def normalize_phase(cls, v: Any) -> Any:
+        if not isinstance(v, str):
+            return v
+        # Collapse control chars/newlines and runs of whitespace; strip ends.
+        return " ".join(_PHASE_CONTROL_CHARS_RE.sub(" ", v).split())
+
+
 class AutomationRunResponse(BaseModel):
     """Response for a single automation run."""
 
@@ -781,6 +800,7 @@ class AutomationRunResponse(BaseModel):
     status: RunStatus
     error_detail: str | None
     status_detail: dict[str, Any] | None = None
+    current_phase: str | None = None
     conversation_id: str | None
     cost: float | None = None
     timeout_at: UtcDatetime | None

--- a/openhands/automation/utils/run.py
+++ b/openhands/automation/utils/run.py
@@ -135,6 +135,7 @@ async def mark_run_status(
     error_detail: str | None = None,
     max_duration: timedelta | None = None,
     status_detail: dict | None = None,
+    current_phase: str | None = None,
 ) -> None:
     """Update a run's status and set the appropriate timestamp.
 
@@ -149,6 +150,9 @@ async def mark_run_status(
         error_detail: Optional error message (only used for FAILED status)
         max_duration: Maximum run duration for computing timeout_at
         status_detail: Optional structured lifecycle detail to persist
+        current_phase: Optional live progress phase to persist. Unlike
+            status_detail there is no clearing branch — the last phase is
+            kept on terminal transitions by design.
     """
     if max_duration is None:
         max_duration = timedelta(seconds=resolve_automation_timeout_seconds(None))
@@ -180,6 +184,10 @@ async def mark_run_status(
     elif status in (AutomationRunStatus.RUNNING, AutomationRunStatus.COMPLETED):
         values["status_detail"] = None
         run.status_detail = None
+
+    if current_phase is not None:
+        values["current_phase"] = current_phase
+        run.current_phase = current_phase
 
     await session.execute(
         update(AutomationRun).where(AutomationRun.id == run.id).values(**values)
@@ -263,6 +271,33 @@ async def update_run_timeout_at(
             await session.commit()
     except Exception:
         logger.exception("Failed to update timeout_at for run %s", run_id)
+
+
+async def update_run_current_phase(
+    session_factory: async_sessionmaker[AsyncSession],
+    run_id: uuid.UUID,
+    phase: str,
+) -> None:
+    """Best-effort write of the live progress phase for an in-flight run.
+
+    Guarded by status IN (PENDING, RUNNING) so a terminal run's final state
+    is never disturbed. Failure is non-fatal — phases are cosmetic.
+    """
+    try:
+        async with session_factory() as session:
+            await session.execute(
+                update(AutomationRun)
+                .where(
+                    AutomationRun.id == run_id,
+                    AutomationRun.status.in_(
+                        (AutomationRunStatus.PENDING, AutomationRunStatus.RUNNING)
+                    ),
+                )
+                .values(current_phase=phase)
+            )
+            await session.commit()
+    except Exception:
+        logger.exception("Failed to update current_phase for run %s", run_id)
 
 
 async def _record_first_run_outcome_in_session(

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -4,6 +4,7 @@ The dispatcher polls for PENDING automation runs and marks them as RUNNING.
 """
 
 import asyncio
+import logging
 import uuid
 from datetime import timedelta
 from typing import Any, cast
@@ -26,6 +27,7 @@ from openhands.automation.utils import utcnow
 from openhands.automation.utils.run import (
     mark_run_status,
     mark_run_terminal,
+    update_run_current_phase,
     update_run_timeout_at,
 )
 from openhands.automation.utils.tarball_validation import is_http_url
@@ -254,6 +256,22 @@ class TestUpdateRunTimeoutAt:
         async with async_session_factory() as session:
             updated = await session.get(AutomationRun, run_id)
             assert updated.timeout_at == original_timeout_at
+
+
+class TestUpdateRunCurrentPhase:
+    """Tests for the best-effort live phase write."""
+
+    async def test_database_failure_is_logged_not_raised(self, caplog):
+        """A failing session is logged and swallowed — phases are cosmetic."""
+        session_factory = MagicMock(side_effect=RuntimeError("db down"))
+
+        with caplog.at_level(logging.ERROR, logger="openhands.automation.utils.run"):
+            await update_run_current_phase(session_factory, uuid.uuid4(), "Cloning")
+
+        assert any(
+            "Failed to update current_phase" in record.message
+            for record in caplog.records
+        )
 
 
 class TestMarkRunTerminalFirstRunOutcome:

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -361,6 +361,38 @@ class TestDispatchPendingRuns:
             updated = result.scalars().first()
             assert updated.status == AutomationRunStatus.RUNNING
 
+    @patch("openhands.automation.dispatcher._execute_run_safe", new_callable=AsyncMock)
+    async def test_dispatch_sets_initial_phase(
+        self, mock_execute, async_session_factory, mock_settings, mock_client
+    ):
+        """The RUNNING transition records the initial live progress phase."""
+        async with async_session_factory() as session:
+            automation = Automation(
+                user_id=TEST_USER_ID,
+                org_id=TEST_ORG_ID,
+                name="Test",
+                trigger={"type": "cron", "schedule": "* * * * *", "timezone": "UTC"},
+                tarball_path="s3://bucket/code.tar.gz",
+                entrypoint="uv run main.py",
+                enabled=True,
+            )
+            session.add(automation)
+            await session.commit()
+
+            run = AutomationRun(
+                automation_id=automation.id,
+                status=AutomationRunStatus.PENDING,
+            )
+            session.add(run)
+            await session.commit()
+            run_id = run.id
+
+        await dispatch_pending_runs(async_session_factory, mock_settings, mock_client)
+
+        async with async_session_factory() as session:
+            updated = await session.get(AutomationRun, run_id)
+            assert updated.current_phase == "Preparing environment"
+
     @patch(
         "openhands.automation.dispatcher.capture_automation_event",
         new_callable=AsyncMock,
@@ -806,6 +838,90 @@ class TestEffectiveTimeout:
             remaining = (updated.timeout_at - utcnow()).total_seconds()
             expected = sandbox_cfg.default_run_duration + sandbox_cfg.run_timeout_margin
             assert expected - 30 < remaining <= expected
+
+
+class TestExecuteRunPhaseReporting:
+    """Phase-reporting wiring in _execute_run."""
+
+    async def _run_successful_execution(
+        self, mock_execute, async_session_factory, mock_settings, mock_client
+    ):
+        """Drive _execute_run through a successful dispatch; returns run_id."""
+        async with async_session_factory() as session:
+            automation = Automation(
+                user_id=TEST_USER_ID,
+                org_id=TEST_ORG_ID,
+                name="Phase Wiring",
+                trigger={"type": "cron", "schedule": "* * * * *", "timezone": "UTC"},
+                tarball_path="https://example.com/code.tar.gz",
+                entrypoint="uv run main.py",
+                enabled=True,
+            )
+            session.add(automation)
+            await session.commit()
+
+            run = AutomationRun(
+                automation_id=automation.id,
+                status=AutomationRunStatus.RUNNING,
+                started_at=utcnow(),
+            )
+            session.add(run)
+            await session.commit()
+            run_id = run.id
+
+        async with async_session_factory() as session:
+            run = (
+                (
+                    await session.execute(
+                        select(AutomationRun)
+                        .options(selectinload(AutomationRun.automation))
+                        .where(AutomationRun.id == run_id)
+                    )
+                )
+                .scalars()
+                .first()
+            )
+
+        backend = MagicMock()
+        ctx = MagicMock(
+            agent_url="http://agent.test", sandbox_id="sbx-1", session_key="sk-1"
+        )
+        backend.get_execution_context = AsyncMock(return_value=ctx)
+        backend.build_env_vars = MagicMock(return_value={})
+        backend.get_work_dir = MagicMock(return_value="/workspace")
+        mock_execute.return_value = MagicMock(
+            success=True, bash_command_id="cmd-1", error=None
+        )
+
+        with patch("openhands.automation.dispatcher.get_backend", return_value=backend):
+            await _execute_run(run, mock_settings, async_session_factory, mock_client)
+
+        return run_id
+
+    @patch("openhands.automation.dispatcher.execute_in_context", new_callable=AsyncMock)
+    async def test_exposes_phase_url_to_sandbox(
+        self, mock_execute, async_session_factory, mock_settings, mock_client
+    ):
+        """The sandbox env carries the per-run phase reporting endpoint."""
+        run_id = await self._run_successful_execution(
+            mock_execute, async_session_factory, mock_settings, mock_client
+        )
+
+        env_vars = mock_execute.await_args.kwargs["env_vars"]
+        assert env_vars["AUTOMATION_PHASE_URL"].endswith(f"/v1/runs/{run_id}/phase")
+
+    @patch("openhands.automation.dispatcher.execute_in_context", new_callable=AsyncMock)
+    async def test_marks_starting_automation_phase_after_bash_dispatch(
+        self, mock_execute, async_session_factory, mock_settings, mock_client
+    ):
+        """A successful bash dispatch advances the phase past provisioning."""
+        run_id = await self._run_successful_execution(
+            mock_execute, async_session_factory, mock_settings, mock_client
+        )
+
+        async with async_session_factory() as session:
+            updated = await session.get(AutomationRun, run_id)
+            assert updated.current_phase == "Starting automation"
 
 
 class TestBuildEventPayload:

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -2719,6 +2719,124 @@ class TestCompleteRun:
         assert "first_run" not in metadata
 
 
+class TestReportRunPhase:
+    """Tests for POST /runs/{run_id}/phase endpoint."""
+
+    async def _seed_run(self, async_session, status, *, user_id=None, org_id=None):
+        """Create an automation + run in the given status; returns the run."""
+        from openhands.automation.models import AutomationRunStatus
+
+        automation = Automation(
+            user_id=user_id or TEST_USER_ID,
+            org_id=org_id or TEST_ORG_ID,
+            name="Phase Test Automation",
+            trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
+            tarball_path="s3://bucket/code.tar.gz",
+            entrypoint="uv run script.py",
+        )
+        async_session.add(automation)
+        await async_session.commit()
+
+        run = AutomationRun(
+            automation_id=automation.id,
+            status=AutomationRunStatus(status),
+        )
+        async_session.add(run)
+        await async_session.commit()
+        return run
+
+    async def test_report_phase_updates_in_flight_run(
+        self, async_client, async_session
+    ):
+        """A phase posted while the run is RUNNING is stored and returned."""
+        run = await self._seed_run(async_session, "RUNNING")
+
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"phase": "Cloning repositories"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["current_phase"] == "Cloning repositories"
+        await async_session.refresh(run)
+        assert run.current_phase == "Cloning repositories"
+
+    async def test_report_phase_returns_409_for_terminal_run(
+        self, async_client, async_session
+    ):
+        """A phase posted after the run reached a terminal state is rejected."""
+        run = await self._seed_run(async_session, "COMPLETED")
+
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"phase": "Too late"},
+        )
+
+        assert response.status_code == 409
+        await async_session.refresh(run)
+        assert run.current_phase is None
+
+    async def test_report_phase_normalizes_control_characters_and_whitespace(
+        self, async_client, async_session
+    ):
+        """Control chars/newlines and whitespace runs collapse to single spaces."""
+        run = await self._seed_run(async_session, "RUNNING")
+
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"phase": " Checking\nout\tPR   #123 "},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["current_phase"] == "Checking out PR #123"
+
+    async def test_report_phase_rejects_blank_phase(self, async_client, async_session):
+        """A phase that is empty after normalization fails validation."""
+        run = await self._seed_run(async_session, "RUNNING")
+
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"phase": " \n\t "},
+        )
+
+        assert response.status_code == 422
+
+    async def test_report_phase_for_other_users_run_returns_403(
+        self, async_client, async_session
+    ):
+        """Reporting a phase on another user's run is forbidden."""
+        run = await self._seed_run(
+            async_session, "RUNNING", user_id=OTHER_USER_ID, org_id=OTHER_ORG_ID
+        )
+
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"phase": "Sneaky"},
+        )
+
+        assert response.status_code == 403
+
+    async def test_last_phase_is_preserved_after_completion(
+        self, async_client, async_session
+    ):
+        """Completion keeps the last reported phase (unlike status_detail)."""
+        run = await self._seed_run(async_session, "RUNNING")
+        await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/phase",
+            json={"phase": "Running QA checks"},
+        )
+
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{run.id}/complete",
+            json={"status": "COMPLETED"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["current_phase"] == "Running QA checks"
+        await async_session.refresh(run)
+        assert run.current_phase == "Running QA checks"
+
+
 class TestDownloadTarball:
     """Tests for GET /{automation_id}/tarball endpoint."""
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -3071,6 +3071,15 @@ class TestReportRunPhase:
 
         assert response.status_code == 422
 
+    async def test_report_phase_for_unknown_run_returns_404(self, async_client):
+        """Reporting a phase on a run that does not exist returns 404."""
+        response = await async_client.post(
+            f"/api/automation/v1/runs/{uuid.uuid4()}/phase",
+            json={"phase": "Ghost"},
+        )
+
+        assert response.status_code == 404
+
     async def test_report_phase_for_other_users_run_returns_403(
         self, async_client, async_session
     ):


### PR DESCRIPTION
## Why

Users cannot tell what an automation run is doing while it is active — the API exposes only a coarse run status until the run terminates, so long or multi-step automations (e.g. a code-review automation that clones a repo, examines a diff, and posts comments) feel opaque: there is no way to see whether a run is progressing, stuck, or nearly done. Issue OpenHands/OpenHands#16572 asks for live, user-facing phase updates during a run.

There was no mid-run write channel at all: the only sandbox→service writes were the terminal `/complete` and `/cancel` endpoints, and the preset scripts printed their phase banners to stdout only.

## Summary

- Add `AutomationRun.current_phase` (nullable, 200 chars; migration `021`, revising `020`) plus a sandbox-callable `POST /v1/runs/{run_id}/phase` endpoint that reuses the completion callback's auth/ownership pattern, only accepts writes while the run is PENDING/RUNNING (409 once terminal), normalizes the message server-side, and exposes the field on `AutomationRunResponse`.
- Instrument the run pipeline end to end: the dispatcher injects `AUTOMATION_PHASE_URL` and writes "Preparing environment" / "Starting automation" infra phases; the preset `sdk_main.py` scripts report standard setup phases and then stream redacted, throttled LLM-authored per-action summaries as live phases; both `setup.sh` scripts report "Installing dependencies". All reporting is best-effort — a failed phase POST can never fail a run.
- Document the contract for custom automations in `docs/run-phase-reporting.md` (env vars, curl/Python examples, response codes, safety guidance: no secrets, payloads, or stack traces in phase text).

## Issue Number

Fixes OpenHands/OpenHands#16572 (backend half; the dashboard rendering lands in the GUI repository).

## How to Test

1. Run the suite: `make test` (or `uv run python -m pytest tests/ -q`) — see the new `TestReportRunPhase` and dispatcher phase tests.
2. Manual API check against a local service:
   - Dispatch a run, then while it is RUNNING:
     `curl -X POST "$BASE/v1/runs/<run_id>/phase" -H "Authorization: Bearer <key>" -H "Content-Type: application/json" -d '{"phase": "Examining the diff"}'`
   - `GET /v1/{automation_id}/runs` now returns `current_phase` on the run.
   - Repeat the POST after the run completes → `409`.
3. Create a **new** prompt-preset automation (tarballs are baked at creation; pre-existing automations keep their old scripts) and dispatch it: the run's `current_phase` advances through Preparing environment → Installing dependencies → Setting up workspace → … → Agent is working on the task → live action summaries.

## Video/Screenshots

Live-dashboard screencast is attached to the companion GUI PR (per the issue's acceptance criteria); this PR is API/pipeline only. Reviewer-reproducible evidence here: the `TestReportRunPhase` suite and the curl flow above.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
