### PR TITLE
fix(presets): pin SDK install to the run venv so UV_PYTHON cannot redirect it

### DIFF
--- a/openhands/automation/presets/plugin/setup.sh
+++ b/openhands/automation/presets/plugin/setup.sh
@@ -40,9 +40,32 @@ echo "[setup] Creating isolated virtual environment"
 uv venv .venv --python '>=3.12' --quiet
 
 echo "[setup] Installing OpenHands SDK from PyPI (version: $SDK_VERSION)"
+# Clear UV_PYTHON so an ambient value (e.g. exported by the agent-server's
+# own uvx/uv launcher) cannot redirect the install away from the .venv we
+# just created in the CWD: `uv pip install` honours UV_PYTHON ahead of the
+# local .venv, silently installing into a different environment while the
+# run venv stays empty (#338).
+unset UV_PYTHON
 uv pip install --quiet \
   "openhands-sdk==${SDK_VERSION}" \
   "openhands-tools==${SDK_VERSION}" \
   "openhands-workspace==${SDK_VERSION}"
+
+# Fail at the setup step when the SDK is not importable from the run venv:
+# a misdirected install would otherwise surface later as a confusing
+# ModuleNotFoundError inside main.py (#338).
+echo "[setup] Verifying SDK is importable from the run venv"
+if [ -x .venv/bin/python ]; then
+    VENV_PYTHON=.venv/bin/python
+elif [ -x .venv/Scripts/python.exe ]; then
+    VENV_PYTHON=.venv/Scripts/python.exe
+else
+    echo "[setup] ERROR: run venv python not found in .venv" >&2
+    exit 1
+fi
+"$VENV_PYTHON" -c 'import openhands.sdk, openhands.tools.preset, openhands.workspace' || {
+    echo "[setup] ERROR: OpenHands SDK not importable in .venv (install misdirected?)" >&2
+    exit 1
+}
 
 echo "[setup] Done"

--- a/openhands/automation/presets/prompt/setup.sh
+++ b/openhands/automation/presets/prompt/setup.sh
@@ -40,9 +40,32 @@ echo "[setup] Creating isolated virtual environment"
 uv venv .venv --python '>=3.12' --quiet
 
 echo "[setup] Installing OpenHands SDK from PyPI (version: $SDK_VERSION)"
+# Clear UV_PYTHON so an ambient value (e.g. exported by the agent-server's
+# own uvx/uv launcher) cannot redirect the install away from the .venv we
+# just created in the CWD: `uv pip install` honours UV_PYTHON ahead of the
+# local .venv, silently installing into a different environment while the
+# run venv stays empty (#338).
+unset UV_PYTHON
 uv pip install --quiet \
   "openhands-sdk==${SDK_VERSION}" \
   "openhands-tools==${SDK_VERSION}" \
   "openhands-workspace==${SDK_VERSION}"
+
+# Fail at the setup step when the SDK is not importable from the run venv:
+# a misdirected install would otherwise surface later as a confusing
+# ModuleNotFoundError inside main.py (#338).
+echo "[setup] Verifying SDK is importable from the run venv"
+if [ -x .venv/bin/python ]; then
+    VENV_PYTHON=.venv/bin/python
+elif [ -x .venv/Scripts/python.exe ]; then
+    VENV_PYTHON=.venv/Scripts/python.exe
+else
+    echo "[setup] ERROR: run venv python not found in .venv" >&2
+    exit 1
+fi
+"$VENV_PYTHON" -c 'import openhands.sdk, openhands.tools.preset, openhands.workspace' || {
+    echo "[setup] ERROR: OpenHands SDK not importable in .venv (install misdirected?)" >&2
+    exit 1
+}
 
 echo "[setup] Done"

--- a/scripts/test_tarball/setup.sh
+++ b/scripts/test_tarball/setup.sh
@@ -32,9 +32,28 @@ echo "[setup] Creating isolated virtual environment"
 uv venv .venv --python '>=3.12' --quiet
 
 echo "[setup] Installing OpenHands SDK from PyPI (version: $SDK_VERSION)"
