### PR TITLE
fix: require preset automations to use finish tool

### DIFF
--- a/openhands/automation/preset_router.py
+++ b/openhands/automation/preset_router.py
@@ -73,6 +73,7 @@ router = APIRouter(prefix="/v1/preset", tags=["Presets"])
 
 # Preset files directories
 PRESETS_DIR = Path(__file__).parent / "presets"
+SHARED_FINISH_TOOL_HOOK = PRESETS_DIR / "finish_tool_hook.py"
 PROMPT_PRESET_DIR = PRESETS_DIR / "prompt"
 PLUGIN_PRESET_DIR = PRESETS_DIR / "plugin"
 
@@ -103,6 +104,7 @@ def _load_prompt_preset_files() -> dict[str, str]:
         _PROMPT_PRESET_CACHE = {
             "main.py": (PROMPT_PRESET_DIR / "sdk_main.py").read_text(),
             "setup.sh": (PROMPT_PRESET_DIR / "setup.sh").read_text(),
+            "finish_tool_hook.py": SHARED_FINISH_TOOL_HOOK.read_text(),
         }
     return _PROMPT_PRESET_CACHE
 
@@ -117,6 +119,7 @@ def _load_plugin_preset_files() -> dict[str, str]:
         _PLUGIN_PRESET_CACHE = {
             "main.py": (PLUGIN_PRESET_DIR / "sdk_main.py").read_text(),
             "setup.sh": (PLUGIN_PRESET_DIR / "setup.sh").read_text(),
+            "finish_tool_hook.py": SHARED_FINISH_TOOL_HOOK.read_text(),
         }
     return _PLUGIN_PRESET_CACHE
 
@@ -247,6 +250,9 @@ def _generate_tarball(prompt: str, repos: list[RepoSource] | None = None) -> byt
 
     with tarfile.open(fileobj=tarball_buffer, mode="w:gz") as tar:
         _add_file_to_tar(tar, "main.py", preset_files["main.py"])
+        _add_file_to_tar(
+            tar, "finish_tool_hook.py", preset_files["finish_tool_hook.py"]
+        )
         _add_file_to_tar(tar, "prompt.txt", prompt)
         _add_file_to_tar(tar, "setup.sh", preset_files["setup.sh"], mode=0o755)
 
@@ -792,6 +798,9 @@ def _generate_plugin_tarball(
 
     with tarfile.open(fileobj=tarball_buffer, mode="w:gz") as tar:
         _add_file_to_tar(tar, "main.py", preset_files["main.py"])
+        _add_file_to_tar(
+            tar, "finish_tool_hook.py", preset_files["finish_tool_hook.py"]
+        )
         _add_file_to_tar(tar, "prompt.txt", prompt)
         _add_file_to_tar(tar, "setup.sh", preset_files["setup.sh"], mode=0o755)
 

--- a/openhands/automation/presets/finish_tool_hook.py
+++ b/openhands/automation/presets/finish_tool_hook.py
@@ -1,0 +1,108 @@
+"""Shared hook config for automation preset conversations."""
+
+import os
+import shlex
+import sys
+
+from openhands.sdk.hooks import HookConfig, HookDefinition, HookMatcher
+
+
+FINISH_TOOL_REQUIRED_MESSAGE = (
+    "The task appears complete, but automation runs must end by calling the "
+    "finish tool. Please call the finish tool now with the final task outcome."
+)
+
+
+def _finish_tool_marker_path(script_dir: str) -> str:
+    run_id = os.environ.get("AUTOMATION_RUN_ID") or "current"
+    safe_run_id = "".join(ch if ch.isalnum() or ch in "-_" else "_" for ch in run_id)
+    return os.path.join(
+        os.path.abspath(script_dir),
+        ".openhands_automation_runtime",
+        safe_run_id,
+        "finish_tool_used",
+    )
+
+
+def _python_hook_command(code: str) -> str:
+    return f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
+
+
+def finish_tool_required_hook_config(script_dir: str) -> HookConfig:
+    marker_path = _finish_tool_marker_path(script_dir)
+    runtime_dir = os.path.dirname(marker_path)
+    deny_payload = {
+        "decision": "deny",
+        "reason": "finish tool was not used",
+        "additionalContext": FINISH_TOOL_REQUIRED_MESSAGE,
+    }
+
+    return HookConfig(
+        session_start=[
+            HookMatcher(
+                hooks=[
+                    HookDefinition(
+                        name="reset-finish-tool-marker",
+                        command=_python_hook_command(
+                            "from pathlib import Path\n"
+                            f"path = Path({marker_path!r})\n"
+                            "path.parent.mkdir(parents=True, exist_ok=True)\n"
+                            "path.unlink(missing_ok=True)\n"
+                        ),
+                        timeout=5,
+                    )
+                ],
+            )
+        ],
+        post_tool_use=[
+            HookMatcher(
+                matcher="/(?:finish|FinishTool)/",
+                hooks=[
+                    HookDefinition(
+                        name="mark-finish-tool-used",
+                        command=_python_hook_command(
+                            "from pathlib import Path\n"
+                            f"path = Path({marker_path!r})\n"
+                            "path.parent.mkdir(parents=True, exist_ok=True)\n"
+                            "path.write_text('finish\\n')\n"
+                        ),
+                        timeout=5,
+                    )
+                ],
+            )
+        ],
+        stop=[
+            HookMatcher(
+                hooks=[
+                    HookDefinition(
+                        name="require-finish-tool",
+                        command=_python_hook_command(
+                            "import json\n"
+                            "import sys\n"
+                            "from pathlib import Path\n"
+                            f"if Path({marker_path!r}).is_file():\n"
+                            "    sys.exit(0)\n"
+                            f"print(json.dumps({deny_payload!r}))\n"
+                            "sys.exit(2)\n"
+                        ),
+                        timeout=5,
+                    )
+                ],
+            )
+        ],
+        session_end=[
+            HookMatcher(
+                hooks=[
+                    HookDefinition(
+                        name="cleanup-finish-tool-marker",
+                        command=_python_hook_command(
+                            "import shutil\n"
+                            "from pathlib import Path\n"
+                            f"shutil.rmtree(Path({runtime_dir!r}), ignore_errors=True)\n"
+                        ),
+                        timeout=5,
+                    )
+                ],
+            )
+        ],
+    )

--- a/openhands/automation/presets/plugin/sdk_main.py
+++ b/openhands/automation/presets/plugin/sdk_main.py
@@ -68,6 +68,7 @@ import inspect
 import json
 import os
 import random
+import shlex
 import sys
 import threading
 import time
@@ -184,6 +185,7 @@ def _phase_poster() -> None:
 
 # SDK imports (before workspace context so import errors are caught)
 from openhands.sdk import Conversation, RemoteConversation
+from openhands.sdk.hooks import HookConfig, HookDefinition, HookMatcher
 from openhands.tools.preset import TaskOutcome
 
 try:
@@ -213,6 +215,84 @@ def _normalize_mcp_config(raw_mcp_config):
     ):
         return raw_mcp_config["mcpServers"]
     return raw_mcp_config
