### PR TITLE
feat: add pinned_at field to Automation for cross-device pin sync

### DIFF
--- a/migrations/versions/022_add_automation_pinned_at.py
+++ b/migrations/versions/022_add_automation_pinned_at.py
@@ -1,0 +1,41 @@
+"""Add pinned_at column to automations.
+
+Revision ID: 022
+Revises: 021
+Create Date: 2026-08-27
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "022"
+down_revision: str = "021"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sqlite() -> bool:
+    return op.get_bind().dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "automations",
+        sa.Column("pinned_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    if _is_sqlite():
+        return
+
+    op.execute(
+        "COMMENT ON COLUMN automations.pinned_at IS "
+        "'Timestamp when the automation was pinned. NULL means unpinned. "
+        "Ordered by recency to determine pin order.'"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("automations", "pinned_at")

--- a/openhands/automation/models.py
+++ b/openhands/automation/models.py
@@ -104,6 +104,11 @@ class Automation(Base):
         DateTime(timezone=True), nullable=True
     )
 
+    # Pinned timestamp (NULL = not pinned; set to UTC now when pinned)
+    pinned_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     # Soft delete timestamp (NULL = not deleted)
     deleted_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True, index=True

--- a/openhands/automation/router.py
+++ b/openhands/automation/router.py
@@ -226,6 +226,10 @@ async def update_automation(
     auto = await _get_user_automation(session, automation_id, user.user_id, user.org_id)
 
     update_data = body.model_dump(exclude_unset=True)
+    # Convert pinned boolean to pinned_at timestamp before writing to the model
+    if "pinned" in update_data:
+        pinned = update_data.pop("pinned")
+        update_data["pinned_at"] = utcnow() if pinned else None
     # Handle trigger field mapping (only if trigger has a real value)
     if body.trigger is not None:
         update_data["trigger"] = body.trigger.model_dump()

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -411,6 +411,7 @@ class UpdateAutomationRequest(BaseModel):
     )
     keep_alive: bool | None = Field(default=None)
     enabled: bool | None = None
+    pinned: bool | None = None
 
     @field_validator("tarball_path")
     @classmethod
@@ -741,6 +742,7 @@ class AutomationResponse(BaseModel):
     disabled_reason: str | None = None
     disabled_detail: dict[str, Any] | None = None
     disabled_at: UtcDatetime | None = None
+    pinned_at: UtcDatetime | None = None
     last_triggered_at: UtcDatetime | None
     created_at: UtcDatetime
     updated_at: UtcDatetime

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1558,6 +1558,112 @@ class TestUpdateAutomation:
 
         assert response.status_code == 422
 
+    async def test_pin_automation(self, async_client, async_session):
+        """PATCH pinned:true sets pinned_at to a UTC timestamp."""
+        automation = Automation(
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            name="Test",
+            trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
+            tarball_path="s3://bucket/code.tar.gz",
+            entrypoint="uv run script.py",
+        )
+        async_session.add(automation)
+        await async_session.commit()
+
+        response = await async_client.patch(
+            f"/api/automation/v1/{automation.id}",
+            json={"pinned": True},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pinned_at"] is not None
+        # Response must be timezone-aware (ends with Z or +00:00)
+        assert data["pinned_at"].endswith("Z") or "+00:00" in data["pinned_at"]
+
+    async def test_unpin_automation(self, async_client, async_session):
+        """PATCH pinned:false clears pinned_at."""
+        from datetime import UTC, datetime
+
+        automation = Automation(
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            name="Test",
+            trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
+            tarball_path="s3://bucket/code.tar.gz",
+            entrypoint="uv run script.py",
+            pinned_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        async_session.add(automation)
+        await async_session.commit()
+
+        response = await async_client.patch(
+            f"/api/automation/v1/{automation.id}",
+            json={"pinned": False},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["pinned_at"] is None
+
+    async def test_pin_automation_does_not_affect_other_fields(
+        self, async_client, async_session
+    ):
+        """PATCH pinned:true leaves all other fields unchanged."""
+        automation = Automation(
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            name="My Automation",
+            trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
+            tarball_path="s3://bucket/code.tar.gz",
+            entrypoint="uv run script.py",
+            enabled=True,
+        )
+        async_session.add(automation)
+        await async_session.commit()
+
+        response = await async_client.patch(
+            f"/api/automation/v1/{automation.id}",
+            json={"pinned": True},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "My Automation"
+        assert data["enabled"] is True
+        assert data["pinned_at"] is not None
+
+    async def test_omitting_pinned_leaves_pinned_at_unchanged(
+        self, async_client, async_session
+    ):
+        """PATCH without pinned field does not touch pinned_at."""
+        from datetime import UTC, datetime
+
+        original_ts = datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)
+        automation = Automation(
+            user_id=TEST_USER_ID,
+            org_id=TEST_ORG_ID,
+            name="Test",
+            trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
+            tarball_path="s3://bucket/code.tar.gz",
+            entrypoint="uv run script.py",
+            pinned_at=original_ts,
+        )
+        async_session.add(automation)
+        await async_session.commit()
+
+        response = await async_client.patch(
+            f"/api/automation/v1/{automation.id}",
+            json={"name": "Renamed"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Renamed"
+        # pinned_at must still reflect the original pin time
+        assert data["pinned_at"] is not None
+        assert "2026-06-15" in data["pinned_at"]
+
 
 class TestDispatchAutomation:
     """Tests for POST /v1/{id}/dispatch endpoint."""


### PR DESCRIPTION
## Summary

Closes #394

Pinned automations are currently stored in browser \`localStorage\`, so pin state is lost when switching devices or browsers. This PR persists pin state in the database via a new nullable \`pinned_at\` column.

- **\`Automation\` model** (\`openhands/automation/models.py\`): adds \`pinned_at: DateTime(timezone=True), nullable=True\`. \`NULL\` = unpinned; a UTC timestamp = pinned (ordering by recency gives pin order).
- **\`AutomationResponse\` schema** (\`openhands/automation/schemas.py\`): exposes \`pinned_at: UtcDatetime | None\` so all list and detail endpoints return the field.
- **\`UpdateAutomationRequest\` schema** (\`openhands/automation/schemas.py\`): adds \`pinned: bool | None\`. The PATCH handler converts \`true\` → current UTC timestamp and \`false\` → \`NULL\` before writing to the model, so callers never deal with timestamps directly.
- **Router** (\`openhands/automation/router.py\`): translates \`pinned\` → \`pinned_at\` in \`update_automation\` before the generic field-copy loop.
- **Migration** (\`migrations/versions/022_add_automation_pinned_at.py\`): Alembic migration that \`ADD COLUMN pinned_at TIMESTAMPTZ NULL\` with \`NULL\` defaults for all existing rows.

## HUMAN: Testing

Ran the service locally against a fresh PostgreSQL instance with migrations applied. Created an automation via \`POST /api/automation/v1\` and confirmed \`pinned_at\` was \`null\`. Sent \`PATCH {"pinned": true}\` and verified the response contained a UTC timestamp; a subsequent GET confirmed it persisted. Sent \`PATCH {"pinned": false}\` and verified \`pinned_at\` returned to \`null\` on both the response and a follow-up GET.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)