### PR TITLE
fix: scope automation management to the org instead of the owner

### DIFF
--- a/openhands/automation/preset_router.py
+++ b/openhands/automation/preset_router.py
@@ -464,7 +464,7 @@ async def create_automation_from_prompt(
     # the existing automation unchanged instead of creating a duplicate.
     if body.template is not None:
         existing = await find_existing_template_automation(
-            session, user.user_id, user.org_id, body.template.id
+            session, user.org_id, body.template.id
         )
         if existing is not None:
             response.status_code = status.HTTP_200_OK
@@ -871,7 +871,7 @@ async def create_automation_from_plugin(
     # the existing automation unchanged instead of creating a duplicate.
     if body.template is not None:
         existing = await find_existing_template_automation(
-            session, user.user_id, user.org_id, body.template.id
+            session, user.org_id, body.template.id
         )
         if existing is not None:
             response.status_code = status.HTTP_200_OK

--- a/openhands/automation/router.py
+++ b/openhands/automation/router.py
@@ -114,7 +114,7 @@ async def create_automation(
     # query and leaves the new upload unreferenced rather than adopting it.
     if body.template is not None:
         existing = await find_existing_template_automation(
-            session, user.user_id, user.org_id, body.template.id
+            session, user.org_id, body.template.id
         )
         if existing is not None:
             response.status_code = status.HTTP_200_OK
@@ -174,9 +174,8 @@ async def list_automations(
     user: AuthenticatedUser = Depends(_require_manage_automations),
     session: AsyncSession = Depends(get_session),
 ) -> AutomationListResponse:
-    """List automations for the authenticated user (excludes soft-deleted)."""
+    """List automations for the caller's org (excludes soft-deleted)."""
     base_query = select(Automation).where(
-        Automation.user_id == user.user_id,
         Automation.org_id == user.org_id,
         Automation.deleted_at.is_(None),
     )
@@ -204,7 +203,7 @@ async def get_automation(
     session: AsyncSession = Depends(get_session),
 ) -> AutomationResponse:
     """Get a single automation by ID."""
-    auto = await _get_user_automation(session, automation_id, user.user_id, user.org_id)
+    auto = await _get_org_automation(session, automation_id, user.org_id)
     return AutomationResponse.model_validate(auto)
 
 
@@ -223,7 +222,7 @@ async def update_automation(
     session: AsyncSession = Depends(get_session, scope="function"),
 ) -> AutomationResponse:
     """Partially update an automation."""
-    auto = await _get_user_automation(session, automation_id, user.user_id, user.org_id)
+    auto = await _get_org_automation(session, automation_id, user.org_id)
 
     update_data = body.model_dump(exclude_unset=True)
     # Handle trigger field mapping (only if trigger has a real value)
@@ -311,7 +310,7 @@ async def delete_automation(
     session: AsyncSession = Depends(get_session),
 ) -> None:
     """Soft delete an automation."""
-    auto = await _get_user_automation(session, automation_id, user.user_id, user.org_id)
+    auto = await _get_org_automation(session, automation_id, user.org_id)
     was_enabled = auto.enabled
     auto.enabled = False
     deleted_at = utcnow()
@@ -361,7 +360,7 @@ async def download_automation_tarball(
     - s3:// or gs:// URLs: returns 422 (cannot proxy cloud storage URLs).
     - 404 if the automation has no accessible tarball.
     """
-    auto = await _get_user_automation(session, automation_id, user.user_id, user.org_id)
+    auto = await _get_org_automation(session, automation_id, user.org_id)
 
     upload_id = parse_internal_upload_id(auto.tarball_path)
     if upload_id is not None:
@@ -428,7 +427,7 @@ async def dispatch_automation(
     Creates a PENDING run for the specified automation, which will be
     picked up by the dispatcher and executed.
     """
-    auto = await _get_user_automation(session, automation_id, user.user_id, user.org_id)
+    auto = await _get_org_automation(session, automation_id, user.org_id)
     if not auto.enabled:
         raise HTTPException(
             status.HTTP_409_CONFLICT,
@@ -471,8 +470,8 @@ async def list_automation_runs(
 
     Returns runs ordered by creation time (latest first), with pagination.
     """
-    # Verify the automation exists and belongs to the user
-    await _get_user_automation(session, automation_id, user.user_id, user.org_id)
+    # Verify the automation exists and belongs to the caller's org
+    await _get_org_automation(session, automation_id, user.org_id)
 
     # Count lifetime runs by status for this automation
     count_result = await session.execute(
@@ -766,7 +765,7 @@ async def cancel_run(
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Run not found")
 
     automation = run.automation
-    if automation.user_id != user.user_id or automation.org_id != user.org_id:
+    if automation.org_id != user.org_id:
         raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Not your automation")
 
     # Only PENDING and RUNNING runs can be cancelled
@@ -847,17 +846,15 @@ async def cancel_run(
 # --- Helpers ---
 
 
-async def _get_user_automation(
+async def _get_org_automation(
     session: AsyncSession,
     automation_id: uuid.UUID,
-    user_id: uuid.UUID,
     org_id: uuid.UUID,
 ) -> Automation:
-    """Fetch a non-deleted automation, ensuring it belongs to the given user and org."""
+    """Fetch a non-deleted automation in the caller's org."""
     result = await session.execute(
         select(Automation).where(
             Automation.id == automation_id,
-            Automation.user_id == user_id,
             Automation.org_id == org_id,
             Automation.deleted_at.is_(None),
         )

--- a/openhands/automation/utils/templates.py
+++ b/openhands/automation/utils/templates.py
@@ -21,8 +21,8 @@ TEMPLATE_EXISTS_RESPONSE: dict[int | str, dict[str, Any]] = {
     200: {
         "model": AutomationResponse,
         "description": (
-            "An automation created from this template already exists for this "
-            "user; it is returned unchanged."
+            "An automation created from this template already exists in this "
+            "organization; it is returned unchanged."
         ),
     },
 }
@@ -30,11 +30,10 @@ TEMPLATE_EXISTS_RESPONSE: dict[int | str, dict[str, Any]] = {
 
 async def find_existing_template_automation(
     session: AsyncSession,
-    user_id: uuid.UUID,
     org_id: uuid.UUID,
     template_id: str,
 ) -> Automation | None:
-    """Find the caller's live automation created from the given template.
+    """Find the org's live automation created from the given template.
 
     JSON extraction mirrors ``get_event_automations``: ``json_extract`` on
     SQLite, ``->``/``->>`` on PostgreSQL. Rows without provenance yield NULL and
@@ -56,7 +55,6 @@ async def find_existing_template_automation(
     result = await session.execute(
         select(Automation)
         .where(
-            Automation.user_id == user_id,
             Automation.org_id == org_id,
             Automation.deleted_at.is_(None),
             template_filter,

--- a/tests/test_cancel_run.py
+++ b/tests/test_cancel_run.py
@@ -106,8 +106,8 @@ async def test_cancel_nonexistent_run_returns_404(async_client, async_session):
     assert resp.status_code == 404
 
 
-async def test_cancel_other_users_run_returns_403(async_client, async_session):
-    """Cancelling another user's run should return 403."""
+async def test_cancel_other_orgs_run_returns_403(async_client, async_session):
+    """Cancelling a run from another org should return 403."""
     automation = Automation(
         user_id=OTHER_USER_ID,
         org_id=OTHER_ORG_ID,
@@ -129,3 +129,30 @@ async def test_cancel_other_users_run_returns_403(async_client, async_session):
 
     resp = await async_client.post(f"/api/automation/v1/runs/{run.id}/cancel")
     assert resp.status_code == 403
+
+
+async def test_cancel_same_org_other_users_run(async_client, async_session):
+    """Cancelling a run owned by another member of the same org should succeed."""
+    automation = Automation(
+        user_id=OTHER_USER_ID,
+        org_id=TEST_ORG_ID,
+        name="Teammate Automation",
+        trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
+        tarball_path="https://example.com/code.tar.gz",
+        entrypoint="python main.py",
+    )
+    async_session.add(automation)
+    await async_session.flush()
+
+    run = AutomationRun(
+        id=uuid.uuid4(),
+        automation_id=automation.id,
+        status=AutomationRunStatus.RUNNING,
+        started_at=utcnow(),
+    )
+    async_session.add(run)
+    await async_session.flush()
+
+    resp = await async_client.post(f"/api/automation/v1/runs/{run.id}/cancel")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "CANCELLED"

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -739,6 +739,28 @@ class TestListAutomations:
         assert data["total"] == 1
         assert data["automations"][0]["name"] == "Test Automation"
 
+    async def test_list_automations_includes_other_org_members(
+        self, async_client, async_session
+    ):
+        """Automations owned by another member of the caller's org are listed."""
+        automation = Automation(
+            user_id=OTHER_USER_ID,
+            org_id=TEST_ORG_ID,
+            name="Teammate Automation",
+            trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
+            tarball_path="s3://bucket/path/to/code.tar.gz",
+            entrypoint="uv run script.py",
+        )
+        async_session.add(automation)
+        await async_session.commit()
+
+        response = await async_client.get("/api/automation/v1")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["automations"][0]["name"] == "Teammate Automation"
+
     async def test_list_automations_excludes_deleted(self, async_client, async_session):
         """Soft-deleted automations are not returned."""
         # Create a deleted automation
@@ -917,6 +939,29 @@ class TestGetAutomation:
 
 class TestDeleteAutomation:
     """Tests for DELETE /v1/{id} endpoint."""
+
+    async def test_delete_other_org_members_automation(
+        self, async_client, async_session
+    ):
+        """A member can delete an automation owned by another member of their org."""
+        automation = Automation(
+            user_id=OTHER_USER_ID,
+            org_id=TEST_ORG_ID,
+            name="Teammate Automation",
+            trigger={"type": "cron", "schedule": "0 9 * * *", "timezone": "UTC"},
+            tarball_path="s3://bucket/path/to/code.tar.gz",
+            entrypoint="uv run script.py",
+            enabled=True,
+        )
+        async_session.add(automation)
+        await async_session.commit()
+
+        response = await async_client.delete(f"/api/automation/v1/{automation.id}")
+
+        assert response.status_code == 204
+        await async_session.refresh(automation)
+        assert automation.enabled is False
+        assert automation.deleted_at is not None
 
     async def test_delete_automation_soft_deletes(self, async_client, async_session):
         """DELETE sets enabled=False and deleted_at."""


### PR DESCRIPTION
Fixes the scoping half of #396.

## Problem

Management endpoints filtered on `user_id` **AND** `org_id`, while event matching filtered on `org_id` alone and the scheduler on neither. An automation created by one account therefore fired for its whole org — acting on the org's repos under the org's bot identity — while being invisible and unmanageable to every other member of that org: it was absent from `GET /automations`, `DELETE` returned 404, and cancel returned 403. With no org-wide listing endpoint, it read as "already deleted" while still running.

This is easy to hit with a shared or service account that owns an org's automations, and the only remedies were authenticating as that exact account or writing to the database.

## Change

`list`, `get`, `patch`, `delete`, `tarball`, `dispatch`, `runs` and `cancel_run` now resolve by `org_id`. `_get_user_automation` becomes `_get_org_automation`; the `user_id` predicate is dropped from the list query and from the `cancel_run` ownership check.

Authorization is unchanged: every one of these routes already depends on `require_permission("manage_automations")`, which is org-scoped, so dropping the owner predicate does not leave them ungated. `user_id` is still recorded on create — it just no longer governs access.

Template dedupe (`find_existing_template_automation`) is org-scoped to match, so enabling a template twice in one org returns the existing automation rather than creating a per-member duplicate.

`complete_run` and `report_run_phase` are callbacks from inside the sandbox rather than user actions, so they keep the owner check.

No schema change and no migration — `org_id` is already present and indexed.

## Tests

- `test_list_automations_includes_other_org_members` — a teammate's automation is listed
- `test_delete_other_org_members_automation` — a member can delete a teammate's automation
- `test_cancel_same_org_other_users_run` — a member can cancel a teammate's run
- `test_cancel_other_users_run_returns_403` renamed to `test_cancel_other_orgs_run_returns_403`; it was always cross-org, and cross-org rejection is unchanged

Full unit suite passes (1483). Pre-commit clean: ruff format, ruff lint, pycodestyle, pyright.

## Deliberately not included

The `last_triggered_at` observability problem also described in #396 — the event path never writes it, so event-triggered automations report `NULL` forever and any query ranking by it to find active automations silently misses them. That is a separate concern; keeping this PR to the access-control change.

## Follow-up worth considering

The list response has no owner field, so the UI will now show automations without indicating who created them. A small `agent-canvas` change to surface the owner would help.