+
+
+FINISH_TOOL_REQUIRED_MESSAGE = (
+    "The task appears complete, but automation runs must end by calling the "
+    "finish tool. Please call the finish tool now with the final task outcome."
+)
+
+
+def _finish_tool_marker_name() -> str:
+    run_id = os.environ.get("AUTOMATION_RUN_ID") or "current"
+    safe_run_id = "".join(
+        ch if ch.isalnum() or ch in "-_" else "_" for ch in run_id
+    )
+    return f".openhands_automation_finish_tool_used_{safe_run_id}"
+
+
+def _python_hook_command(code: str) -> str:
+    return f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
+
+
+def _finish_tool_required_hook_config() -> HookConfig:
+    marker_name = _finish_tool_marker_name()
+    deny_payload = {
+        "decision": "deny",
+        "reason": "finish tool was not used",
+        "additionalContext": FINISH_TOOL_REQUIRED_MESSAGE,
+    }
+
+    return HookConfig(
+        session_start=[
+            HookMatcher(
+                hooks=[
+                    HookDefinition(
+                        name="reset-finish-tool-marker",
+                        command=_python_hook_command(
+                            "from pathlib import Path\n"
+                            f"Path({marker_name!r}).unlink(missing_ok=True)\n"
+                        ),
+                        timeout=5,
+                    )
+                ],
+            )
+        ],
+        post_tool_use=[
+            HookMatcher(
+                matcher="/(?:finish|FinishTool)/",
+                hooks=[
+                    HookDefinition(
+                        name="mark-finish-tool-used",
+                        command=_python_hook_command(
+                            "from pathlib import Path\n"
+                            f"Path({marker_name!r}).write_text('finish\\n')\n"
+                        ),
+                        timeout=5,
+                    )
+                ],
+            )
+        ],
+        stop=[
+            HookMatcher(
+                hooks=[
+                    HookDefinition(
+                        name="require-finish-tool",
+                        command=_python_hook_command(
+                            "import json\n"
+                            "import sys\n"
+                            "from pathlib import Path\n"
+                            f"if Path({marker_name!r}).is_file():\n"
+                            "    sys.exit(0)\n"
+                            f"print(json.dumps({deny_payload!r}))\n"
+                            "sys.exit(2)\n"
+                        ),
+                        timeout=5,
+                    )
+                ],
+            )
+        ],
+    )
 
 
 def _build_conversation_title(event_context) -> str | None:
