### PR TITLE
fix: honour the stored setup_script_path when executing automations

### DIFF
--- a/openhands/automation/dispatcher.py
+++ b/openhands/automation/dispatcher.py
@@ -421,6 +421,7 @@ async def _execute_run(
             env_vars=env_vars,
             timeout=effective_timeout,
             run_id=run_id,
+            setup_script_path=automation.setup_script_path,
             sandbox_id=ctx.sandbox_id,
         )
     except PermanentDispatchError as exc:

--- a/openhands/automation/execution.py
+++ b/openhands/automation/execution.py
@@ -341,6 +341,7 @@ async def execute_in_context(
     timeout: int | None = None,
     run_id: str | None = None,
     sandbox_id: str | None = None,
+    setup_script_path: str | None = None,
 ) -> DispatchResult:
     """Execute automation code in an existing execution context.
 
@@ -348,7 +349,7 @@ async def execute_in_context(
     The context (agent_url, session_key) is obtained from the backend.
 
     1. Get tarball into environment (upload bytes OR download from URL).
-    2. Extract it, run ``setup.sh`` (if present), then start *entrypoint*.
+    2. Extract it, run the setup script (if present), then start *entrypoint*.
     3. Return immediately without waiting for the entrypoint to complete.
 
     Args:
@@ -364,6 +365,10 @@ async def execute_in_context(
             path (/tmp/automation-<run_id>.tar.gz) that prevents collisions
             when concurrent runs share the same filesystem (sandboxless mode)
         sandbox_id: Sandbox ID for logging (Cloud mode only)
+        setup_script_path: Path to the setup script inside the extracted
+            tarball (default: ``setup.sh``). The value is validated by the
+            request layer (relative, no traversal, no shell metacharacters)
+            before it is stored on the automation.
 
     Returns:
         DispatchResult with success status
@@ -408,12 +413,13 @@ async def execute_in_context(
             )
             env_prefix = _env_command_prefix(env_path)
 
+        setup_cmd = _shell_quote(setup_script_path or "setup.sh")
         cmd = (
             f"{env_prefix}mkdir -p {work_dir}"
             f" && tar xzf {tarball_path} -C {work_dir}"
             f" && rm -f {tarball_path}"
             f" && cd {work_dir}"
-            f" && ([ ! -f setup.sh ] || bash setup.sh)"
+            f" && ([ ! -f {setup_cmd} ] || bash {setup_cmd})"
             f" && {entrypoint}"
         )
 
@@ -484,6 +490,7 @@ async def run_automation(
     run_id: str | None = None,
     keep_sandbox: bool = False,
     work_dir: str = DEFAULT_WORK_DIR,
+    setup_script_path: str | None = None,
 ) -> AutomationResult:
     """Execute an automation end-to-end in a fresh sandbox (blocking).
 
