### PR TITLE
ci: add issue duplicate checker workflows (parity with sdk/OpenHands)

### DIFF
--- a/.github/workflows/issue-duplicate-checker.yml
+++ b/.github/workflows/issue-duplicate-checker.yml
@@ -1,0 +1,92 @@
+---
+name: Issue Duplicate Check via OpenHands Cloud
+
+on:
+    issues:
+        types: [opened]
+    schedule:
+        - cron: 0 9 * * *
+    workflow_dispatch:
+        inputs:
+            mode:
+                description: Which workflow path to run
+                required: true
+                type: choice
+                options:
+                    - smoke-clone
+                    - issue-check
+                    - auto-close
+                default: smoke-clone
+            issue_number:
+                description: Existing issue number to analyze when mode is issue-check
+                required: false
+                type: number
+            close_after_days:
+                description: Days to wait before auto-closing duplicate candidates in auto-close mode
+                required: false
+                type: number
+                default: 3
+
+permissions:
+    contents: read
+    issues: write
+
+jobs:
+    smoke-clone:
+        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'smoke-clone'
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - name: Clone repository
+              env:
+                  REPOSITORY: ${{ github.repository }}
+              run: |
+                  git clone --depth 1 "https://github.com/${REPOSITORY}.git" /tmp/repo-clone
+                  echo "REPO_HEAD=$(git -C /tmp/repo-clone rev-parse --short HEAD)" >> "$GITHUB_ENV"
+
+            - name: Summarize smoke test
+              run: |
+                  {
+                    echo "## Smoke clone completed"
+                    echo
+                    echo "- Repository cloned to /tmp/repo-clone"
+                    echo "- Repository HEAD: ${REPO_HEAD}"
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+    issue-duplicate-check:
+        if: |
+            github.event_name == 'issues' ||
+            (github.event_name == 'workflow_dispatch' && inputs.mode == 'issue-check' && inputs.issue_number != '')
+        runs-on: ubuntu-latest
+        timeout-minutes: 35
+        concurrency:
+            group: issue-duplicate-check-${{ github.repository }}-${{ github.event.issue.number || inputs.issue_number }}
+            cancel-in-progress: false
+        steps:
+            - name: Run issue duplicate check
+              uses: OpenHands/extensions/plugins/issue-duplicate-checker@fb020c71eb8e7cd2678f0251ab24327d3738da7d
+              with:
+                  mode: issue-check
+                  repository: ${{ github.repository }}
+                  issue-number: ${{ github.event.issue.number || inputs.issue_number }}
+                  close-after-days: ${{ inputs.close_after_days || '3' }}
+                  openhands-api-key: ${{ secrets.OPENHANDS_API_KEY }}
+                  github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC || github.token }}
+
+    auto-close-duplicates:
+        if: |
+            github.event_name == 'schedule' ||
+            (github.event_name == 'workflow_dispatch' && inputs.mode == 'auto-close')
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
+        concurrency:
+            group: auto-close-duplicates-${{ github.repository }}
+            cancel-in-progress: false
+        steps:
+            - name: Auto-close aged duplicate candidates
+              uses: OpenHands/extensions/plugins/issue-duplicate-checker@fb020c71eb8e7cd2678f0251ab24327d3738da7d
+              with:
+                  mode: auto-close
+                  repository: ${{ github.repository }}
+                  close-after-days: ${{ inputs.close_after_days || '3' }}
+                  github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC || github.token }}

--- a/.github/workflows/remove-duplicate-candidate-label.yml
+++ b/.github/workflows/remove-duplicate-candidate-label.yml
@@ -1,0 +1,31 @@
+---
+name: Remove duplicate candidate label on activity
+
+on:
+    issue_comment:
+        types: [created]
+
+permissions:
+    issues: write
+
+concurrency:
+    group: remove-duplicate-${{ github.repository }}-${{ github.event.issue.number }}
+    cancel-in-progress: false
+
+jobs:
+    remove-duplicate-candidate:
+        if: |
+            github.event.issue.state == 'open' &&
+            github.event.issue.pull_request == null &&
+            contains(github.event.issue.labels.*.name, 'duplicate-candidate') &&
+            github.event.comment.user.type != 'Bot' &&
+            !startsWith(github.event.comment.body || '', '<!-- openhands-duplicate-check') &&
+            !startsWith(github.event.comment.body || '', '<!-- openhands-duplicate-veto')
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - name: Remove duplicate-candidate label
+              uses: OpenHands/extensions/plugins/issue-duplicate-checker@fb020c71eb8e7cd2678f0251ab24327d3738da7d
+              with:
+                  mode: remove-label
+                  github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC || github.token }}


### PR DESCRIPTION
HUMAN:
We are starting to see dupes or almost-dupe issues in this repo, we could use the duplicate checker to link and potentially close.


### What

Adds the **issue duplicate checker** workflows to this repo, matching what `OpenHands/software-agent-sdk` and `OpenHands/OpenHands` already run:

- `issue-duplicate-checker.yml` — on new issues (and a daily `cron` sweep + manual `workflow_dispatch`), calls the shared `OpenHands/extensions/plugins/issue-duplicate-checker` action to flag likely duplicates with a `duplicate-candidate` label, and auto-closes aged candidates.
- `remove-duplicate-candidate-label.yml` — clears the `duplicate-candidate` label when a human comments on the issue, so genuine activity un-flags it.

### Why

`automation` has an active issue tracker (75+ open) but no duplicate detection, unlike the sibling repos. This brings it to parity so duplicates get triaged the same way.

### Notes

- The workflow files are the repo-agnostic versions from `OpenHands/OpenHands` (parameterized on `${{ github.repository }}`), copied verbatim so behavior matches the other repos. The action is pinned to the same commit (`fb020c71…`).
- **Secrets:** the duplicate-check job uses `OPENHANDS_API_KEY` (OpenHands Cloud) and `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` (falls back to `github.token`). These are used by the same workflow in the sibling repos; please confirm they're available to this repo at the org level before merging — without `OPENHANDS_API_KEY` the check job will fail.
- No changes to app code; workflows only.

Opened at @enyst's request (parity pass across the main repos).