@@ -527,6 +607,7 @@ This automation was triggered by a webhook event:
         "workspace": workspace,
         "plugins": plugin_sources,  # All plugins loaded here
         "callbacks": [event_callback],
+        "hook_config": _finish_tool_required_hook_config(),
         "delete_on_close": False,  # Keep conversation history after completion
         "tags": conversation_tags,
     }

--- a/openhands/automation/presets/plugin/sdk_main.py
+++ b/openhands/automation/presets/plugin/sdk_main.py
@@ -223,20 +223,26 @@ FINISH_TOOL_REQUIRED_MESSAGE = (
 )
 
 
-def _finish_tool_marker_name() -> str:
+def _finish_tool_marker_path(script_dir: str) -> str:
     run_id = os.environ.get("AUTOMATION_RUN_ID") or "current"
     safe_run_id = "".join(
         ch if ch.isalnum() or ch in "-_" else "_" for ch in run_id
     )
-    return f".openhands_automation_finish_tool_used_{safe_run_id}"
+    return os.path.join(
+        os.path.abspath(script_dir),
+        ".openhands_automation_runtime",
+        safe_run_id,
+        "finish_tool_used",
+    )
 
 
 def _python_hook_command(code: str) -> str:
     return f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
 
 
-def _finish_tool_required_hook_config() -> HookConfig:
-    marker_name = _finish_tool_marker_name()
+def _finish_tool_required_hook_config(script_dir: str) -> HookConfig:
+    marker_path = _finish_tool_marker_path(script_dir)
+    runtime_dir = os.path.dirname(marker_path)
     deny_payload = {
         "decision": "deny",
         "reason": "finish tool was not used",
@@ -251,7 +257,9 @@ def _finish_tool_required_hook_config() -> HookConfig:
                         name="reset-finish-tool-marker",
                         command=_python_hook_command(
                             "from pathlib import Path\n"
-                            f"Path({marker_name!r}).unlink(missing_ok=True)\n"
+                            f"path = Path({marker_path!r})\n"
+                            "path.parent.mkdir(parents=True, exist_ok=True)\n"
+                            "path.unlink(missing_ok=True)\n"
                         ),
                         timeout=5,
                     )
@@ -266,7 +274,9 @@ def _finish_tool_required_hook_config() -> HookConfig:
                         name="mark-finish-tool-used",
                         command=_python_hook_command(
                             "from pathlib import Path\n"
-                            f"Path({marker_name!r}).write_text('finish\\n')\n"
+                            f"path = Path({marker_path!r})\n"
+                            "path.parent.mkdir(parents=True, exist_ok=True)\n"
+                            "path.write_text('finish\\n')\n"
                         ),
                         timeout=5,
                     )
@@ -282,10 +292,25 @@ def _finish_tool_required_hook_config() -> HookConfig:
                             "import json\n"
                             "import sys\n"
                             "from pathlib import Path\n"
-                            f"if Path({marker_name!r}).is_file():\n"
+                            f"if Path({marker_path!r}).is_file():\n"
                             "    sys.exit(0)\n"
                             f"print(json.dumps({deny_payload!r}))\n"
                             "sys.exit(2)\n"