+# Clear UV_PYTHON so an ambient value (e.g. exported by the agent-server's
+# own uvx/uv launcher) cannot redirect the install away from the .venv we
+# just created in the CWD (#338).
+unset UV_PYTHON
 uv pip install --quiet \
   "openhands-sdk==${SDK_VERSION}" \
   "openhands-tools==${SDK_VERSION}" \
   "openhands-workspace==${SDK_VERSION}"
+
+# Fail at the setup step when the SDK is not importable from the run venv (#338).
+echo "[setup] Verifying SDK is importable from the run venv"
+if [ -x .venv/bin/python ]; then
+    VENV_PYTHON=.venv/bin/python
+elif [ -x .venv/Scripts/python.exe ]; then
+    VENV_PYTHON=.venv/Scripts/python.exe
+else
+    echo "[setup] ERROR: run venv python not found in .venv" >&2
+    exit 1
+fi
+"$VENV_PYTHON" -c 'import openhands.sdk, openhands.tools.preset, openhands.workspace' || {
+    echo "[setup] ERROR: OpenHands SDK not importable in .venv (install misdirected?)" >&2
+    exit 1
+}
 
 echo "[setup] Done"

--- a/tests/test_preset_router.py
+++ b/tests/test_preset_router.py
@@ -163,6 +163,51 @@ class TestPresetFileSyntax:
         )
 
     @pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
+    def test_preset_setup_sh_clears_ambient_uv_python_before_install(self, preset_name):
+        """setup.sh clears UV_PYTHON so the install targets the run venv (#338).
+
+        ``uv pip install`` honours an ambient ``UV_PYTHON`` ahead of the ``.venv``
+        in the CWD, so an inherited value (e.g. from the agent-server's uvx
+        launcher) silently redirects the SDK install into a different
+        environment while setup still reports success.
+        """
+        setup_sh_path = PRESETS_DIR / preset_name / "setup.sh"
+        content = setup_sh_path.read_text()
+
+        assert "unset UV_PYTHON" in content, (
+            "setup.sh must unset UV_PYTHON before `uv pip install` so an ambient "
+            "value cannot redirect the install out of the run venv (#338)"
+        )
+
+    @pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
+    def test_preset_setup_sh_verifies_sdk_import_from_run_venv(self, preset_name):
+        """setup.sh verifies the SDK imports from the run venv before exiting.
+
+        A misdirected install would otherwise surface later as a confusing
+        ``ModuleNotFoundError`` inside ``main.py`` instead of failing at the
+        setup step (#338).
+        """
+        setup_sh_path = PRESETS_DIR / preset_name / "setup.sh"
+        content = setup_sh_path.read_text()
+
+        assert "import openhands.sdk" in content, (
+            "setup.sh must verify the SDK is importable from the run venv "
+            "before handing off to the entrypoint (#338)"
+        )
+
+    @pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
+    def test_preset_setup_sh_handles_windows_venv_layout(self, preset_name):
+        """The run-venv verification covers both POSIX and Windows layouts."""
+        setup_sh_path = PRESETS_DIR / preset_name / "setup.sh"
+        content = setup_sh_path.read_text()
+
+        assert ".venv/bin/python" in content, "POSIX venv python path missing"
+        assert ".venv/Scripts/python.exe" in content, (
+            "Windows venv python path missing — preset entrypoints support "
+            "Windows sandboxes (see _get_preset_entrypoint)"
+        )
+
+    @pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
     def test_preset_finish_tool_uses_task_outcome_schema(self, preset_name):
         """Preset agents attach TaskOutcome structured output to FinishTool."""
         sdk_main_path = PRESETS_DIR / preset_name / "sdk_main.py"

--- a/tests/test_test_tarball_setup.py
+++ b/tests/test_test_tarball_setup.py
@@ -14,6 +14,21 @@ def test_test_tarball_setup_fetches_service_sdk_version():
     assert "openhands-sdk==${SDK_VERSION}" in content
 
 