@@ -492,7 +499,7 @@ async def run_automation(
 
     1. Create sandbox and wait until RUNNING.
     2. Get tarball into sandbox (upload bytes OR download from URL).
-    3. Extract it, run ``setup.sh`` (if present), then run *entrypoint*.
+    3. Extract it, run the setup script (if present), then run *entrypoint*.
     4. Wait for completion and return the result.
     5. Delete the sandbox (unless *keep_sandbox* is True).
 
@@ -500,8 +507,9 @@ async def run_automation(
     (downloaded directly inside sandbox via curl). URLs avoid downloading
     untrusted/large files on the automation service.
 
-    *env_vars* are exported before setup.sh and the entrypoint run,
-    so setup.sh can consume injected values such as ``AUTOMATION_API_URL``.
+    *env_vars* are exported before the setup script and the entrypoint run,
+    so the setup script can consume injected values such as
+    ``AUTOMATION_API_URL``.
     The sandbox identity env vars (``SANDBOX_ID``, ``SESSION_API_KEY``) are
     **always** injected so the SDK's ``local_agent_server_mode`` works.
     If *callback_url* / *run_id* are set they are injected as
@@ -510,6 +518,10 @@ async def run_automation(
 
     *work_dir* is the working directory for tarball extraction
     (default: /workspace/project).
+
+    *setup_script_path* is the path of the setup script inside the extracted
+    tarball (default: ``setup.sh``). Validated by the request layer before it
+    is stored on the automation.
     """
     timeout = resolve_automation_timeout_seconds(timeout)
     http_timeout = get_config().http.http_long_timeout
@@ -574,11 +586,12 @@ async def run_automation(
                 )
                 env_prefix = _env_command_prefix(env_path)
 
+            setup_cmd = _shell_quote(setup_script_path or "setup.sh")
             cmd = (
                 f"{env_prefix}mkdir -p {work_dir}"
                 f" && tar xzf {TARBALL_PATH} -C {work_dir}"
                 f" && cd {work_dir}"
-                f" && ([ ! -f setup.sh ] || bash setup.sh)"
+                f" && ([ ! -f {setup_cmd} ] || bash {setup_cmd})"
                 f" && {entrypoint}"
             )
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -326,6 +326,119 @@ class TestExecuteInContextErrors:
         assert result.sandbox_id == "test-sandbox-id"
 
 
+class TestSetupScriptPath:
+    """The stored ``setup_script_path`` must reach the executed command.
+
+    The field is validated, persisted and echoed back by the API, but the
+    executor historically ran a hardcoded root ``setup.sh`` — a tarball
+    naming anything else silently skipped its setup step (issue #343).
+    """
+
+    @pytest.mark.asyncio
+    @patch("openhands.automation.execution._start_bash", new_callable=AsyncMock)
+    @patch("openhands.automation.execution._upload", new_callable=AsyncMock)
+    async def test_custom_path_is_used_in_command(self, mock_upload, mock_start_bash):
+        """execute_in_context runs the stored setup script path, quoted."""
+        mock_start_bash.return_value = "cmd-1"
+
+        result = await execute_in_context(
+            client=AsyncMock(),
+            agent_url="https://agent.example.com",
+            session_key="session-key",
+            entrypoint="python main.py",
+            tarball_source=b"fake tarball bytes",
+            work_dir=DEFAULT_WORK_DIR,
+            setup_script_path="scripts/setup.sh",
+        )
+
+        assert result.success is True
+        command = mock_start_bash.await_args.args[3]
+        assert "([ ! -f 'scripts/setup.sh' ] || bash 'scripts/setup.sh')" in command
+
+    @pytest.mark.asyncio
+    @patch("openhands.automation.execution._start_bash", new_callable=AsyncMock)
+    @patch("openhands.automation.execution._upload", new_callable=AsyncMock)
+    async def test_default_setup_sh_when_unset(self, mock_upload, mock_start_bash):
+        """Without a stored path the root setup.sh convention is kept."""
+        mock_start_bash.return_value = "cmd-1"
+
+        result = await execute_in_context(
+            client=AsyncMock(),
+            agent_url="https://agent.example.com",
+            session_key="session-key",
+            entrypoint="python main.py",
+            tarball_source=b"fake tarball bytes",
+            work_dir=DEFAULT_WORK_DIR,
+        )
+
+        assert result.success is True
+        command = mock_start_bash.await_args.args[3]
+        assert "([ ! -f 'setup.sh' ] || bash 'setup.sh')" in command
+
+    @pytest.mark.asyncio
+    @patch("openhands.automation.execution._start_bash", new_callable=AsyncMock)
+    @patch("openhands.automation.execution._upload", new_callable=AsyncMock)
+    async def test_path_with_single_quote_is_escaped(
+        self, mock_upload, mock_start_bash
+    ):
+        """A quote in the path (allowed by the validator) stays literal."""
+        mock_start_bash.return_value = "cmd-1"
+
+        result = await execute_in_context(
+            client=AsyncMock(),
+            agent_url="https://agent.example.com",
+            session_key="session-key",
+            entrypoint="python main.py",
+            tarball_source=b"fake tarball bytes",
+            work_dir=DEFAULT_WORK_DIR,
+            setup_script_path="scripts/se'tup.sh",
+        )
+
+        assert result.success is True
+        command = mock_start_bash.await_args.args[3]
+        assert (
+            "([ ! -f 'scripts/se'\\''tup.sh' ] || bash 'scripts/se'\\''tup.sh')"
+            in command
+        )
+
+    @pytest.mark.asyncio
+    @patch("openhands.automation.execution._bash", new_callable=AsyncMock)
+    @patch("openhands.automation.execution._upload", new_callable=AsyncMock)
+    @patch("openhands.automation.execution._create_and_wait", new_callable=AsyncMock)
+    @patch("openhands.automation.execution.httpx.AsyncClient")
+    async def test_blocking_path_uses_custom_setup_script(
+        self,
+        mock_async_client,
+        mock_create_and_wait,
+        mock_upload,
+        mock_bash,
+    ):
+        """run_automation (blocking mode) also honours the stored path."""
+        context_manager = MagicMock()
+        context_manager.__aenter__ = AsyncMock(return_value=AsyncMock())
+        context_manager.__aexit__ = AsyncMock(return_value=None)
+        mock_async_client.return_value = context_manager
+        mock_create_and_wait.return_value = (
+            "sandbox-1",
+            "session-key",
+            "https://agent.example.com",
+        )
+        mock_bash.return_value = (0, "", "")
+
+        result = await run_automation(
+            api_url="https://api.example.com",
+            api_key="api-key",
+            entrypoint="python main.py",
+            tarball_source=b"fake tarball bytes",
+            keep_sandbox=True,
+            setup_script_path="scripts/setup.sh",
+        )
+
+        assert result.success is True
+        command = mock_bash.await_args.args[3]
+        assert "([ ! -f 'scripts/setup.sh' ] || bash 'scripts/setup.sh')" in command
+
+
 class TestPrivateEnvironmentInjection:
     def test_env_file_is_loaded_and_removed(self, tmp_path):
         env_path = tmp_path / "private.env"


### PR DESCRIPTION
## Problem

`setup_script_path` is accepted, validated, persisted and echoed back by the API, but no executor ever reads it. Both execution paths build `... && cd {work_dir} && ([ ! -f setup.sh ] || bash setup.sh) && {entrypoint}` with a hardcoded root `setup.sh` (`execution.py:416`, `execution.py:581`), so a tarball that names its setup script anything else silently skips its setup step and then fails in the entrypoint (typically `ModuleNotFoundError`) with nothing in the logs pointing at the skipped setup. The presets are unaffected only because they hardcode `setup_script_path="setup.sh"`.

Fixes #343 (option "Honour the field" from the issue).

## Triage / Root cause

`grep -rn setup_script_path openhands/` on `main` returns only the request models (`schemas.py`), the router pass-through (`router.py:137`), the ORM model (`models.py:84`), the git-sync serializer and the preset constructions — the two `cmd` builders in `execution.py` never see the stored value, because `execute_in_context` does not receive it (the dispatcher has the `Automation` row in scope at its call site but only passes `entrypoint`).

## Fix

- `execute_in_context` takes a new `setup_script_path: str | None = None` parameter and interpolates it into the setup fragment with the existing `_shell_quote` helper, keeping the `setup.sh` default when unset: `([ ! -f '{path}' ] || bash '{path}')`. The value is already validated at the request layer (relative, no `..` segments, no shell metacharacters), and single-quoting keeps a `'` in a stored path literal.
- `run_automation` (blocking path, used by the e2e scripts) gains the same parameter and interpolation.
- The dispatcher passes `setup_script_path=automation.setup_script_path` at its single production call site.
- Docstrings that promised `setup.sh` now describe the configured setup script.

## Verification

- `uv run pytest tests/ -q --ignore=tests/integration` → **1460 passed** (includes 4 new tests in `tests/test_execution.py::TestSetupScriptPath`: custom path reaches the dispatch command, default `setup.sh` when unset, a single quote in the path stays escaped, and the blocking path honours the stored path).
- Rebased onto `main` @ `3efb91d` (`020_add_automation_disabled_reason` landed after opening): full suite → **1473 passed, 0 failed**; the dispatcher hunk composes cleanly with the new unhealthy-automation logic.
- Rebased onto `main` @ `f1b3244` (release 1.9.0, includes SDK 1.44.0 bump #393; no hunk overlap with dispatcher/execution): targeted suite `tests/test_execution.py` + `tests/test_dispatcher.py` → **85 passed, 0 failed** on SDK 1.44.0; pre-commit (ruff format/lint, pycodestyle, pyright) all pass.
- `uv run pre-commit run --files openhands/automation/execution.py openhands/automation/dispatcher.py tests/test_execution.py` → ruff format/lint, pycodestyle, pyright all passed.

## Notes

- `tests/test_router.py`'s "valid setup_script_path is accepted" case (asserting 201 for `"scripts/setup.sh"`) needed no change: the issue called it out as blessing a value the runner would never execute, and after this fix that value is genuinely executed, so the assertion is now correct end-to-end.
- Open PR #179 (cross-platform preset bootstrap) also threads `setup_script_path` into `execute_in_context` as part of a larger rework. That PR is aimed at a different problem (POSIX-free presets), has changes requested (duplicated bootstrap + Windows `os.execv`), and has been open since June, so I did not treat it as covering this issue — but if it revives, this change will need a small rebase on the same lines.
- Presets keep `setup_script_path="setup.sh"` and are unaffected; git-synced `automation.yaml` values round-trip through the existing serializer and now take effect on the next run.

HUMAN: This PR was prepared with AI assistance (code search, patch, and test execution guided by a human reviewer); the fix follows the approach sketched in issue #343.