+                        ),
+                        timeout=5,
+                    )
+                ],
+            )
+        ],
+        session_end=[
+            HookMatcher(
+                hooks=[
+                    HookDefinition(
+                        name="cleanup-finish-tool-marker",
+                        command=_python_hook_command(
+                            "import shutil\n"
+                            "from pathlib import Path\n"
+                            f"shutil.rmtree(Path({runtime_dir!r}), ignore_errors=True)\n"
                         ),
                         timeout=5,
                     )
@@ -607,7 +632,7 @@ This automation was triggered by a webhook event:
         "workspace": workspace,
         "plugins": plugin_sources,  # All plugins loaded here
         "callbacks": [event_callback],
-        "hook_config": _finish_tool_required_hook_config(),
+        "hook_config": _finish_tool_required_hook_config(SCRIPT_DIR),
         "delete_on_close": False,  # Keep conversation history after completion
         "tags": conversation_tags,
     }

--- a/openhands/automation/presets/plugin/sdk_main.py
+++ b/openhands/automation/presets/plugin/sdk_main.py
@@ -68,7 +68,6 @@ import inspect
 import json
 import os
 import random
-import shlex
 import sys
 import threading
 import time
@@ -185,7 +184,7 @@ def _phase_poster() -> None:
 
 # SDK imports (before workspace context so import errors are caught)
 from openhands.sdk import Conversation, RemoteConversation
-from openhands.sdk.hooks import HookConfig, HookDefinition, HookMatcher
+from finish_tool_hook import finish_tool_required_hook_config
 from openhands.tools.preset import TaskOutcome
 
 try:
@@ -216,108 +215,6 @@ def _normalize_mcp_config(raw_mcp_config):
         return raw_mcp_config["mcpServers"]
     return raw_mcp_config
 
-
-FINISH_TOOL_REQUIRED_MESSAGE = (
-    "The task appears complete, but automation runs must end by calling the "
-    "finish tool. Please call the finish tool now with the final task outcome."
-)
-
-
-def _finish_tool_marker_path(script_dir: str) -> str:
-    run_id = os.environ.get("AUTOMATION_RUN_ID") or "current"
-    safe_run_id = "".join(
-        ch if ch.isalnum() or ch in "-_" else "_" for ch in run_id
-    )
-    return os.path.join(
-        os.path.abspath(script_dir),
-        ".openhands_automation_runtime",
-        safe_run_id,
-        "finish_tool_used",
-    )
-
-
-def _python_hook_command(code: str) -> str:
-    return f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
-
-
-def _finish_tool_required_hook_config(script_dir: str) -> HookConfig:
-    marker_path = _finish_tool_marker_path(script_dir)
-    runtime_dir = os.path.dirname(marker_path)
-    deny_payload = {
-        "decision": "deny",
-        "reason": "finish tool was not used",
-        "additionalContext": FINISH_TOOL_REQUIRED_MESSAGE,
-    }
-
-    return HookConfig(
-        session_start=[
-            HookMatcher(
-                hooks=[
-                    HookDefinition(
-                        name="reset-finish-tool-marker",
-                        command=_python_hook_command(
-                            "from pathlib import Path\n"
-                            f"path = Path({marker_path!r})\n"
-                            "path.parent.mkdir(parents=True, exist_ok=True)\n"
-                            "path.unlink(missing_ok=True)\n"
-                        ),
-                        timeout=5,
-                    )
-                ],
-            )
-        ],
-        post_tool_use=[
-            HookMatcher(
-                matcher="/(?:finish|FinishTool)/",
-                hooks=[
-                    HookDefinition(
-                        name="mark-finish-tool-used",
-                        command=_python_hook_command(
-                            "from pathlib import Path\n"
-                            f"path = Path({marker_path!r})\n"
-                            "path.parent.mkdir(parents=True, exist_ok=True)\n"
-                            "path.write_text('finish\\n')\n"
-                        ),
-                        timeout=5,
-                    )
-                ],
-            )
-        ],
-        stop=[
-            HookMatcher(
-                hooks=[
-                    HookDefinition(
-                        name="require-finish-tool",
-                        command=_python_hook_command(
-                            "import json\n"
-                            "import sys\n"
-                            "from pathlib import Path\n"
-                            f"if Path({marker_path!r}).is_file():\n"
-                            "    sys.exit(0)\n"
-                            f"print(json.dumps({deny_payload!r}))\n"
-                            "sys.exit(2)\n"
-                        ),
-                        timeout=5,
-                    )
-                ],
-            )
-        ],
-        session_end=[
-            HookMatcher(
-                hooks=[
-                    HookDefinition(
-                        name="cleanup-finish-tool-marker",
-                        command=_python_hook_command(
-                            "import shutil\n"
-                            "from pathlib import Path\n"
-                            f"shutil.rmtree(Path({runtime_dir!r}), ignore_errors=True)\n"
-                        ),
-                        timeout=5,
-                    )
-                ],
-            )
-        ],
-    )
 
 
 def _build_conversation_title(event_context) -> str | None:
@@ -632,7 +529,7 @@ This automation was triggered by a webhook event:
         "workspace": workspace,
         "plugins": plugin_sources,  # All plugins loaded here
         "callbacks": [event_callback],
-        "hook_config": _finish_tool_required_hook_config(SCRIPT_DIR),
+        "hook_config": finish_tool_required_hook_config(SCRIPT_DIR),
         "delete_on_close": False,  # Keep conversation history after completion
         "tags": conversation_tags,
     }

--- a/openhands/automation/presets/prompt/sdk_main.py
+++ b/openhands/automation/presets/prompt/sdk_main.py
@@ -71,6 +71,7 @@ Runtime-injected secrets (via conversation.update_secrets after Conversation cre
 import inspect
 import json
 import os
+import shlex
 import sys
 import threading
 import time
@@ -188,6 +189,7 @@ def _phase_poster() -> None:
 
 # SDK imports (before workspace context so import errors are caught)
 from openhands.sdk import Conversation, RemoteConversation
+from openhands.sdk.hooks import HookConfig, HookDefinition, HookMatcher
 from openhands.tools.preset import TaskOutcome
 
 try:
@@ -216,6 +218,84 @@ def _normalize_mcp_config(raw_mcp_config):
     ):
         return raw_mcp_config["mcpServers"]
     return raw_mcp_config
+
+
+FINISH_TOOL_REQUIRED_MESSAGE = (
+    "The task appears complete, but automation runs must end by calling the "
+    "finish tool. Please call the finish tool now with the final task outcome."
+)
+
+
+def _finish_tool_marker_name() -> str:
+    run_id = os.environ.get("AUTOMATION_RUN_ID") or "current"
+    safe_run_id = "".join(
+        ch if ch.isalnum() or ch in "-_" else "_" for ch in run_id
+    )
+    return f".openhands_automation_finish_tool_used_{safe_run_id}"
+
+
+def _python_hook_command(code: str) -> str:
+    return f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
+
+
+def _finish_tool_required_hook_config() -> HookConfig:
+    marker_name = _finish_tool_marker_name()
+    deny_payload = {
+        "decision": "deny",
+        "reason": "finish tool was not used",
+        "additionalContext": FINISH_TOOL_REQUIRED_MESSAGE,
+    }
+
+    return HookConfig(
+        session_start=[
+            HookMatcher(
+                hooks=[
+                    HookDefinition(
+                        name="reset-finish-tool-marker",
+                        command=_python_hook_command(
+                            "from pathlib import Path\n"
+                            f"Path({marker_name!r}).unlink(missing_ok=True)\n"
+                        ),
+                        timeout=5,
+                    )
+                ],
+            )
+        ],
+        post_tool_use=[
+            HookMatcher(
+                matcher="/(?:finish|FinishTool)/",
+                hooks=[
+                    HookDefinition(
+                        name="mark-finish-tool-used",
+                        command=_python_hook_command(
+                            "from pathlib import Path\n"
+                            f"Path({marker_name!r}).write_text('finish\\n')\n"
+                        ),
+                        timeout=5,
+                    )
+                ],
+            )
+        ],
+        stop=[
+            HookMatcher(
+                hooks=[
+                    HookDefinition(
+                        name="require-finish-tool",
+                        command=_python_hook_command(
+                            "import json\n"
+                            "import sys\n"
+                            "from pathlib import Path\n"
+                            f"if Path({marker_name!r}).is_file():\n"
+                            "    sys.exit(0)\n"
+                            f"print(json.dumps({deny_payload!r}))\n"
+                            "sys.exit(2)\n"
+                        ),
+                        timeout=5,
+                    )
+                ],
+            )
+        ],
+    )
 
 
 def _build_conversation_title(event_context) -> str | None:
@@ -480,6 +560,7 @@ This automation was triggered by a webhook event:
         "agent": agent,
         "workspace": workspace,
         "callbacks": [event_callback],
+        "hook_config": _finish_tool_required_hook_config(),
         "delete_on_close": False,  # Keep conversation history after completion
         "tags": conversation_tags or None,
     }