+def test_test_tarball_setup_clears_ambient_uv_python_and_verifies_import():
+    """Test tarball setup.sh pins the install to the run venv like the
+    presets (#338): unset UV_PYTHON before `uv pip install` and verify the
+    SDK is importable from the run venv before handing off."""
+    content = TEST_TARBALL_SETUP.read_text()
+
+    assert "unset UV_PYTHON" in content, (
+        "setup.sh must unset UV_PYTHON so an ambient value cannot redirect "
+        "the install out of the run venv (#338)"
+    )
+    assert "import openhands.sdk" in content, (
+        "setup.sh must verify the SDK is importable from the run venv (#338)"
+    )
+
+
 def test_test_automation_runner_provides_automation_api_url():
     content = TEST_AUTOMATION_SCRIPT.read_text()
 


### PR DESCRIPTION
## Problem

Preset `setup.sh` creates a per-run venv and then installs the OpenHands SDK with a bare `uv pip install`. `uv` honours an ambient `UV_PYTHON` **ahead of the `.venv` in the CWD**, so when the agent-server's environment carries `UV_PYTHON` (e.g. it was launched via `uvx`/`uv run`), the install is silently redirected into a *different* environment: `setup.sh` prints `[setup] Done` and exits 0, the run venv stays empty, and the entrypoint fails with a confusing traceback that points at `main.py`:

```
ModuleNotFoundError: No module named 'openhands'
```

Reproduced locally with uv 0.11.7: with a 3.12 `.venv` in the CWD and `UV_PYTHON` pointing at a 3.13 environment, `uv pip install six` reports `Using Python 3.13.13 environment at: fake-server-env` — `six` lands in the 3.13 env, `.venv/bin/python -c "import six"` fails. Exactly the mechanism in #338 (which also documents the second-order damage: when the SDK version differs, the run *overwrites the live agent-server's* environment).

Closes #338.

## Triage / Root cause

`openhands/automation/presets/prompt/setup.sh:43` (and the byte-identical `presets/plugin/setup.sh` + `scripts/test_tarball/setup.sh`):

```sh
uv venv .venv --python '>=3.12' --quiet   # explicit flag: UV_PYTHON ignored here
uv pip install --quiet ...                # no flag: ambient UV_PYTHON wins over ./.venv
```

## Fix

- `unset UV_PYTHON` before the `uv pip install` in all three copies of the script, so no ambient value can redirect the install away from the run venv.
- After the install, verify the SDK is importable from the run venv and fail loudly at the setup step (covering both POSIX `.venv/bin/python` and Windows `.venv/Scripts/python.exe` layouts — the entrypoint already supports both via `_get_preset_entrypoint`), so a misdirected install surfaces as `[setup] ERROR: ...` instead of a `ModuleNotFoundError` inside `main.py`.

I used `unset UV_PYTHON` rather than the `--python .venv/bin/python` variant sketched in the issue because hardcoding the POSIX venv path would break Windows sandboxes; with `UV_PYTHON` cleared, `uv pip install` resolves to the `.venv` in the CWD (which `execution.py` guarantees is the run's work dir) portably.

The secondary `--python '>=3.12'` free-threaded-interpreter issue from #338 is **not** addressed here (needs an interpreter-request policy decision) — happy to follow up separately.

## Verification

- Reproduced the redirect (old behavior) and the fix (new fragment installs into `.venv`; the import check fails loudly on an empty venv) — sequence quoted in the issue monitor notes.
- `bash -n` clean on all three copies.
- `uv run pytest tests/ -q --ignore=tests/integration` → **1463 passed**, including 8 new regression tests asserting both preset copies (and the test-tarball copy) clear `UV_PYTHON` and verify the SDK import, and that the verification handles both venv layouts.
- `uv run pre-commit run --files <changed>` → ruff format/lint, pycodestyle, pyright all pass.

## Notes / Risks

- Complementary to (not overlapping) open PR #349, which unsets an inherited `VIRTUAL_ENV` for the same failure class (`uv` also honours `VIRTUAL_ENV`); the two changes compose cleanly. If #349 merges first this applies on top with at most a trivial rebase.
- Pre-existing content tests (`test_*_setup_sh_fetches_sdk_version_from_api`, `test_test_tarball_setup_fetches_service_sdk_version`) pass unchanged.
- Maintainer-authored issue (#338, VascoSch92).

HUMAN: Prepared by Santhi Prakash with AI assistance (code, verification, PR description); reviewed and submitted by Santhi Prakash.