--- a/openhands/automation/presets/prompt/sdk_main.py
+++ b/openhands/automation/presets/prompt/sdk_main.py
@@ -226,20 +226,26 @@ FINISH_TOOL_REQUIRED_MESSAGE = (
 )
 
 
-def _finish_tool_marker_name() -> str:
+def _finish_tool_marker_path(script_dir: str) -> str:
     run_id = os.environ.get("AUTOMATION_RUN_ID") or "current"
     safe_run_id = "".join(
         ch if ch.isalnum() or ch in "-_" else "_" for ch in run_id
     )
-    return f".openhands_automation_finish_tool_used_{safe_run_id}"
+    return os.path.join(
+        os.path.abspath(script_dir),
+        ".openhands_automation_runtime",
+        safe_run_id,
+        "finish_tool_used",
+    )
 
 
 def _python_hook_command(code: str) -> str:
     return f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
 
 
-def _finish_tool_required_hook_config() -> HookConfig:
-    marker_name = _finish_tool_marker_name()
+def _finish_tool_required_hook_config(script_dir: str) -> HookConfig:
+    marker_path = _finish_tool_marker_path(script_dir)
+    runtime_dir = os.path.dirname(marker_path)
     deny_payload = {
         "decision": "deny",
         "reason": "finish tool was not used",
@@ -254,7 +260,9 @@ def _finish_tool_required_hook_config() -> HookConfig:
                         name="reset-finish-tool-marker",
                         command=_python_hook_command(
                             "from pathlib import Path\n"
-                            f"Path({marker_name!r}).unlink(missing_ok=True)\n"
+                            f"path = Path({marker_path!r})\n"
+                            "path.parent.mkdir(parents=True, exist_ok=True)\n"
+                            "path.unlink(missing_ok=True)\n"
                         ),
                         timeout=5,
                     )
@@ -269,7 +277,9 @@ def _finish_tool_required_hook_config() -> HookConfig:
                         name="mark-finish-tool-used",
                         command=_python_hook_command(
                             "from pathlib import Path\n"
-                            f"Path({marker_name!r}).write_text('finish\\n')\n"
+                            f"path = Path({marker_path!r})\n"
+                            "path.parent.mkdir(parents=True, exist_ok=True)\n"
+                            "path.write_text('finish\\n')\n"
                         ),
                         timeout=5,
                     )
@@ -285,10 +295,25 @@ def _finish_tool_required_hook_config() -> HookConfig:
                             "import json\n"
                             "import sys\n"
                             "from pathlib import Path\n"
-                            f"if Path({marker_name!r}).is_file():\n"
+                            f"if Path({marker_path!r}).is_file():\n"
                             "    sys.exit(0)\n"
                             f"print(json.dumps({deny_payload!r}))\n"
                             "sys.exit(2)\n"
+                        ),
+                        timeout=5,
+                    )
+                ],
+            )
+        ],
+        session_end=[
+            HookMatcher(
+                hooks=[
+                    HookDefinition(
+                        name="cleanup-finish-tool-marker",
+                        command=_python_hook_command(
+                            "import shutil\n"
+                            "from pathlib import Path\n"
+                            f"shutil.rmtree(Path({runtime_dir!r}), ignore_errors=True)\n"
                         ),
                         timeout=5,
                     )
@@ -560,7 +585,7 @@ This automation was triggered by a webhook event:
         "agent": agent,
         "workspace": workspace,
         "callbacks": [event_callback],
-        "hook_config": _finish_tool_required_hook_config(),
+        "hook_config": _finish_tool_required_hook_config(SCRIPT_DIR),
         "delete_on_close": False,  # Keep conversation history after completion
         "tags": conversation_tags or None,
     }

--- a/openhands/automation/presets/prompt/sdk_main.py
+++ b/openhands/automation/presets/prompt/sdk_main.py
@@ -71,7 +71,6 @@ Runtime-injected secrets (via conversation.update_secrets after Conversation cre
 import inspect
 import json
 import os
-import shlex
 import sys
 import threading
 import time
@@ -189,7 +188,7 @@ def _phase_poster() -> None:
 
 # SDK imports (before workspace context so import errors are caught)
 from openhands.sdk import Conversation, RemoteConversation
-from openhands.sdk.hooks import HookConfig, HookDefinition, HookMatcher
+from finish_tool_hook import finish_tool_required_hook_config
 from openhands.tools.preset import TaskOutcome
 
 try:
@@ -219,108 +218,6 @@ def _normalize_mcp_config(raw_mcp_config):
         return raw_mcp_config["mcpServers"]
     return raw_mcp_config
 
-
-FINISH_TOOL_REQUIRED_MESSAGE = (
-    "The task appears complete, but automation runs must end by calling the "
-    "finish tool. Please call the finish tool now with the final task outcome."
-)
-
-
-def _finish_tool_marker_path(script_dir: str) -> str:
-    run_id = os.environ.get("AUTOMATION_RUN_ID") or "current"
-    safe_run_id = "".join(
-        ch if ch.isalnum() or ch in "-_" else "_" for ch in run_id
-    )
-    return os.path.join(
-        os.path.abspath(script_dir),
-        ".openhands_automation_runtime",
-        safe_run_id,
-        "finish_tool_used",
-    )
-
-
-def _python_hook_command(code: str) -> str:
-    return f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
-
-
-def _finish_tool_required_hook_config(script_dir: str) -> HookConfig:
-    marker_path = _finish_tool_marker_path(script_dir)
-    runtime_dir = os.path.dirname(marker_path)
-    deny_payload = {
-        "decision": "deny",
-        "reason": "finish tool was not used",
-        "additionalContext": FINISH_TOOL_REQUIRED_MESSAGE,
-    }
-
-    return HookConfig(
-        session_start=[
-            HookMatcher(
-                hooks=[
-                    HookDefinition(
-                        name="reset-finish-tool-marker",
-                        command=_python_hook_command(
-                            "from pathlib import Path\n"
-                            f"path = Path({marker_path!r})\n"
-                            "path.parent.mkdir(parents=True, exist_ok=True)\n"
-                            "path.unlink(missing_ok=True)\n"
-                        ),
-                        timeout=5,
-                    )
-                ],
-            )
-        ],
-        post_tool_use=[
-            HookMatcher(
-                matcher="/(?:finish|FinishTool)/",
-                hooks=[
-                    HookDefinition(
-                        name="mark-finish-tool-used",
-                        command=_python_hook_command(
-                            "from pathlib import Path\n"
-                            f"path = Path({marker_path!r})\n"
-                            "path.parent.mkdir(parents=True, exist_ok=True)\n"
-                            "path.write_text('finish\\n')\n"
-                        ),
-                        timeout=5,
-                    )
-                ],
-            )
-        ],
-        stop=[
-            HookMatcher(
-                hooks=[
-                    HookDefinition(
-                        name="require-finish-tool",
-                        command=_python_hook_command(
-                            "import json\n"
-                            "import sys\n"
-                            "from pathlib import Path\n"
-                            f"if Path({marker_path!r}).is_file():\n"
-                            "    sys.exit(0)\n"
-                            f"print(json.dumps({deny_payload!r}))\n"
-                            "sys.exit(2)\n"
-                        ),
-                        timeout=5,
-                    )
-                ],
-            )
-        ],
-        session_end=[
-            HookMatcher(
-                hooks=[
-                    HookDefinition(
-                        name="cleanup-finish-tool-marker",
-                        command=_python_hook_command(
-                            "import shutil\n"
-                            "from pathlib import Path\n"
-                            f"shutil.rmtree(Path({runtime_dir!r}), ignore_errors=True)\n"
-                        ),
-                        timeout=5,
-                    )
-                ],
-            )
-        ],
-    )
 
 
 def _build_conversation_title(event_context) -> str | None:
@@ -585,7 +482,7 @@ This automation was triggered by a webhook event:
         "agent": agent,
         "workspace": workspace,
         "callbacks": [event_callback],
-        "hook_config": _finish_tool_required_hook_config(SCRIPT_DIR),
+        "hook_config": finish_tool_required_hook_config(SCRIPT_DIR),
         "delete_on_close": False,  # Keep conversation history after completion
         "tags": conversation_tags or None,
     }

--- a/tests/test_preset_router.py
+++ b/tests/test_preset_router.py
@@ -174,6 +174,24 @@ class TestPresetFileSyntax:
         assert "finish_tool_response_schema=TaskOutcome" in content
         assert 'Tool(name="FinishTool"' not in content
 
+    @pytest.mark.parametrize("preset_name", ["prompt", "plugin"])
+    def test_preset_requires_finish_tool_via_stop_hook(self, preset_name):
+        """Preset conversations nudge text-only endings to call FinishTool."""
+        sdk_main_path = PRESETS_DIR / preset_name / "sdk_main.py"
+        content = sdk_main_path.read_text()
+
+        assert (
+            "from openhands.sdk.hooks import HookConfig, HookDefinition, HookMatcher"
+            in content
+        )
+        assert "def _finish_tool_required_hook_config() -> HookConfig:" in content
+        assert "session_start=[" in content
+        assert "post_tool_use=[" in content
+        assert 'matcher="/(?:finish|FinishTool)/"' in content
+        assert "stop=[" in content
+        assert '"hook_config": _finish_tool_required_hook_config(),' in content
+        assert "Please call the finish tool now" in content
+
 
 class TestPresetEntrypoint:
     def test_get_preset_entrypoint_posix(self, monkeypatch):

--- a/tests/test_preset_router.py
+++ b/tests/test_preset_router.py
@@ -184,12 +184,22 @@ class TestPresetFileSyntax:
             "from openhands.sdk.hooks import HookConfig, HookDefinition, HookMatcher"
             in content
         )
-        assert "def _finish_tool_required_hook_config() -> HookConfig:" in content
+        assert "def _finish_tool_marker_path(script_dir: str) -> str:" in content
+        assert '".openhands_automation_runtime"' in content
+        assert (
+            "def _finish_tool_required_hook_config(script_dir: str) -> HookConfig:"
+            in content
+        )
         assert "session_start=[" in content
         assert "post_tool_use=[" in content
         assert 'matcher="/(?:finish|FinishTool)/"' in content
         assert "stop=[" in content
-        assert '"hook_config": _finish_tool_required_hook_config(),' in content
+        assert "session_end=[" in content
+        assert "shutil.rmtree" in content
+        assert (
+            '"hook_config": _finish_tool_required_hook_config(SCRIPT_DIR),'
+            in content
+        )
         assert "Please call the finish tool now" in content
 
 

--- a/tests/test_preset_router.py
+++ b/tests/test_preset_router.py
@@ -144,6 +144,14 @@ class TestPresetFileSyntax:
             "setup.sh doesn't look like a valid shell script"
         )
 
+    def test_shared_finish_tool_hook_syntax(self):
+        """Verify shared finish-tool hook helper has valid Python syntax."""
+        helper_path = PRESETS_DIR / "finish_tool_hook.py"
+        assert helper_path.exists(), f"Preset file not found: {helper_path}"
+
+        source = helper_path.read_text()
+        compile(source, str(helper_path), "exec")
+
     def test_prompt_setup_sh_fetches_sdk_version_from_api(self):
         """Prompt setup.sh fetches SDK version from the automation service API."""
         setup_sh_path = PRESETS_DIR / "prompt" / "setup.sh"
@@ -180,27 +188,25 @@ class TestPresetFileSyntax:
         sdk_main_path = PRESETS_DIR / preset_name / "sdk_main.py"
         content = sdk_main_path.read_text()
 
+        helper_content = (PRESETS_DIR / "finish_tool_hook.py").read_text()
+
         assert (
-            "from openhands.sdk.hooks import HookConfig, HookDefinition, HookMatcher"
-            in content
+            "from finish_tool_hook import finish_tool_required_hook_config" in content
         )
-        assert "def _finish_tool_marker_path(script_dir: str) -> str:" in content
-        assert '".openhands_automation_runtime"' in content
+        assert "def _finish_tool_marker_path(script_dir: str) -> str:" not in content
         assert (
-            "def _finish_tool_required_hook_config(script_dir: str) -> HookConfig:"
-            in content
+            "def finish_tool_required_hook_config(script_dir: str) -> HookConfig:"
+            in helper_content
         )
-        assert "session_start=[" in content
-        assert "post_tool_use=[" in content
-        assert 'matcher="/(?:finish|FinishTool)/"' in content
-        assert "stop=[" in content
-        assert "session_end=[" in content
-        assert "shutil.rmtree" in content
-        assert (
-            '"hook_config": _finish_tool_required_hook_config(SCRIPT_DIR),'
-            in content
-        )
-        assert "Please call the finish tool now" in content
+        assert '".openhands_automation_runtime"' in helper_content
+        assert "session_start=[" in helper_content
+        assert "post_tool_use=[" in helper_content
+        assert 'matcher="/(?:finish|FinishTool)/"' in helper_content
+        assert "stop=[" in helper_content
+        assert "session_end=[" in helper_content
+        assert "shutil.rmtree" in helper_content
+        assert '"hook_config": finish_tool_required_hook_config(SCRIPT_DIR),' in content
+        assert "Please call the finish tool now" in helper_content
 
 
 class TestPresetEntrypoint:
@@ -378,6 +384,7 @@ class TestGenerateTarball:
         with tarfile.open(fileobj=io.BytesIO(tarball_bytes), mode="r:gz") as tar:
             names = tar.getnames()
             assert "main.py" in names
+            assert "finish_tool_hook.py" in names
             assert "prompt.txt" in names
             assert "setup.sh" in names
             # Note: load_skills.py and clone_repos.py are no longer needed
@@ -502,6 +509,7 @@ class TestReplacePromptInTarball:
         assert new_files["prompt.txt"].decode() == "New prompt"
         for name in (
             "main.py",
+            "finish_tool_hook.py",
             "setup.sh",
             "plugins_config.json",
             "repos_config.json",
@@ -704,6 +712,7 @@ class TestCreateAutomationFromPrompt:
         assert tarball_bytes is not None
         with tarfile.open(fileobj=io.BytesIO(tarball_bytes), mode="r:gz") as tar:
             assert "main.py" in tar.getnames()
+            assert "finish_tool_hook.py" in tar.getnames()
             assert "prompt.txt" in tar.getnames()
             assert "setup.sh" in tar.getnames()
             assert "automation_model.py" not in tar.getnames()
@@ -1238,6 +1247,7 @@ class TestGeneratePluginTarball:
         with tarfile.open(fileobj=io.BytesIO(tarball_bytes), mode="r:gz") as tar:
             names = tar.getnames()
             assert "main.py" in names
+            assert "finish_tool_hook.py" in names
             assert "plugins_config.json" in names
             assert "prompt.txt" in names
             assert "setup.sh" in names
@@ -1689,6 +1699,7 @@ class TestExperimentTarball:
             assert "experiment_config.json" in names
             assert "plugins_config.json" not in names
             assert "main.py" in names
+            assert "finish_tool_hook.py" in names
             assert "prompt.txt" in names
             assert "setup.sh" in names
 
@@ -1827,6 +1838,7 @@ class TestCreateAutomationFromPlugin:
         assert tarball_bytes is not None
         with tarfile.open(fileobj=io.BytesIO(tarball_bytes), mode="r:gz") as tar:
             assert "main.py" in tar.getnames()
+            assert "finish_tool_hook.py" in tar.getnames()
             assert "plugins_config.json" in tar.getnames()
             assert "prompt.txt" in tar.getnames()
             assert "setup.sh" in tar.getnames()


### PR DESCRIPTION
## Summary
- Add preset hook configuration that requires automation conversations to finish via the `finish` tool.
- Track finish-tool usage with a run-specific marker under `.openhands_automation_runtime/<run_id>/finish_tool_used` in the extracted preset runtime directory.
- Clear the marker on `SessionStart` and remove the runtime marker directory on `SessionEnd` so task workspaces are not left with loose marker files.
- Apply the hook wiring to both prompt and plugin preset scripts.
- Add preset tests covering hook imports, hook configuration, finish matcher, runtime directory cleanup, and `Conversation` wiring.

## QA evidence

<img width="2424" height="1724" alt="image" src="https://github.com/user-attachments/assets/086176d9-bcc8-4fbf-adb7-1dfc2ff8a80e" />

_This PR was updated by an AI agent (OpenHands) on behalf of the user._
