### PR TITLE
feat: add automation draft lifecycle dispatch

### DIFF
--- a/migrations/versions/022_add_automation_drafts.py
+++ b/migrations/versions/022_add_automation_drafts.py
@@ -61,9 +61,7 @@ def upgrade() -> None:
         sa.Column("name", sa.String(length=500), nullable=True),
         sa.Column("draft_body", sa.JSON(), nullable=False),
         sa.Column("validation_errors", sa.JSON(), nullable=True),
-        sa.Column(
-            "dispatchable", sa.Boolean(), nullable=False, server_default="false"
-        ),
+        sa.Column("dispatchable", sa.Boolean(), nullable=False, server_default="false"),
         sa.Column("source_automation_id", sa.Uuid(), nullable=True),
         sa.Column("materialized_automation_id", sa.Uuid(), nullable=True),
         sa.Column("last_test_run_id", sa.Uuid(), nullable=True),
@@ -127,7 +125,7 @@ def upgrade() -> None:
 
     op.execute(
         "COMMENT ON COLUMN automations.lifecycle_status IS "
-        "'First-class lifecycle state: ACTIVE, INACTIVE, or DRAFT.'"
+        "'Automation state: ACTIVE, INACTIVE, or DRAFT.'"
     )
     op.execute(
         "COMMENT ON COLUMN automation_runs.trigger_source IS "

--- a/migrations/versions/022_add_automation_drafts.py
+++ b/migrations/versions/022_add_automation_drafts.py
@@ -1,0 +1,167 @@
+"""Add automation drafts and run trigger source.
+
+Revision ID: 022
+Revises: 021
+Create Date: 2026-09-03
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "022"
+down_revision: str = "021"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sqlite() -> bool:
+    return op.get_bind().dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "automations",
+        sa.Column(
+            "lifecycle_status",
+            sa.String(length=20),
+            nullable=False,
+            server_default="ACTIVE",
+        ),
+    )
+    op.create_index(
+        "ix_automations_lifecycle_status", "automations", ["lifecycle_status"]
+    )
+    op.execute(
+        "UPDATE automations SET lifecycle_status = CASE "
+        "WHEN enabled THEN 'ACTIVE' ELSE 'INACTIVE' END"
+    )
+
+    op.add_column(
+        "automation_runs",
+        sa.Column("trigger_source", sa.String(length=32), nullable=True),
+    )
+    op.create_index(
+        "ix_automation_runs_trigger_source", "automation_runs", ["trigger_source"]
+    )
+    op.create_index(
+        "ix_automation_runs_status_trigger_source",
+        "automation_runs",
+        ["status", "trigger_source"],
+    )
+
+    op.create_table(
+        "automation_drafts",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("org_id", sa.Uuid(), nullable=False),
+        sa.Column("endpoint", sa.String(length=64), nullable=False),
+        sa.Column("name", sa.String(length=500), nullable=True),
+        sa.Column("draft_body", sa.JSON(), nullable=False),
+        sa.Column("validation_errors", sa.JSON(), nullable=True),
+        sa.Column(
+            "dispatchable", sa.Boolean(), nullable=False, server_default="false"
+        ),
+        sa.Column("source_automation_id", sa.Uuid(), nullable=True),
+        sa.Column("materialized_automation_id", sa.Uuid(), nullable=True),
+        sa.Column("last_test_run_id", sa.Uuid(), nullable=True),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_automation_id"], ["automations.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["materialized_automation_id"], ["automations.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["last_test_run_id"], ["automation_runs.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_automation_drafts_user_id", "automation_drafts", ["user_id"])
+    op.create_index("ix_automation_drafts_org_id", "automation_drafts", ["org_id"])
+    op.create_index(
+        "ix_automation_drafts_deleted_at", "automation_drafts", ["deleted_at"]
+    )
+    op.create_index(
+        "ix_automation_drafts_org_updated_at",
+        "automation_drafts",
+        ["org_id", "updated_at"],
+    )
+    op.create_index(
+        "ix_automation_drafts_org_deleted_at",
+        "automation_drafts",
+        ["org_id", "deleted_at"],
+    )
+    op.create_index(
+        "ix_automation_drafts_source_automation_id",
+        "automation_drafts",
+        ["source_automation_id"],
+    )
+    op.create_index(
+        "ix_automation_drafts_materialized_automation_id",
+        "automation_drafts",
+        ["materialized_automation_id"],
+    )
+    op.create_index(
+        "ix_automation_drafts_last_test_run_id",
+        "automation_drafts",
+        ["last_test_run_id"],
+    )
+
+    if _is_sqlite():
+        return
+
+    op.execute(
+        "COMMENT ON COLUMN automations.lifecycle_status IS "
+        "'First-class lifecycle state: ACTIVE, INACTIVE, or DRAFT.'"
+    )
+    op.execute(
+        "COMMENT ON COLUMN automation_runs.trigger_source IS "
+        "'How the run was created: manual, cron, event, or NULL for legacy rows.'"
+    )
+    op.execute(
+        "COMMENT ON TABLE automation_drafts IS "
+        "'Incomplete or complete automation setup drafts saved by setup UIs.'"
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_automation_drafts_last_test_run_id", table_name="automation_drafts"
+    )
+    op.drop_index(
+        "ix_automation_drafts_materialized_automation_id",
+        table_name="automation_drafts",
+    )
+    op.drop_index(
+        "ix_automation_drafts_source_automation_id", table_name="automation_drafts"
+    )
+    op.drop_index("ix_automation_drafts_org_deleted_at", table_name="automation_drafts")
+    op.drop_index("ix_automation_drafts_org_updated_at", table_name="automation_drafts")
+    op.drop_index("ix_automation_drafts_deleted_at", table_name="automation_drafts")
+    op.drop_index("ix_automation_drafts_org_id", table_name="automation_drafts")
+    op.drop_index("ix_automation_drafts_user_id", table_name="automation_drafts")
+    op.drop_table("automation_drafts")
+
+    op.drop_index(
+        "ix_automation_runs_status_trigger_source", table_name="automation_runs"
+    )
+    op.drop_index("ix_automation_runs_trigger_source", table_name="automation_runs")
+    op.drop_column("automation_runs", "trigger_source")
+
+    op.drop_index("ix_automations_lifecycle_status", table_name="automations")
+    op.drop_column("automations", "lifecycle_status")

--- a/openhands/automation/app.py
+++ b/openhands/automation/app.py
@@ -18,6 +18,7 @@ from openhands.automation.db import (
     set_sqlite_mode,
 )
 from openhands.automation.dispatcher import dispatcher_loop
+from openhands.automation.draft_router import router as draft_router
 from openhands.automation.event_router import router as event_router
 from openhands.automation.git_sync import git_sync_loop, is_git_sync_supported
 from openhands.automation.git_sync.router import router as git_sync_router
@@ -293,6 +294,7 @@ _base_path = get_settings().base_path
 app.include_router(uploads_router, prefix=_base_path)
 app.include_router(capabilities_router, prefix=_base_path)
 app.include_router(preset_router, prefix=_base_path)
+app.include_router(draft_router, prefix=_base_path)
 app.include_router(event_router, prefix=_base_path)
 app.include_router(webhook_router, prefix=_base_path)
 app.include_router(telemetry_router, prefix=_base_path)

--- a/openhands/automation/capabilities_router.py
+++ b/openhands/automation/capabilities_router.py
@@ -76,6 +76,7 @@ _DRAFT_MODELS: dict[str, type[DraftModel]] = {
 # Features every deployment has: they come from the SDK code the service
 # packages into a run, not from configuration.
 _STATIC_FEATURES = (
+    "automationDrafts",
     "conversationDispatch",
     # Can run a client-supplied tarball, so an entry may ship a script bundle.
     "customTarball",

--- a/openhands/automation/dispatcher.py
+++ b/openhands/automation/dispatcher.py
@@ -22,7 +22,7 @@ from datetime import timedelta
 from typing import Any
 
 import httpx
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
@@ -37,6 +37,7 @@ from openhands.automation.exceptions import (
 from openhands.automation.execution import execute_in_context
 from openhands.automation.models import (
     Automation,
+    AutomationLifecycleStatus,
     AutomationRun,
     AutomationRunStatus,
     TarballUpload,
@@ -135,8 +136,14 @@ async def _poll_pending_runs(
         .options(selectinload(AutomationRun.automation))
         .where(
             AutomationRun.status == AutomationRunStatus.PENDING,
-            Automation.enabled.is_(True),
             Automation.deleted_at.is_(None),
+            or_(
+                AutomationRun.trigger_source == "manual",
+                and_(
+                    Automation.enabled.is_(True),
+                    Automation.lifecycle_status == AutomationLifecycleStatus.ACTIVE,
+                ),
+            ),
         )
         .order_by(AutomationRun.created_at.asc())
         .limit(batch_size)

--- a/openhands/automation/dispatcher.py
+++ b/openhands/automation/dispatcher.py
@@ -37,9 +37,9 @@ from openhands.automation.exceptions import (
 from openhands.automation.execution import execute_in_context
 from openhands.automation.models import (
     Automation,
-    AutomationLifecycleStatus,
     AutomationRun,
     AutomationRunStatus,
+    AutomationState,
     TarballUpload,
 )
 from openhands.automation.telemetry import capture_automation_event
@@ -141,7 +141,7 @@ async def _poll_pending_runs(
                 AutomationRun.trigger_source == "manual",
                 and_(
                     Automation.enabled.is_(True),
-                    Automation.lifecycle_status == AutomationLifecycleStatus.ACTIVE,
+                    Automation.lifecycle_status == AutomationState.ACTIVE,
                 ),
             ),
         )

--- a/openhands/automation/draft_router.py
+++ b/openhands/automation/draft_router.py
@@ -1,0 +1,575 @@
+"""Server-backed automation drafts.
+
+Draft rows hold partial setup UI state. A draft is materialized into a disabled
+Automation only when it validates and the user manually dispatches it for a test
+run.
+"""
+
+import logging
+import uuid
+from typing import Any
+
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Query,
+    Request,
+    status,
+)
+from pydantic import BaseModel, ValidationError
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from openhands.automation.auth import AuthenticatedUser, require_permission
+from openhands.automation.capabilities_router import (
+    _DRAFT_MODELS,
+    _cron_errors,
+    _event_type_errors,
+    _schema_errors,
+)
+from openhands.automation.db import get_session
+from openhands.automation.git_sync import mark_git_sync_dirty
+from openhands.automation.models import (
+    Automation,
+    AutomationDraft,
+    AutomationLifecycleStatus,
+    TarballUpload,
+    UploadStatus,
+)
+from openhands.automation.preset_router import (
+    CreatePluginAutomationRequest,
+    CreatePromptAutomationRequest,
+    _bytes_to_async_iter,
+    _generate_plugin_tarball,
+    _generate_tarball,
+    _get_preset_entrypoint,
+    _resolve_experiment_variant_models,
+    _safe_truncate,
+)
+from openhands.automation.schemas import (
+    AutomationDraftListResponse,
+    AutomationDraftResponse,
+    AutomationRunResponse,
+    CreateAutomationDraftRequest,
+    CreateAutomationRequest,
+    CronTrigger,
+    DraftEndpoint,
+    DraftValidationError,
+    EventTrigger,
+    UpdateAutomationDraftRequest,
+)
+from openhands.automation.storage import FileStore, get_file_store
+from openhands.automation.telemetry import (
+    capture_automation_event,
+    get_request_telemetry_context,
+)
+from openhands.automation.utils import utcnow
+from openhands.automation.utils.model_profiles import (
+    resolve_model_profile_for_user,
+    validate_model_profile_for_user,
+)
+from openhands.automation.utils.run import create_pending_run
+from openhands.automation.utils.tarball_validation import (
+    build_internal_url,
+    build_upload_storage_path,
+    validate_tarball_path,
+)
+from openhands.automation.utils.timeout import default_automation_timeout
+from openhands.automation.utils.webhook import get_webhook_config
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/drafts", tags=["Automation Drafts"])
+
+_require_view_automations = require_permission("view_automations")
+_require_manage_automations = require_permission("manage_automations")
+
+
+async def _assert_org_automation_exists(
+    session: AsyncSession, automation_id: uuid.UUID, org_id: uuid.UUID
+) -> None:
+    result = await session.execute(
+        select(Automation.id).where(
+            Automation.id == automation_id,
+            Automation.org_id == org_id,
+            Automation.deleted_at.is_(None),
+        )
+    )
+    if result.scalar_one_or_none() is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Automation not found")
+
+
+async def _get_org_draft(
+    session: AsyncSession, draft_id: uuid.UUID, org_id: uuid.UUID
+) -> AutomationDraft:
+    result = await session.execute(
+        select(AutomationDraft).where(
+            AutomationDraft.id == draft_id,
+            AutomationDraft.org_id == org_id,
+            AutomationDraft.deleted_at.is_(None),
+        )
+    )
+    draft = result.scalars().first()
+    if draft is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, detail="Automation draft not found"
+        )
+    return draft
+
+
+def _draft_name(name: str | None, draft_body: dict[str, Any]) -> str | None:
+    if name:
+        return name
+    body_name = draft_body.get("name")
+    return body_name if isinstance(body_name, str) and body_name.strip() else None
+
+
+def _errors_to_json(errors: list[DraftValidationError]) -> list[dict[str, Any]]:
+    return [error.model_dump() for error in errors]
+
+
+async def _validate_draft_body(
+    endpoint: DraftEndpoint,
+    draft_body: dict[str, Any],
+    user: AuthenticatedUser,
+    session: AsyncSession,
+) -> tuple[BaseModel | None, list[DraftValidationError]]:
+    try:
+        draft = _DRAFT_MODELS[endpoint].model_validate(draft_body)
+    except ValidationError as e:
+        return None, _schema_errors(e)
+
+    errors: list[DraftValidationError] = []
+    try:
+        validate_model_profile_for_user(draft.model, user)
+    except HTTPException as e:
+        errors.append(
+            DraftValidationError(
+                field="model",
+                code="model_profile_not_found",
+                message=str(e.detail),
+            )
+        )
+
+    if isinstance(draft, CreatePluginAutomationRequest):
+        try:
+            default_model = resolve_model_profile_for_user(draft.model, user)
+            _resolve_experiment_variant_models(
+                draft.variants, user, default_model=default_model
+            )
+        except HTTPException as e:
+            errors.append(
+                DraftValidationError(
+                    field="variants",
+                    code="variant_model_profile_not_found",
+                    message=str(e.detail),
+                )
+            )
+
+    if isinstance(draft, CreateAutomationRequest):
+        try:
+            await validate_tarball_path(
+                tarball_path=draft.tarball_path,
+                user_id=user.user_id,
+                org_id=user.org_id,
+                session=session,
+            )
+        except HTTPException as e:
+            errors.append(
+                DraftValidationError(
+                    field="tarball_path",
+                    code=f"tarball_path_{e.status_code}",
+                    message=str(e.detail),
+                )
+            )
+
+    trigger = draft.trigger
+    if isinstance(trigger, CronTrigger):
+        errors.extend(_cron_errors(trigger))
+    elif isinstance(trigger, EventTrigger):
+        webhook = await get_webhook_config(trigger.source, user.org_id, session)
+        if webhook is None:
+            errors.append(
+                DraftValidationError(
+                    field="trigger.source",
+                    code="event_source_not_configured",
+                    message=(
+                        f"No webhook is configured to deliver '{trigger.source}' "
+                        "events to this deployment."
+                    ),
+                )
+            )
+        else:
+            errors.extend(_event_type_errors(trigger))
+
+    return draft, errors
+
+
+async def _refresh_validation(
+    draft: AutomationDraft,
+    user: AuthenticatedUser,
+    session: AsyncSession,
+) -> BaseModel | None:
+    parsed, errors = await _validate_draft_body(
+        draft.endpoint, draft.draft_body, user, session
+    )
+    draft.validation_errors = _errors_to_json(errors) if errors else None
+    draft.dispatchable = not errors
+    return parsed if not errors else None
+
+
+async def _write_generated_tarball(
+    *,
+    session: AsyncSession,
+    file_store: FileStore,
+    user: AuthenticatedUser,
+    name: str,
+    prefix: str,
+    description: str,
+    tarball_content: bytes,
+) -> str:
+    upload_id = uuid.uuid4()
+    storage_path = build_upload_storage_path(user.org_id, user.user_id, upload_id)
+    upload = TarballUpload(
+        id=upload_id,
+        user_id=user.user_id,
+        org_id=user.org_id,
+        name=f"{prefix}-{_safe_truncate(name, 50)}",
+        description=_safe_truncate(description, 200),
+        status=UploadStatus.UPLOADING,
+        storage_path=storage_path,
+    )
+    session.add(upload)
+    await session.flush()
+
+    try:
+        size_bytes = await file_store.write_stream(
+            path=storage_path,
+            stream=_bytes_to_async_iter(tarball_content),
+            content_type="application/x-tar",
+        )
+        upload.status = UploadStatus.COMPLETED
+        upload.size_bytes = size_bytes
+    except Exception as e:
+        logger.exception("Failed to upload generated draft tarball: %s", e)
+        upload.status = UploadStatus.FAILED
+        upload.error_message = f"Upload failed: {e!s}"
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to upload tarball: {e!s}",
+        )
+
+    return build_internal_url(upload_id)
+
+
+async def _materialize_raw_draft(
+    body: CreateAutomationRequest,
+    user: AuthenticatedUser,
+    session: AsyncSession,
+) -> dict[str, Any]:
+    await validate_tarball_path(
+        tarball_path=body.tarball_path,
+        user_id=user.user_id,
+        org_id=user.org_id,
+        session=session,
+    )
+    preset_metadata = None
+    if body.template is not None:
+        preset_metadata = {"template": body.template.model_dump(exclude_none=True)}
+    return {
+        "name": body.name,
+        "prompt": None,
+        "preset_metadata": preset_metadata,
+        "model": resolve_model_profile_for_user(body.model, user),
+        "trigger": body.trigger.model_dump(),
+        "tarball_path": body.tarball_path,
+        "setup_script_path": body.setup_script_path,
+        "entrypoint": body.entrypoint,
+        "timeout": default_automation_timeout(body.timeout),
+        "keep_alive": body.keep_alive,
+    }
+
+
+async def _materialize_prompt_draft(
+    body: CreatePromptAutomationRequest,
+    user: AuthenticatedUser,
+    session: AsyncSession,
+    file_store: FileStore,
+) -> dict[str, Any]:
+    tarball_content = _generate_tarball(body.prompt, repos=body.repos)
+    tarball_path = await _write_generated_tarball(
+        session=session,
+        file_store=file_store,
+        user=user,
+        name=body.name,
+        prefix="draft-prompt-automation",
+        description=(
+            f"Draft test generated from prompt: {_safe_truncate(body.prompt, 100)}"
+        ),
+        tarball_content=tarball_content,
+    )
+    preset_metadata: dict[str, Any] = {"preset_type": "prompt", "prompt": body.prompt}
+    if body.repos:
+        preset_metadata["repos"] = [r.model_dump(exclude_none=True) for r in body.repos]
+    if body.template is not None:
+        preset_metadata["template"] = body.template.model_dump(exclude_none=True)
+    return {
+        "name": body.name,
+        "prompt": body.prompt,
+        "preset_metadata": preset_metadata,
+        "model": resolve_model_profile_for_user(body.model, user),
+        "trigger": body.trigger.model_dump(),
+        "tarball_path": tarball_path,
+        "setup_script_path": "setup.sh",
+        "entrypoint": _get_preset_entrypoint(),
+        "timeout": default_automation_timeout(body.timeout),
+        "keep_alive": body.keep_alive,
+    }
+
+
+async def _materialize_plugin_draft(
+    body: CreatePluginAutomationRequest,
+    user: AuthenticatedUser,
+    session: AsyncSession,
+    file_store: FileStore,
+) -> dict[str, Any]:
+    model = resolve_model_profile_for_user(body.model, user)
+    variants = _resolve_experiment_variant_models(
+        body.variants, user, default_model=model
+    )
+    tarball_content = _generate_plugin_tarball(
+        body.plugins,
+        body.prompt,
+        repos=body.repos,
+        experiment_id=body.experiment_id,
+        variants=variants,
+    )
+    tarball_path = await _write_generated_tarball(
+        session=session,
+        file_store=file_store,
+        user=user,
+        name=body.name,
+        prefix="draft-plugin-automation",
+        description=f"Draft plugin automation test: {_safe_truncate(body.name, 100)}",
+        tarball_content=tarball_content,
+    )
+    preset_metadata: dict[str, Any] = {"preset_type": "plugin", "prompt": body.prompt}
+    if body.plugins:
+        preset_metadata["plugins"] = [
+            p.model_dump(exclude_none=True) for p in body.plugins
+        ]
+    if body.repos:
+        preset_metadata["repos"] = [r.model_dump(exclude_none=True) for r in body.repos]
+    if body.template is not None:
+        preset_metadata["template"] = body.template.model_dump(exclude_none=True)
+    return {
+        "name": body.name,
+        "prompt": body.prompt,
+        "preset_metadata": preset_metadata,
+        "model": model,
+        "trigger": body.trigger.model_dump(),
+        "tarball_path": tarball_path,
+        "setup_script_path": "setup.sh",
+        "entrypoint": _get_preset_entrypoint(),
+        "timeout": default_automation_timeout(body.timeout),
+        "keep_alive": body.keep_alive,
+    }
+
+
+async def _materialize_draft(
+    draft: AutomationDraft,
+    parsed: BaseModel,
+    user: AuthenticatedUser,
+    request: Request,
+    session: AsyncSession,
+    file_store: FileStore,
+) -> Automation:
+    if isinstance(parsed, CreateAutomationRequest):
+        values = await _materialize_raw_draft(parsed, user, session)
+    elif isinstance(parsed, CreatePromptAutomationRequest):
+        values = await _materialize_prompt_draft(parsed, user, session, file_store)
+    elif isinstance(parsed, CreatePluginAutomationRequest):
+        values = await _materialize_plugin_draft(parsed, user, session, file_store)
+    else:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Unsupported draft endpoint",
+        )
+
+    automation: Automation | None = None
+    if draft.materialized_automation_id is not None:
+        existing = await session.get(Automation, draft.materialized_automation_id)
+        if existing is not None and existing.deleted_at is None:
+            automation = existing
+
+    values.update(
+        {
+            "enabled": False,
+            "lifecycle_status": AutomationLifecycleStatus.DRAFT,
+            "disabled_reason": None,
+            "disabled_detail": None,
+            "disabled_at": None,
+        }
+    )
+    if automation is None:
+        automation = Automation(
+            id=uuid.uuid4(),
+            user_id=user.user_id,
+            org_id=user.org_id,
+            telemetry_distinct_id=get_request_telemetry_context(
+                request
+            ).frontend_distinct_id,
+            **values,
+        )
+        session.add(automation)
+        draft.materialized_automation_id = automation.id
+    else:
+        for field, value in values.items():
+            setattr(automation, field, value)
+    await session.flush()
+    await mark_git_sync_dirty(session, automation)
+    return automation
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def create_draft(
+    body: CreateAutomationDraftRequest,
+    user: AuthenticatedUser = Depends(_require_manage_automations),
+    session: AsyncSession = Depends(get_session),
+) -> AutomationDraftResponse:
+    if body.source_automation_id is not None:
+        await _assert_org_automation_exists(
+            session, body.source_automation_id, user.org_id
+        )
+    draft = AutomationDraft(
+        user_id=user.user_id,
+        org_id=user.org_id,
+        endpoint=body.endpoint,
+        name=_draft_name(body.name, body.draft),
+        draft_body=body.draft,
+        source_automation_id=body.source_automation_id,
+    )
+    session.add(draft)
+    await session.flush()
+    await _refresh_validation(draft, user, session)
+    await session.flush()
+    await session.refresh(draft)
+    return AutomationDraftResponse.model_validate(draft)
+
+
+@router.get("")
+async def list_drafts(
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    user: AuthenticatedUser = Depends(_require_view_automations),
+    session: AsyncSession = Depends(get_session),
+) -> AutomationDraftListResponse:
+    base_query = select(AutomationDraft).where(
+        AutomationDraft.org_id == user.org_id,
+        AutomationDraft.deleted_at.is_(None),
+    )
+    total = (
+        await session.execute(select(func.count()).select_from(base_query.subquery()))
+    ).scalar() or 0
+    result = await session.execute(
+        base_query.order_by(AutomationDraft.updated_at.desc())
+        .offset(offset)
+        .limit(limit)
+    )
+    return AutomationDraftListResponse(
+        drafts=[
+            AutomationDraftResponse.model_validate(draft) for draft in result.scalars()
+        ],
+        total=total,
+    )
+
+
+@router.get("/{draft_id}")
+async def get_draft(
+    draft_id: uuid.UUID,
+    user: AuthenticatedUser = Depends(_require_view_automations),
+    session: AsyncSession = Depends(get_session),
+) -> AutomationDraftResponse:
+    draft = await _get_org_draft(session, draft_id, user.org_id)
+    return AutomationDraftResponse.model_validate(draft)
+
+
+@router.patch("/{draft_id}")
+async def update_draft(
+    draft_id: uuid.UUID,
+    body: UpdateAutomationDraftRequest,
+    user: AuthenticatedUser = Depends(_require_manage_automations),
+    session: AsyncSession = Depends(get_session),
+) -> AutomationDraftResponse:
+    draft = await _get_org_draft(session, draft_id, user.org_id)
+    if body.endpoint is not None:
+        draft.endpoint = body.endpoint
+    if body.draft is not None:
+        draft.draft_body = body.draft
+    if body.name is not None or body.draft is not None:
+        draft.name = _draft_name(body.name, draft.draft_body)
+    await _refresh_validation(draft, user, session)
+    await session.flush()
+    await session.refresh(draft)
+    return AutomationDraftResponse.model_validate(draft)
+
+
+@router.delete("/{draft_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_draft(
+    draft_id: uuid.UUID,
+    user: AuthenticatedUser = Depends(_require_manage_automations),
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    draft = await _get_org_draft(session, draft_id, user.org_id)
+    draft.deleted_at = utcnow()
+    await session.flush()
+
+
+@router.post("/{draft_id}/dispatch", status_code=status.HTTP_201_CREATED)
+async def dispatch_draft(
+    draft_id: uuid.UUID,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    user: AuthenticatedUser = Depends(_require_manage_automations),
+    session: AsyncSession = Depends(get_session),
+    file_store: FileStore = Depends(get_file_store),
+) -> AutomationRunResponse:
+    del background_tasks
+    draft = await _get_org_draft(session, draft_id, user.org_id)
+    parsed = await _refresh_validation(draft, user, session)
+    if parsed is None:
+        await session.flush()
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "message": "Draft is not dispatchable",
+                "errors": draft.validation_errors or [],
+            },
+        )
+
+    automation = await _materialize_draft(
+        draft, parsed, user, request, session, file_store
+    )
+    run = await create_pending_run(
+        session,
+        automation,
+        telemetry_distinct_id=get_request_telemetry_context(
+            request
+        ).frontend_distinct_id,
+        trigger_source="manual",
+    )
+    draft.last_test_run_id = run.id
+    await session.flush()
+    await session.refresh(run)
+    await capture_automation_event(
+        "automation_run_created",
+        request=request,
+        user=user,
+        automation=automation,
+        run=run,
+        properties={"trigger_source": "manual", "draft_id": str(draft.id)},
+    )
+    return AutomationRunResponse.model_validate(run)

--- a/openhands/automation/draft_router.py
+++ b/openhands/automation/draft_router.py
@@ -34,7 +34,7 @@ from openhands.automation.git_sync import mark_git_sync_dirty
 from openhands.automation.models import (
     Automation,
     AutomationDraft,
-    AutomationLifecycleStatus,
+    AutomationState,
     TarballUpload,
     UploadStatus,
 )
@@ -408,7 +408,7 @@ async def _materialize_draft(
     values.update(
         {
             "enabled": False,
-            "lifecycle_status": AutomationLifecycleStatus.DRAFT,
+            "lifecycle_status": AutomationState.DRAFT,
             "disabled_reason": None,
             "disabled_detail": None,
             "disabled_at": None,

--- a/openhands/automation/draft_router.py
+++ b/openhands/automation/draft_router.py
@@ -7,7 +7,7 @@ run.
 
 import logging
 import uuid
-from typing import Any
+from typing import Any, cast
 
 from fastapi import (
     APIRouter,
@@ -233,7 +233,7 @@ async def _refresh_validation(
     session: AsyncSession,
 ) -> BaseModel | None:
     parsed, errors = await _validate_draft_body(
-        draft.endpoint, draft.draft_body, user, session
+        cast(DraftEndpoint, draft.endpoint), draft.draft_body, user, session
     )
     draft.validation_errors = _errors_to_json(errors) if errors else None
     draft.dispatchable = not errors
@@ -525,7 +525,7 @@ async def update_draft(
     session: AsyncSession = Depends(get_session),
 ) -> AutomationDraftResponse:
     draft = await _get_org_draft(session, draft_id, user.org_id)
-    endpoint = body.endpoint or draft.endpoint
+    endpoint = cast(DraftEndpoint, body.endpoint or draft.endpoint)
     draft_body = body.draft if body.draft is not None else draft.draft_body
     draft_body = _normalize_draft_body_or_422(endpoint, draft_body)
     if body.endpoint is not None:

--- a/openhands/automation/draft_schemas.py
+++ b/openhands/automation/draft_schemas.py
@@ -121,6 +121,10 @@ class _BaseDraftBody(BaseModel):
         return normalize_automation_state_enabled(data)
 
 
+def _normalize_automation_state(data: Any) -> Any:
+    return normalize_automation_state_enabled(data)
+
+
 def _normalize_list_field(data: dict[str, Any], field: str) -> None:
     if (
         field in data
@@ -169,7 +173,7 @@ class PromptAutomationDraftBody(_BaseDraftBody):
     @model_validator(mode="before")
     @classmethod
     def normalize_repos(cls, data: Any) -> Any:
-        data = super().validate_automation_state_enabled(data)
+        data = _normalize_automation_state(data)
         if isinstance(data, dict):
             _normalize_list_field(data, "repos")
         return data
@@ -210,7 +214,7 @@ class PluginAutomationDraftBody(_BaseDraftBody):
     @model_validator(mode="before")
     @classmethod
     def normalize_plugins_and_repos(cls, data: Any) -> Any:
-        data = super().validate_automation_state_enabled(data)
+        data = _normalize_automation_state(data)
         if isinstance(data, dict):
             _normalize_list_field(data, "plugins")
             _normalize_list_field(data, "repos")

--- a/openhands/automation/git_sync/loop.py
+++ b/openhands/automation/git_sync/loop.py
@@ -54,6 +54,7 @@ from openhands.automation.git_sync.serializer import (
 from openhands.automation.models import (
     Automation,
     AutomationGitSyncState,
+    AutomationLifecycleStatus,
     TarballUpload,
     UploadStatus,
 )
@@ -474,6 +475,18 @@ async def _validate_and_resolve_fields(
         session, fields, deserialized, slug, existing, pending_storage_deletes
     )
 
+    enabled = True if fields.get("enabled") is None else bool(fields["enabled"])
+    lifecycle_status = fields.get("lifecycle_status")
+    if lifecycle_status == AutomationLifecycleStatus.DRAFT.value:
+        lifecycle = AutomationLifecycleStatus.DRAFT
+        enabled = False
+    else:
+        lifecycle = (
+            AutomationLifecycleStatus.ACTIVE
+            if enabled
+            else AutomationLifecycleStatus.INACTIVE
+        )
+
     return {
         "name": name,
         "model": fields.get("model"),
@@ -482,10 +495,8 @@ async def _validate_and_resolve_fields(
         "setup_script_path": setup_script_path,
         "timeout": timeout,
         "keep_alive": fields.get("keep_alive"),
-        # `dict.get`'s default only applies when the key is absent. A hand edit
-        # leaving "enabled:" empty is valid YAML parsing to None, and
-        # bool(None) would silently disable a live automation on import.
-        "enabled": True if fields.get("enabled") is None else bool(fields["enabled"]),
+        "enabled": enabled,
+        "lifecycle_status": lifecycle,
         "prompt": fields.get("prompt"),
         "preset_metadata": fields.get("preset_metadata"),
         "tarball_path": tarball_path,
@@ -718,6 +729,7 @@ async def _import_from_git(
         automation = await session.get(Automation, state.automation_id)
         if automation is not None and automation.deleted_at is None:
             automation.enabled = False
+            automation.lifecycle_status = AutomationLifecycleStatus.INACTIVE
             automation.deleted_at = utcnow()
             result.deleted_in_db += 1
             logger.info("Soft-deleted automation %s (removed from git)", automation.id)

--- a/openhands/automation/git_sync/loop.py
+++ b/openhands/automation/git_sync/loop.py
@@ -54,7 +54,7 @@ from openhands.automation.git_sync.serializer import (
 from openhands.automation.models import (
     Automation,
     AutomationGitSyncState,
-    AutomationLifecycleStatus,
+    AutomationState,
     TarballUpload,
     UploadStatus,
 )
@@ -477,15 +477,11 @@ async def _validate_and_resolve_fields(
 
     enabled = True if fields.get("enabled") is None else bool(fields["enabled"])
     lifecycle_status = fields.get("lifecycle_status")
-    if lifecycle_status == AutomationLifecycleStatus.DRAFT.value:
-        lifecycle = AutomationLifecycleStatus.DRAFT
+    if lifecycle_status == AutomationState.DRAFT.value:
+        lifecycle = AutomationState.DRAFT
         enabled = False
     else:
-        lifecycle = (
-            AutomationLifecycleStatus.ACTIVE
-            if enabled
-            else AutomationLifecycleStatus.INACTIVE
-        )
+        lifecycle = AutomationState.ACTIVE if enabled else AutomationState.INACTIVE
 
     return {
         "name": name,
@@ -729,7 +725,7 @@ async def _import_from_git(
         automation = await session.get(Automation, state.automation_id)
         if automation is not None and automation.deleted_at is None:
             automation.enabled = False
-            automation.lifecycle_status = AutomationLifecycleStatus.INACTIVE
+            automation.lifecycle_status = AutomationState.INACTIVE
             automation.deleted_at = utcnow()
             result.deleted_in_db += 1
             logger.info("Soft-deleted automation %s (removed from git)", automation.id)

--- a/openhands/automation/git_sync/serializer.py
+++ b/openhands/automation/git_sync/serializer.py
@@ -140,6 +140,9 @@ def _automation_yaml_fields(
         "timeout": automation.timeout,
         "keep_alive": automation.keep_alive,
         "enabled": automation.enabled,
+        "lifecycle_status": getattr(
+            automation.lifecycle_status, "value", automation.lifecycle_status
+        ),
         "prompt": automation.prompt,
         "preset_metadata": automation.preset_metadata,
         "tarball_source": {

--- a/openhands/automation/models.py
+++ b/openhands/automation/models.py
@@ -49,8 +49,8 @@ class AutomationRunStatus(enum.Enum):
     SKIPPED = "SKIPPED"
 
 
-class AutomationLifecycleStatus(enum.Enum):
-    """Lifecycle state of an automation definition."""
+class AutomationState(enum.Enum):
+    """State of an automation definition."""
 
     ACTIVE = "ACTIVE"
     INACTIVE = "INACTIVE"
@@ -104,15 +104,16 @@ class Automation(Base):
     keep_alive: Mapped[bool | None] = mapped_column(default=None, nullable=True)
 
     # Whether the automation is enabled (can be triggered automatically).
-    # Kept for backwards compatibility; lifecycle_status is the first-class
-    # active/inactive/draft state. Only ACTIVE rows should have enabled=True.
+    # Kept for backwards compatibility; lifecycle_status stores the
+    # active/inactive/draft automation state. Only ACTIVE rows should have
+    # enabled=True.
     enabled: Mapped[bool] = mapped_column(default=True, nullable=False, index=True)
 
-    lifecycle_status: Mapped[AutomationLifecycleStatus] = mapped_column(
-        Enum(AutomationLifecycleStatus, native_enum=False, length=20),
+    lifecycle_status: Mapped[AutomationState] = mapped_column(
+        Enum(AutomationState, native_enum=False, length=20),
         nullable=False,
-        default=AutomationLifecycleStatus.ACTIVE,
-        server_default=AutomationLifecycleStatus.ACTIVE.value,
+        default=AutomationState.ACTIVE,
+        server_default=AutomationState.ACTIVE.value,
         index=True,
     )
 

--- a/openhands/automation/models.py
+++ b/openhands/automation/models.py
@@ -8,6 +8,7 @@ from typing import Any
 from sqlalchemy import (
     JSON,
     BigInteger,
+    Boolean,
     DateTime,
     Enum,
     Float,
@@ -46,6 +47,14 @@ class AutomationRunStatus(enum.Enum):
     FAILED = "FAILED"
     CANCELLED = "CANCELLED"
     SKIPPED = "SKIPPED"
+
+
+class AutomationLifecycleStatus(enum.Enum):
+    """Lifecycle state of an automation definition."""
+
+    ACTIVE = "ACTIVE"
+    INACTIVE = "INACTIVE"
+    DRAFT = "DRAFT"
 
 
 class Automation(Base):
@@ -94,8 +103,18 @@ class Automation(Base):
     # means the automation service owns explicit cleanup.
     keep_alive: Mapped[bool | None] = mapped_column(default=None, nullable=True)
 
-    # Whether the automation is enabled (can be triggered)
+    # Whether the automation is enabled (can be triggered automatically).
+    # Kept for backwards compatibility; lifecycle_status is the first-class
+    # active/inactive/draft state. Only ACTIVE rows should have enabled=True.
     enabled: Mapped[bool] = mapped_column(default=True, nullable=False, index=True)
+
+    lifecycle_status: Mapped[AutomationLifecycleStatus] = mapped_column(
+        Enum(AutomationLifecycleStatus, native_enum=False, length=20),
+        nullable=False,
+        default=AutomationLifecycleStatus.ACTIVE,
+        server_default=AutomationLifecycleStatus.ACTIVE.value,
+        index=True,
+    )
 
     # Current disabled-state metadata. AutomationDisableEvent keeps history.
     disabled_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -207,6 +226,11 @@ class AutomationRun(Base):
     # local mode). Set immediately after `_start_bash` returns.
     bash_command_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
+    # How this run was created: manual, cron, event, or null for legacy rows.
+    trigger_source: Mapped[str | None] = mapped_column(
+        String(32), nullable=True, index=True
+    )
+
     # Event payload for event-triggered runs (JSON)
     # Contains the webhook payload that triggered this run.
     # For GitHub events: model_dump() of the parsed Pydantic event
@@ -247,6 +271,69 @@ class AutomationRun(Base):
         Index("ix_automation_runs_status", "status"),
         Index("ix_automation_runs_status_created_at", "status", "created_at"),
         Index("ix_automation_runs_status_timeout_at", "status", "timeout_at"),
+        Index("ix_automation_runs_status_trigger_source", "status", "trigger_source"),
+    )
+
+
+class AutomationDraft(Base):
+    """Editable automation setup state, including incomplete form drafts."""
+
+    __tablename__ = "automation_drafts"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(Uuid, nullable=False, index=True)
+    org_id: Mapped[uuid.UUID] = mapped_column(Uuid, nullable=False, index=True)
+
+    # Creation endpoint this draft body targets: /v1, /v1/preset/prompt, etc.
+    endpoint: Mapped[str] = mapped_column(String(64), nullable=False)
+    name: Mapped[str | None] = mapped_column(String(500), nullable=True)
+
+    # Partial request body owned by the setup UI. It may be incomplete and is
+    # only promoted to an Automation after full endpoint-schema validation.
+    draft_body: Mapped[dict[str, Any]] = mapped_column(
+        JSON, nullable=False, default=dict
+    )
+    validation_errors: Mapped[list[dict[str, Any]] | None] = mapped_column(
+        JSON, nullable=True
+    )
+    dispatchable: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+
+    source_automation_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("automations.id", ondelete="SET NULL"), nullable=True
+    )
+    materialized_automation_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("automations.id", ondelete="SET NULL"), nullable=True
+    )
+    last_test_run_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("automation_runs.id", ondelete="SET NULL"), nullable=True
+    )
+
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=text("CURRENT_TIMESTAMP"),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=text("CURRENT_TIMESTAMP"),
+        onupdate=utcnow,
+        nullable=False,
+    )
+
+    __table_args__ = (
+        Index("ix_automation_drafts_org_updated_at", "org_id", "updated_at"),
+        Index("ix_automation_drafts_org_deleted_at", "org_id", "deleted_at"),
+        Index("ix_automation_drafts_source_automation_id", "source_automation_id"),
+        Index(
+            "ix_automation_drafts_materialized_automation_id",
+            "materialized_automation_id",
+        ),
+        Index("ix_automation_drafts_last_test_run_id", "last_test_run_id"),
     )
 
 

--- a/openhands/automation/preset_router.py
+++ b/openhands/automation/preset_router.py
@@ -39,11 +39,18 @@ from openhands.automation.auth import (
 from openhands.automation.constants import MODEL_PROFILE_PATTERN
 from openhands.automation.db import get_session
 from openhands.automation.git_sync import mark_git_sync_dirty
-from openhands.automation.models import Automation, TarballUpload, UploadStatus
+from openhands.automation.models import (
+    Automation,
+    AutomationLifecycleStatus as ModelAutomationLifecycleStatus,
+    TarballUpload,
+    UploadStatus,
+)
 from openhands.automation.schemas import (
+    AutomationLifecycleStatus,
     AutomationResponse,
     TemplateProvenance,
     Trigger,
+    normalize_lifecycle_enabled,
 )
 from openhands.automation.storage import FileStore, ObjectNotFoundError, get_file_store
 from openhands.automation.telemetry import (
@@ -73,6 +80,23 @@ from openhands.workspace import RepoSource
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/preset", tags=["Presets"])
+
+
+def _model_lifecycle_status(
+    lifecycle_status: AutomationLifecycleStatus | str | None, enabled: bool
+) -> ModelAutomationLifecycleStatus:
+    if lifecycle_status is not None:
+        return ModelAutomationLifecycleStatus(str(lifecycle_status))
+    return (
+        ModelAutomationLifecycleStatus.ACTIVE
+        if enabled
+        else ModelAutomationLifecycleStatus.INACTIVE
+    )
+
+
+def _lifecycle_enabled(lifecycle_status: ModelAutomationLifecycleStatus) -> bool:
+    return lifecycle_status == ModelAutomationLifecycleStatus.ACTIVE
+
 
 _require_manage_automations = require_permission("manage_automations")
 
@@ -202,6 +226,13 @@ class CreatePromptAutomationRequest(BaseModel):
         default=True,
         description="Whether the automation starts enabled.",
     )
+    lifecycle_status: AutomationLifecycleStatus | None = Field(
+        default=None,
+        description=(
+            "First-class lifecycle state. DRAFT/INACTIVE rows are not "
+            "triggered automatically."
+        ),
+    )
 
     @field_validator("timeout")
     @classmethod
@@ -212,6 +243,7 @@ class CreatePromptAutomationRequest(BaseModel):
     @classmethod
     def normalize_repos(cls, data: Any) -> Any:
         """Normalize repos to always be a list if provided."""
+        data = normalize_lifecycle_enabled(data)
         if isinstance(data, dict) and "repos" in data and data["repos"] is not None:
             repos = data["repos"]
             if isinstance(repos, (str, dict)):
@@ -482,6 +514,7 @@ async def create_automation_from_prompt(
             return AutomationResponse.model_validate(existing)
 
     model = resolve_model_profile_for_user(body.model, user)
+    lifecycle_status = _model_lifecycle_status(body.lifecycle_status, body.enabled)
 
     # 1. Generate tarball with SDK code, prompt, and optional repos config
     tarball_content = _generate_tarball(body.prompt, repos=body.repos)
@@ -551,7 +584,8 @@ async def create_automation_from_prompt(
             entrypoint=_get_preset_entrypoint(),
             timeout=default_automation_timeout(body.timeout),
             keep_alive=body.keep_alive,
-            enabled=body.enabled,
+            enabled=_lifecycle_enabled(lifecycle_status),
+            lifecycle_status=lifecycle_status,
             telemetry_distinct_id=get_request_telemetry_context(
                 request
             ).frontend_distinct_id,
@@ -706,6 +740,13 @@ class CreatePluginAutomationRequest(BaseModel):
         default=True,
         description="Whether the automation starts enabled.",
     )
+    lifecycle_status: AutomationLifecycleStatus | None = Field(
+        default=None,
+        description=(
+            "First-class lifecycle state. DRAFT/INACTIVE rows are not "
+            "triggered automatically."
+        ),
+    )
 
     @field_validator("timeout")
     @classmethod
@@ -716,6 +757,7 @@ class CreatePluginAutomationRequest(BaseModel):
     @classmethod
     def normalize_plugins_and_repos(cls, data: dict) -> dict:  # type: ignore[type-arg]
         """Normalize plugins and repos to always be lists."""
+        data = normalize_lifecycle_enabled(data)
         if isinstance(data, dict):
             # Normalize plugins
             if "plugins" in data and data["plugins"] is not None:
@@ -892,6 +934,7 @@ async def create_automation_from_plugin(
             return AutomationResponse.model_validate(existing)
 
     model = resolve_model_profile_for_user(body.model, user)
+    lifecycle_status = _model_lifecycle_status(body.lifecycle_status, body.enabled)
     variants = _resolve_experiment_variant_models(
         body.variants, user, default_model=model
     )
@@ -984,7 +1027,8 @@ async def create_automation_from_plugin(
             entrypoint=_get_preset_entrypoint(),
             timeout=default_automation_timeout(body.timeout),
             keep_alive=body.keep_alive,
-            enabled=body.enabled,
+            enabled=_lifecycle_enabled(lifecycle_status),
+            lifecycle_status=lifecycle_status,
             telemetry_distinct_id=get_request_telemetry_context(
                 request
             ).frontend_distinct_id,

--- a/openhands/automation/preset_router.py
+++ b/openhands/automation/preset_router.py
@@ -41,16 +41,16 @@ from openhands.automation.db import get_session
 from openhands.automation.git_sync import mark_git_sync_dirty
 from openhands.automation.models import (
     Automation,
-    AutomationLifecycleStatus as ModelAutomationLifecycleStatus,
+    AutomationState as ModelAutomationState,
     TarballUpload,
     UploadStatus,
 )
 from openhands.automation.schemas import (
-    AutomationLifecycleStatus,
     AutomationResponse,
+    AutomationState,
     TemplateProvenance,
     Trigger,
-    normalize_lifecycle_enabled,
+    normalize_automation_state_enabled,
 )
 from openhands.automation.storage import FileStore, ObjectNotFoundError, get_file_store
 from openhands.automation.telemetry import (
@@ -82,20 +82,16 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1/preset", tags=["Presets"])
 
 
-def _model_lifecycle_status(
-    lifecycle_status: AutomationLifecycleStatus | str | None, enabled: bool
-) -> ModelAutomationLifecycleStatus:
+def _model_automation_state(
+    lifecycle_status: AutomationState | str | None, enabled: bool
+) -> ModelAutomationState:
     if lifecycle_status is not None:
-        return ModelAutomationLifecycleStatus(str(lifecycle_status))
-    return (
-        ModelAutomationLifecycleStatus.ACTIVE
-        if enabled
-        else ModelAutomationLifecycleStatus.INACTIVE
-    )
+        return ModelAutomationState(str(lifecycle_status))
+    return ModelAutomationState.ACTIVE if enabled else ModelAutomationState.INACTIVE
 
 
-def _lifecycle_enabled(lifecycle_status: ModelAutomationLifecycleStatus) -> bool:
-    return lifecycle_status == ModelAutomationLifecycleStatus.ACTIVE
+def _automation_state_enabled(lifecycle_status: ModelAutomationState) -> bool:
+    return lifecycle_status == ModelAutomationState.ACTIVE
 
 
 _require_manage_automations = require_permission("manage_automations")
@@ -226,10 +222,10 @@ class CreatePromptAutomationRequest(BaseModel):
         default=True,
         description="Whether the automation starts enabled.",
     )
-    lifecycle_status: AutomationLifecycleStatus | None = Field(
+    lifecycle_status: AutomationState | None = Field(
         default=None,
         description=(
-            "First-class lifecycle state. DRAFT/INACTIVE rows are not "
+            "First-class automation state. DRAFT/INACTIVE rows are not "
             "triggered automatically."
         ),
     )
@@ -243,7 +239,7 @@ class CreatePromptAutomationRequest(BaseModel):
     @classmethod
     def normalize_repos(cls, data: Any) -> Any:
         """Normalize repos to always be a list if provided."""
-        data = normalize_lifecycle_enabled(data)
+        data = normalize_automation_state_enabled(data)
         if isinstance(data, dict) and "repos" in data and data["repos"] is not None:
             repos = data["repos"]
             if isinstance(repos, (str, dict)):
@@ -514,7 +510,7 @@ async def create_automation_from_prompt(
             return AutomationResponse.model_validate(existing)
 
     model = resolve_model_profile_for_user(body.model, user)
-    lifecycle_status = _model_lifecycle_status(body.lifecycle_status, body.enabled)
+    lifecycle_status = _model_automation_state(body.lifecycle_status, body.enabled)
 
     # 1. Generate tarball with SDK code, prompt, and optional repos config
     tarball_content = _generate_tarball(body.prompt, repos=body.repos)
@@ -584,7 +580,7 @@ async def create_automation_from_prompt(
             entrypoint=_get_preset_entrypoint(),
             timeout=default_automation_timeout(body.timeout),
             keep_alive=body.keep_alive,
-            enabled=_lifecycle_enabled(lifecycle_status),
+            enabled=_automation_state_enabled(lifecycle_status),
             lifecycle_status=lifecycle_status,
             telemetry_distinct_id=get_request_telemetry_context(
                 request
@@ -740,10 +736,10 @@ class CreatePluginAutomationRequest(BaseModel):
         default=True,
         description="Whether the automation starts enabled.",
     )
-    lifecycle_status: AutomationLifecycleStatus | None = Field(
+    lifecycle_status: AutomationState | None = Field(
         default=None,
         description=(
-            "First-class lifecycle state. DRAFT/INACTIVE rows are not "
+            "First-class automation state. DRAFT/INACTIVE rows are not "
             "triggered automatically."
         ),
     )
@@ -757,7 +753,7 @@ class CreatePluginAutomationRequest(BaseModel):
     @classmethod
     def normalize_plugins_and_repos(cls, data: dict) -> dict:  # type: ignore[type-arg]
         """Normalize plugins and repos to always be lists."""
-        data = normalize_lifecycle_enabled(data)
+        data = normalize_automation_state_enabled(data)
         if isinstance(data, dict):
             # Normalize plugins
             if "plugins" in data and data["plugins"] is not None:
@@ -934,7 +930,7 @@ async def create_automation_from_plugin(
             return AutomationResponse.model_validate(existing)
 
     model = resolve_model_profile_for_user(body.model, user)
-    lifecycle_status = _model_lifecycle_status(body.lifecycle_status, body.enabled)
+    lifecycle_status = _model_automation_state(body.lifecycle_status, body.enabled)
     variants = _resolve_experiment_variant_models(
         body.variants, user, default_model=model
     )
@@ -1027,7 +1023,7 @@ async def create_automation_from_plugin(
             entrypoint=_get_preset_entrypoint(),
             timeout=default_automation_timeout(body.timeout),
             keep_alive=body.keep_alive,
-            enabled=_lifecycle_enabled(lifecycle_status),
+            enabled=_automation_state_enabled(lifecycle_status),
             lifecycle_status=lifecycle_status,
             telemetry_distinct_id=get_request_telemetry_context(
                 request

--- a/openhands/automation/router.py
+++ b/openhands/automation/router.py
@@ -28,18 +28,18 @@ from openhands.automation.git_sync import mark_git_sync_dirty
 from openhands.automation.models import (
     Automation,
     AutomationDisableEvent,
-    AutomationLifecycleStatus as ModelAutomationLifecycleStatus,
     AutomationRun,
     AutomationRunStatus,
+    AutomationState as ModelAutomationState,
     TarballUpload,
 )
 from openhands.automation.preset_router import regenerate_preset_prompt_tarball
 from openhands.automation.schemas import (
-    AutomationLifecycleStatus,
     AutomationListResponse,
     AutomationResponse,
     AutomationRunListResponse,
     AutomationRunResponse,
+    AutomationState,
     CreateAutomationRequest,
     RunCompleteRequest,
     RunPhaseRequest,
@@ -87,22 +87,18 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1", tags=["Automations"])
 
 
-def _model_lifecycle_status(
-    lifecycle_status: AutomationLifecycleStatus | str | None, enabled: bool
-) -> ModelAutomationLifecycleStatus:
+def _model_automation_state(
+    lifecycle_status: AutomationState | str | None, enabled: bool
+) -> ModelAutomationState:
     if lifecycle_status is not None:
-        return ModelAutomationLifecycleStatus(str(lifecycle_status))
-    return (
-        ModelAutomationLifecycleStatus.ACTIVE
-        if enabled
-        else ModelAutomationLifecycleStatus.INACTIVE
-    )
+        return ModelAutomationState(str(lifecycle_status))
+    return ModelAutomationState.ACTIVE if enabled else ModelAutomationState.INACTIVE
 
 
-def _lifecycle_enabled(
-    lifecycle_status: ModelAutomationLifecycleStatus,
+def _automation_state_enabled(
+    lifecycle_status: ModelAutomationState,
 ) -> bool:
-    return lifecycle_status == ModelAutomationLifecycleStatus.ACTIVE
+    return lifecycle_status == ModelAutomationState.ACTIVE
 
 
 _require_view_automations = require_permission("view_automations")
@@ -178,7 +174,7 @@ async def create_automation(
     if body.template is not None:
         preset_metadata = {"template": body.template.model_dump(exclude_none=True)}
 
-    lifecycle_status = _model_lifecycle_status(body.lifecycle_status, body.enabled)
+    lifecycle_status = _model_automation_state(body.lifecycle_status, body.enabled)
 
     auto = Automation(
         user_id=user.user_id,
@@ -192,7 +188,7 @@ async def create_automation(
         entrypoint=body.entrypoint,
         timeout=default_automation_timeout(body.timeout),
         keep_alive=body.keep_alive,
-        enabled=_lifecycle_enabled(lifecycle_status),
+        enabled=_automation_state_enabled(lifecycle_status),
         lifecycle_status=lifecycle_status,
         telemetry_distinct_id=get_request_telemetry_context(
             request
@@ -281,13 +277,13 @@ async def update_automation(
 
     requested_lifecycle = update_data.pop("lifecycle_status", None)
     if requested_lifecycle is not None:
-        lifecycle_status = _model_lifecycle_status(
+        lifecycle_status = _model_automation_state(
             requested_lifecycle, update_data.get("enabled", auto.enabled)
         )
         update_data["lifecycle_status"] = lifecycle_status
-        update_data["enabled"] = _lifecycle_enabled(lifecycle_status)
+        update_data["enabled"] = _automation_state_enabled(lifecycle_status)
     elif "enabled" in update_data:
-        update_data["lifecycle_status"] = _model_lifecycle_status(
+        update_data["lifecycle_status"] = _model_automation_state(
             None, update_data["enabled"]
         )
 
@@ -299,16 +295,13 @@ async def update_automation(
         update_data["disabled_at"] = None
     elif update_data.get("enabled") is False:
         lifecycle_status = update_data.get("lifecycle_status")
-        is_manual_inactive = (
-            lifecycle_status == ModelAutomationLifecycleStatus.INACTIVE
-            or (
-                lifecycle_status is None
-                and auto.lifecycle_status != ModelAutomationLifecycleStatus.DRAFT
-            )
+        is_manual_inactive = lifecycle_status == ModelAutomationState.INACTIVE or (
+            lifecycle_status is None
+            and auto.lifecycle_status != ModelAutomationState.DRAFT
         )
         skip_pending_reason = (
             "Automation moved to draft by user"
-            if lifecycle_status == ModelAutomationLifecycleStatus.DRAFT
+            if lifecycle_status == ModelAutomationState.DRAFT
             else "Automation disabled by user"
         )
         if auto.enabled and is_manual_inactive:
@@ -388,7 +381,7 @@ async def delete_automation(
     await _assert_can_manage(auto, user)
     was_enabled = auto.enabled
     auto.enabled = False
-    auto.lifecycle_status = ModelAutomationLifecycleStatus.INACTIVE
+    auto.lifecycle_status = ModelAutomationState.INACTIVE
     deleted_at = utcnow()
     auto.deleted_at = deleted_at
     if was_enabled:

--- a/openhands/automation/router.py
+++ b/openhands/automation/router.py
@@ -28,12 +28,14 @@ from openhands.automation.git_sync import mark_git_sync_dirty
 from openhands.automation.models import (
     Automation,
     AutomationDisableEvent,
+    AutomationLifecycleStatus as ModelAutomationLifecycleStatus,
     AutomationRun,
     AutomationRunStatus,
     TarballUpload,
 )
 from openhands.automation.preset_router import regenerate_preset_prompt_tarball
 from openhands.automation.schemas import (
+    AutomationLifecycleStatus,
     AutomationListResponse,
     AutomationResponse,
     AutomationRunListResponse,
@@ -83,6 +85,25 @@ from openhands.automation.utils.unhealthy import maybe_disable_unhealthy_automat
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1", tags=["Automations"])
+
+
+def _model_lifecycle_status(
+    lifecycle_status: AutomationLifecycleStatus | str | None, enabled: bool
+) -> ModelAutomationLifecycleStatus:
+    if lifecycle_status is not None:
+        return ModelAutomationLifecycleStatus(str(lifecycle_status))
+    return (
+        ModelAutomationLifecycleStatus.ACTIVE
+        if enabled
+        else ModelAutomationLifecycleStatus.INACTIVE
+    )
+
+
+def _lifecycle_enabled(
+    lifecycle_status: ModelAutomationLifecycleStatus,
+) -> bool:
+    return lifecycle_status == ModelAutomationLifecycleStatus.ACTIVE
+
 
 _require_view_automations = require_permission("view_automations")
 _require_manage_automations = require_permission("manage_automations")
@@ -157,6 +178,8 @@ async def create_automation(
     if body.template is not None:
         preset_metadata = {"template": body.template.model_dump(exclude_none=True)}
 
+    lifecycle_status = _model_lifecycle_status(body.lifecycle_status, body.enabled)
+
     auto = Automation(
         user_id=user.user_id,
         org_id=user.org_id,
@@ -169,6 +192,8 @@ async def create_automation(
         entrypoint=body.entrypoint,
         timeout=default_automation_timeout(body.timeout),
         keep_alive=body.keep_alive,
+        enabled=_lifecycle_enabled(lifecycle_status),
+        lifecycle_status=lifecycle_status,
         telemetry_distinct_id=get_request_telemetry_context(
             request
         ).frontend_distinct_id,
@@ -254,6 +279,18 @@ async def update_automation(
     if body.trigger is not None:
         update_data["trigger"] = body.trigger.model_dump()
 
+    requested_lifecycle = update_data.pop("lifecycle_status", None)
+    if requested_lifecycle is not None:
+        lifecycle_status = _model_lifecycle_status(
+            requested_lifecycle, update_data.get("enabled", auto.enabled)
+        )
+        update_data["lifecycle_status"] = lifecycle_status
+        update_data["enabled"] = _lifecycle_enabled(lifecycle_status)
+    elif "enabled" in update_data:
+        update_data["lifecycle_status"] = _model_lifecycle_status(
+            None, update_data["enabled"]
+        )
+
     disable_event: AutomationDisableEvent | None = None
     skip_pending_reason: str | None = None
     if update_data.get("enabled") is True:
@@ -261,8 +298,20 @@ async def update_automation(
         update_data["disabled_detail"] = None
         update_data["disabled_at"] = None
     elif update_data.get("enabled") is False:
-        if auto.enabled:
-            skip_pending_reason = "Automation disabled by user"
+        lifecycle_status = update_data.get("lifecycle_status")
+        is_manual_inactive = (
+            lifecycle_status == ModelAutomationLifecycleStatus.INACTIVE
+            or (
+                lifecycle_status is None
+                and auto.lifecycle_status != ModelAutomationLifecycleStatus.DRAFT
+            )
+        )
+        skip_pending_reason = (
+            "Automation moved to draft by user"
+            if lifecycle_status == ModelAutomationLifecycleStatus.DRAFT
+            else "Automation disabled by user"
+        )
+        if auto.enabled and is_manual_inactive:
             disabled_at = utcnow()
             disabled_detail = {"reason": "manual", "source": "user"}
             update_data["disabled_reason"] = "manual"
@@ -339,6 +388,7 @@ async def delete_automation(
     await _assert_can_manage(auto, user)
     was_enabled = auto.enabled
     auto.enabled = False
+    auto.lifecycle_status = ModelAutomationLifecycleStatus.INACTIVE
     deleted_at = utcnow()
     auto.deleted_at = deleted_at
     if was_enabled:
@@ -360,6 +410,7 @@ async def delete_automation(
         reason="Automation deleted by user",
         disabled_detail=auto.disabled_detail,
         completed_at=deleted_at,
+        include_manual=True,
     )
     await session.flush()
     await mark_git_sync_dirty(session, auto)
@@ -455,22 +506,13 @@ async def dispatch_automation(
     """
     auto = await _get_org_automation(session, automation_id, user.org_id)
     await _assert_can_manage(auto, user)
-    if not auto.enabled:
-        raise HTTPException(
-            status.HTTP_409_CONFLICT,
-            detail={
-                "message": "Automation is disabled",
-                "disabled_reason": auto.disabled_reason,
-                "disabled_detail": auto.disabled_detail,
-            },
-        )
-
     run = await create_pending_run(
         session,
         auto,
         telemetry_distinct_id=get_request_telemetry_context(
             request
         ).frontend_distinct_id,
+        trigger_source="manual",
     )
     await session.flush()
     await session.refresh(run)

--- a/openhands/automation/scheduler.py
+++ b/openhands/automation/scheduler.py
@@ -21,8 +21,8 @@ from openhands.automation.db import using_sqlite
 from openhands.automation.git_sync import mark_git_sync_dirty
 from openhands.automation.models import (
     Automation,
-    AutomationLifecycleStatus,
     AutomationRun,
+    AutomationState,
 )
 from openhands.automation.telemetry import capture_automation_event
 from openhands.automation.utils import get_next_fire_time, is_automation_due, utcnow
@@ -62,7 +62,7 @@ def _disable_invalid_cron_automation(
     error: BaseException,
 ) -> None:
     automation.enabled = False
-    automation.lifecycle_status = AutomationLifecycleStatus.INACTIVE
+    automation.lifecycle_status = AutomationState.INACTIVE
     logger.error(
         "Disabling automation with invalid cron trigger: %s",
         reason,
@@ -132,7 +132,7 @@ async def _fetch_enabled_automations(
         select(Automation)
         .where(
             Automation.enabled.is_(True),
-            Automation.lifecycle_status == AutomationLifecycleStatus.ACTIVE,
+            Automation.lifecycle_status == AutomationState.ACTIVE,
             Automation.deleted_at.is_(None),
             (Automation.last_polled_at.is_(None))
             | (Automation.last_polled_at < poll_threshold),

--- a/openhands/automation/scheduler.py
+++ b/openhands/automation/scheduler.py
@@ -19,7 +19,11 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from openhands.automation.db import using_sqlite
 from openhands.automation.git_sync import mark_git_sync_dirty
-from openhands.automation.models import Automation, AutomationRun
+from openhands.automation.models import (
+    Automation,
+    AutomationLifecycleStatus,
+    AutomationRun,
+)
 from openhands.automation.telemetry import capture_automation_event
 from openhands.automation.utils import get_next_fire_time, is_automation_due, utcnow
 from openhands.automation.utils.run import create_pending_run
@@ -58,6 +62,7 @@ def _disable_invalid_cron_automation(
     error: BaseException,
 ) -> None:
     automation.enabled = False
+    automation.lifecycle_status = AutomationLifecycleStatus.INACTIVE
     logger.error(
         "Disabling automation with invalid cron trigger: %s",
         reason,
@@ -127,6 +132,7 @@ async def _fetch_enabled_automations(
         select(Automation)
         .where(
             Automation.enabled.is_(True),
+            Automation.lifecycle_status == AutomationLifecycleStatus.ACTIVE,
             Automation.deleted_at.is_(None),
             (Automation.last_polled_at.is_(None))
             | (Automation.last_polled_at < poll_threshold),
@@ -201,7 +207,9 @@ async def poll_and_schedule(
 
         for automation in due_automations:
             try:
-                run = await create_pending_run(session, automation)
+                run = await create_pending_run(
+                    session, automation, trigger_source="cron"
+                )
                 created_runs.append(run)
                 schedule_properties = {
                     "trigger_source": "cron",

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -6,7 +6,15 @@ import uuid
 from enum import StrEnum
 from typing import Annotated, Any, Final, Literal
 
-from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Discriminator,
+    Field,
+    Tag,
+    field_validator,
+    model_validator,
+)
 from pydantic.alias_generators import to_camel
 
 from openhands.automation.constants import MODEL_PROFILE_PATTERN
@@ -220,6 +228,41 @@ class RunStatus(StrEnum):
     SKIPPED = "SKIPPED"
 
 
+class AutomationLifecycleStatus(StrEnum):
+    """Lifecycle status of an automation definition."""
+
+    ACTIVE = "ACTIVE"
+    INACTIVE = "INACTIVE"
+    DRAFT = "DRAFT"
+
+
+DraftEndpoint = Literal["/v1", "/v1/preset/prompt", "/v1/preset/plugin"]
+
+
+def lifecycle_enabled(status: AutomationLifecycleStatus | str | None) -> bool:
+    if status is None:
+        return True
+    return AutomationLifecycleStatus(status) == AutomationLifecycleStatus.ACTIVE
+
+
+def normalize_lifecycle_enabled(data: Any) -> Any:
+    """Keep lifecycle_status and enabled compatible in request bodies."""
+    if not isinstance(data, dict):
+        return data
+    lifecycle = data.get("lifecycle_status")
+    if lifecycle is None:
+        return data
+    try:
+        expected_enabled = lifecycle_enabled(lifecycle)
+    except ValueError:
+        return data
+    if "enabled" in data and bool(data["enabled"]) != expected_enabled:
+        raise ValueError("enabled must be true only when lifecycle_status is ACTIVE")
+    data = dict(data)
+    data["enabled"] = expected_enabled
+    return data
+
+
 def validate_command_string(
     v: str | None, field_name: str, *, allow_none: bool = True
 ) -> str | None:
@@ -345,6 +388,20 @@ class CreateAutomationRequest(BaseModel):
             "completion (or after post-run callbacks, when configured)."
         ),
     )
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "Backward-compatible active flag; false creates INACTIVE unless "
+            "lifecycle_status is DRAFT."
+        ),
+    )
+    lifecycle_status: AutomationLifecycleStatus | None = Field(
+        default=None,
+        description=(
+            "First-class lifecycle state. DRAFT/INACTIVE rows are not "
+            "triggered automatically."
+        ),
+    )
     template: TemplateProvenance | None = Field(
         default=None,
         description=(
@@ -353,6 +410,11 @@ class CreateAutomationRequest(BaseModel):
             "template id is returned unchanged with HTTP 200."
         ),
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_lifecycle_enabled(cls, data: Any) -> Any:
+        return normalize_lifecycle_enabled(data)
 
     @field_validator("tarball_path")
     @classmethod
@@ -411,6 +473,12 @@ class UpdateAutomationRequest(BaseModel):
     )
     keep_alive: bool | None = Field(default=None)
     enabled: bool | None = None
+    lifecycle_status: AutomationLifecycleStatus | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_lifecycle_enabled(cls, data: Any) -> Any:
+        return normalize_lifecycle_enabled(data)
 
     @field_validator("tarball_path")
     @classmethod
@@ -738,6 +806,7 @@ class AutomationResponse(BaseModel):
     timeout: int | None
     keep_alive: bool | None
     enabled: bool
+    lifecycle_status: AutomationLifecycleStatus = AutomationLifecycleStatus.ACTIVE
     disabled_reason: str | None = None
     disabled_detail: dict[str, Any] | None = None
     disabled_at: UtcDatetime | None = None
@@ -750,6 +819,50 @@ class AutomationResponse(BaseModel):
 
 class AutomationListResponse(BaseModel):
     automations: list[AutomationResponse]
+    total: int
+
+
+class CreateAutomationDraftRequest(BaseModel):
+    """Create a server-backed automation setup draft."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    endpoint: DraftEndpoint
+    draft: dict[str, Any] = Field(default_factory=dict)
+    name: str | None = Field(default=None, min_length=1, max_length=500)
+    source_automation_id: uuid.UUID | None = None
+
+
+class UpdateAutomationDraftRequest(BaseModel):
+    """Partially update a server-backed automation setup draft."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    endpoint: DraftEndpoint | None = None
+    draft: dict[str, Any] | None = None
+    name: str | None = Field(default=None, min_length=1, max_length=500)
+
+
+class AutomationDraftResponse(BaseModel):
+    id: uuid.UUID
+    user_id: uuid.UUID
+    org_id: uuid.UUID
+    endpoint: DraftEndpoint
+    name: str | None
+    draft: dict[str, Any] = Field(validation_alias="draft_body")
+    validation_errors: list[dict[str, Any]] | None = None
+    dispatchable: bool
+    source_automation_id: uuid.UUID | None = None
+    materialized_automation_id: uuid.UUID | None = None
+    last_test_run_id: uuid.UUID | None = None
+    created_at: UtcDatetime
+    updated_at: UtcDatetime
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+
+class AutomationDraftListResponse(BaseModel):
+    drafts: list[AutomationDraftResponse]
     total: int
 
 
@@ -803,6 +916,7 @@ class AutomationRunResponse(BaseModel):
     id: uuid.UUID
     automation_id: uuid.UUID
     status: RunStatus
+    trigger_source: str | None = None
     error_detail: str | None
     status_detail: dict[str, Any] | None = None
     current_phase: str | None = None

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -228,8 +228,8 @@ class RunStatus(StrEnum):
     SKIPPED = "SKIPPED"
 
 
-class AutomationLifecycleStatus(StrEnum):
-    """Lifecycle status of an automation definition."""
+class AutomationState(StrEnum):
+    """State of an automation definition."""
 
     ACTIVE = "ACTIVE"
     INACTIVE = "INACTIVE"
@@ -239,21 +239,21 @@ class AutomationLifecycleStatus(StrEnum):
 DraftEndpoint = Literal["/v1", "/v1/preset/prompt", "/v1/preset/plugin"]
 
 
-def lifecycle_enabled(status: AutomationLifecycleStatus | str | None) -> bool:
+def automation_state_enabled(status: AutomationState | str | None) -> bool:
     if status is None:
         return True
-    return AutomationLifecycleStatus(status) == AutomationLifecycleStatus.ACTIVE
+    return AutomationState(status) == AutomationState.ACTIVE
 
 
-def normalize_lifecycle_enabled(data: Any) -> Any:
-    """Keep lifecycle_status and enabled compatible in request bodies."""
+def normalize_automation_state_enabled(data: Any) -> Any:
+    """Keep automation state and enabled compatible in request bodies."""
     if not isinstance(data, dict):
         return data
     lifecycle = data.get("lifecycle_status")
     if lifecycle is None:
         return data
     try:
-        expected_enabled = lifecycle_enabled(lifecycle)
+        expected_enabled = automation_state_enabled(lifecycle)
     except ValueError:
         return data
     if "enabled" in data and bool(data["enabled"]) != expected_enabled:
@@ -395,10 +395,10 @@ class CreateAutomationRequest(BaseModel):
             "lifecycle_status is DRAFT."
         ),
     )
-    lifecycle_status: AutomationLifecycleStatus | None = Field(
+    lifecycle_status: AutomationState | None = Field(
         default=None,
         description=(
-            "First-class lifecycle state. DRAFT/INACTIVE rows are not "
+            "First-class automation state. DRAFT/INACTIVE rows are not "
             "triggered automatically."
         ),
     )
@@ -413,8 +413,8 @@ class CreateAutomationRequest(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_lifecycle_enabled(cls, data: Any) -> Any:
-        return normalize_lifecycle_enabled(data)
+    def validate_automation_state_enabled(cls, data: Any) -> Any:
+        return normalize_automation_state_enabled(data)
 
     @field_validator("tarball_path")
     @classmethod
@@ -473,12 +473,12 @@ class UpdateAutomationRequest(BaseModel):
     )
     keep_alive: bool | None = Field(default=None)
     enabled: bool | None = None
-    lifecycle_status: AutomationLifecycleStatus | None = None
+    lifecycle_status: AutomationState | None = None
 
     @model_validator(mode="before")
     @classmethod
-    def validate_lifecycle_enabled(cls, data: Any) -> Any:
-        return normalize_lifecycle_enabled(data)
+    def validate_automation_state_enabled(cls, data: Any) -> Any:
+        return normalize_automation_state_enabled(data)
 
     @field_validator("tarball_path")
     @classmethod
@@ -806,7 +806,7 @@ class AutomationResponse(BaseModel):
     timeout: int | None
     keep_alive: bool | None
     enabled: bool
-    lifecycle_status: AutomationLifecycleStatus = AutomationLifecycleStatus.ACTIVE
+    lifecycle_status: AutomationState = AutomationState.ACTIVE
     disabled_reason: str | None = None
     disabled_detail: dict[str, Any] | None = None
     disabled_at: UtcDatetime | None = None

--- a/openhands/automation/utils/run.py
+++ b/openhands/automation/utils/run.py
@@ -12,6 +12,7 @@ from openhands.automation.git_sync import mark_git_sync_dirty
 from openhands.automation.models import (
     Automation,
     AutomationDisableEvent,
+    AutomationLifecycleStatus,
     AutomationRun,
     AutomationRunStatus,
 )
@@ -70,6 +71,7 @@ async def disable_automation(
                 )
                 .values(
                     enabled=False,
+                    lifecycle_status=AutomationLifecycleStatus.INACTIVE,
                     disabled_reason=reason,
                     disabled_detail=disabled_detail,
                     disabled_at=disabled_at,
@@ -129,6 +131,7 @@ async def skip_pending_runs_for_disabled_automation(
     reason: str,
     disabled_detail: dict | None = None,
     completed_at: datetime | None = None,
+    include_manual: bool = False,
 ) -> int:
     """Mark accepted-but-not-dispatched runs terminal when automation is disabled."""
     completed_at = completed_at or utcnow()
@@ -144,12 +147,19 @@ async def skip_pending_runs_for_disabled_automation(
     if disabled_detail is not None:
         status_detail["disabled_detail"] = disabled_detail
 
+    filters = [
+        AutomationRun.automation_id == automation_id,
+        AutomationRun.status == AutomationRunStatus.PENDING,
+    ]
+    if not include_manual:
+        filters.append(
+            (AutomationRun.trigger_source.is_(None))
+            | (AutomationRun.trigger_source != "manual")
+        )
+
     result: CursorResult = await session.execute(  # type: ignore[assignment]
         update(AutomationRun)
-        .where(
-            AutomationRun.automation_id == automation_id,
-            AutomationRun.status == AutomationRunStatus.PENDING,
-        )
+        .where(*filters)
         .values(
             status=AutomationRunStatus.SKIPPED,
             completed_at=completed_at,
@@ -165,6 +175,7 @@ async def create_pending_run(
     automation: Automation,
     *,
     telemetry_distinct_id: str | None = None,
+    trigger_source: str | None = None,
 ) -> AutomationRun:
     """Create a PENDING automation run for dispatch.
 
@@ -184,6 +195,7 @@ async def create_pending_run(
         id=uuid.uuid4(),
         automation_id=automation.id,
         status=AutomationRunStatus.PENDING,
+        trigger_source=trigger_source,
         telemetry_distinct_id=(
             telemetry_distinct_id or automation.telemetry_distinct_id
         ),

--- a/openhands/automation/utils/run.py
+++ b/openhands/automation/utils/run.py
@@ -12,9 +12,9 @@ from openhands.automation.git_sync import mark_git_sync_dirty
 from openhands.automation.models import (
     Automation,
     AutomationDisableEvent,
-    AutomationLifecycleStatus,
     AutomationRun,
     AutomationRunStatus,
+    AutomationState,
 )
 from openhands.automation.telemetry import capture_automation_event
 from openhands.automation.utils.time import utcnow
@@ -71,7 +71,7 @@ async def disable_automation(
                 )
                 .values(
                     enabled=False,
-                    lifecycle_status=AutomationLifecycleStatus.INACTIVE,
+                    lifecycle_status=AutomationState.INACTIVE,
                     disabled_reason=reason,
                     disabled_detail=disabled_detail,
                     disabled_at=disabled_at,

--- a/openhands/automation/utils/unhealthy.py
+++ b/openhands/automation/utils/unhealthy.py
@@ -29,6 +29,7 @@ from openhands.automation.git_sync import mark_git_sync_dirty
 from openhands.automation.models import (
     Automation,
     AutomationDisableEvent,
+    AutomationLifecycleStatus,
     AutomationRun,
     AutomationRunStatus,
 )
@@ -240,6 +241,7 @@ async def _apply_disable(
         )
         .values(
             enabled=False,
+            lifecycle_status=AutomationLifecycleStatus.INACTIVE,
             disabled_reason=cause.reason,
             disabled_detail=disabled_detail,
             disabled_at=disabled_at,

--- a/openhands/automation/utils/unhealthy.py
+++ b/openhands/automation/utils/unhealthy.py
@@ -29,9 +29,9 @@ from openhands.automation.git_sync import mark_git_sync_dirty
 from openhands.automation.models import (
     Automation,
     AutomationDisableEvent,
-    AutomationLifecycleStatus,
     AutomationRun,
     AutomationRunStatus,
+    AutomationState,
 )
 from openhands.automation.utils.run import skip_pending_runs_for_disabled_automation
 from openhands.automation.utils.time import ensure_utc, utcnow
@@ -241,7 +241,7 @@ async def _apply_disable(
         )
         .values(
             enabled=False,
-            lifecycle_status=AutomationLifecycleStatus.INACTIVE,
+            lifecycle_status=AutomationState.INACTIVE,
             disabled_reason=cause.reason,
             disabled_detail=disabled_detail,
             disabled_at=disabled_at,

--- a/openhands/automation/utils/webhook.py
+++ b/openhands/automation/utils/webhook.py
@@ -17,9 +17,9 @@ from openhands.automation.config import get_settings
 from openhands.automation.db import using_sqlite
 from openhands.automation.models import (
     Automation,
-    AutomationLifecycleStatus,
     AutomationRun,
     AutomationRunStatus,
+    AutomationState,
     CustomWebhook,
 )
 from openhands.automation.providers import (
@@ -135,7 +135,7 @@ async def get_event_automations(
     base_filters = [
         Automation.org_id == org_id,
         Automation.enabled == True,  # noqa: E712
-        Automation.lifecycle_status == AutomationLifecycleStatus.ACTIVE,
+        Automation.lifecycle_status == AutomationState.ACTIVE,
         Automation.deleted_at.is_(None),
     ]
 
@@ -197,7 +197,7 @@ async def get_requested_event_types(
 
     base_filters = [
         Automation.enabled == True,  # noqa: E712
-        Automation.lifecycle_status == AutomationLifecycleStatus.ACTIVE,
+        Automation.lifecycle_status == AutomationState.ACTIVE,
         Automation.deleted_at.is_(None),
     ]
 

--- a/openhands/automation/utils/webhook.py
+++ b/openhands/automation/utils/webhook.py
@@ -17,6 +17,7 @@ from openhands.automation.config import get_settings
 from openhands.automation.db import using_sqlite
 from openhands.automation.models import (
     Automation,
+    AutomationLifecycleStatus,
     AutomationRun,
     AutomationRunStatus,
     CustomWebhook,
@@ -134,6 +135,7 @@ async def get_event_automations(
     base_filters = [
         Automation.org_id == org_id,
         Automation.enabled == True,  # noqa: E712
+        Automation.lifecycle_status == AutomationLifecycleStatus.ACTIVE,
         Automation.deleted_at.is_(None),
     ]
 
@@ -195,6 +197,7 @@ async def get_requested_event_types(
 
     base_filters = [
         Automation.enabled == True,  # noqa: E712
+        Automation.lifecycle_status == AutomationLifecycleStatus.ACTIVE,
         Automation.deleted_at.is_(None),
     ]
 
@@ -258,6 +261,7 @@ async def create_automation_run(
         id=uuid.uuid4(),
         automation_id=automation.id,
         status=AutomationRunStatus.PENDING,
+        trigger_source="event",
         event_payload=event_payload,
         telemetry_distinct_id=automation.telemetry_distinct_id,
     )

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -24,9 +24,9 @@ from openhands.automation.dispatcher import (
 from openhands.automation.exceptions import ConcurrencyLimitReachedError
 from openhands.automation.models import (
     Automation,
-    AutomationLifecycleStatus,
     AutomationRun,
     AutomationRunStatus,
+    AutomationState,
 )
 from openhands.automation.utils import utcnow
 from openhands.automation.utils.run import (
@@ -567,7 +567,7 @@ class TestDispatchPendingRuns:
                 tarball_path="s3://bucket/code.tar.gz",
                 entrypoint="uv run main.py",
                 enabled=False,
-                lifecycle_status=AutomationLifecycleStatus.INACTIVE,
+                lifecycle_status=AutomationState.INACTIVE,
             )
             session.add(automation)
             await session.commit()

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -22,7 +22,12 @@ from openhands.automation.dispatcher import (
     dispatcher_loop,
 )
 from openhands.automation.exceptions import ConcurrencyLimitReachedError
-from openhands.automation.models import Automation, AutomationRun, AutomationRunStatus
+from openhands.automation.models import (
+    Automation,
+    AutomationLifecycleStatus,
+    AutomationRun,
+    AutomationRunStatus,
+)
 from openhands.automation.utils import utcnow
 from openhands.automation.utils.run import (
     mark_run_status,
@@ -547,6 +552,41 @@ class TestDispatchPendingRuns:
 
         assert dispatched == []
         mock_execute.assert_not_awaited()
+
+    @patch("openhands.automation.dispatcher._execute_run_safe", new_callable=AsyncMock)
+    async def test_dispatches_manual_run_for_disabled_automation(
+        self, mock_execute, async_session_factory, mock_settings, mock_client
+    ):
+        """Manual pending runs are dispatched even when automation is inactive."""
+        async with async_session_factory() as session:
+            automation = Automation(
+                user_id=TEST_USER_ID,
+                org_id=TEST_ORG_ID,
+                name="Test",
+                trigger={"type": "cron", "schedule": "* * * * *", "timezone": "UTC"},
+                tarball_path="s3://bucket/code.tar.gz",
+                entrypoint="uv run main.py",
+                enabled=False,
+                lifecycle_status=AutomationLifecycleStatus.INACTIVE,
+            )
+            session.add(automation)
+            await session.commit()
+
+            run = AutomationRun(
+                automation_id=automation.id,
+                status=AutomationRunStatus.PENDING,
+                trigger_source="manual",
+            )
+            session.add(run)
+            await session.commit()
+            run_id = run.id
+
+        dispatched = await dispatch_pending_runs(
+            async_session_factory, mock_settings, mock_client
+        )
+
+        assert [run.id for run in dispatched] == [run_id]
+        mock_execute.assert_awaited_once()
 
     @patch("openhands.automation.dispatcher._execute_run_safe", new_callable=AsyncMock)
     async def test_respects_batch_size(

--- a/tests/test_draft_router.py
+++ b/tests/test_draft_router.py
@@ -1,0 +1,163 @@
+"""Tests for server-backed automation drafts."""
+
+import uuid
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openhands.automation.app import app
+from openhands.automation.models import (
+    Automation,
+    AutomationDraft,
+    AutomationLifecycleStatus,
+    AutomationRun,
+)
+from openhands.automation.storage import get_file_store
+
+
+TEST_ORG_ID = uuid.UUID("87654321-4321-8765-4321-876543218765")
+
+
+@pytest.fixture
+async def draft_file_store():
+    store = MagicMock()
+    store._storage = {}
+
+    async def write_stream(
+        path: str,
+        stream: AsyncIterator[bytes],
+        max_size: int | None = None,
+        content_type: str = "application/octet-stream",
+    ) -> int:
+        content = b""
+        async for chunk in stream:
+            content += chunk
+        store._storage[path] = content
+        return len(content)
+
+    store.write_stream = AsyncMock(side_effect=write_stream)
+    store.delete = MagicMock(side_effect=lambda path: store._storage.pop(path, None))
+    app.dependency_overrides[get_file_store] = lambda: store
+    yield store
+    app.dependency_overrides.pop(get_file_store, None)
+
+
+async def test_create_incomplete_draft_saves_partial_body(async_client, async_session):
+    response = await async_client.post(
+        "/api/automation/v1/drafts",
+        json={
+            "endpoint": "/v1/preset/prompt",
+            "draft": {"name": "Half-filled draft"},
+        },
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["draft"] == {"name": "Half-filled draft"}
+    assert data["name"] == "Half-filled draft"
+    assert data["dispatchable"] is False
+    assert data["validation_errors"]
+
+    draft = await async_session.get(AutomationDraft, uuid.UUID(data["id"]))
+    assert draft is not None
+    assert draft.materialized_automation_id is None
+
+
+async def test_raw_draft_with_missing_upload_is_not_dispatchable(
+    async_client, async_session
+):
+    missing_upload = uuid.uuid4()
+    response = await async_client.post(
+        "/api/automation/v1/drafts",
+        json={
+            "endpoint": "/v1",
+            "draft": {
+                "name": "Raw draft",
+                "trigger": {"type": "cron", "schedule": "0 9 * * *"},
+                "tarball_path": f"oh-internal://uploads/{missing_upload}",
+                "entrypoint": "python main.py",
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["dispatchable"] is False
+    assert data["validation_errors"] == [
+        {
+            "field": "tarball_path",
+            "code": "tarball_path_404",
+            "message": "Upload not found",
+        }
+    ]
+
+    draft = await async_session.get(AutomationDraft, uuid.UUID(data["id"]))
+    assert draft is not None
+    assert draft.materialized_automation_id is None
+
+
+async def test_incomplete_draft_dispatch_returns_validation_errors(
+    async_client, async_session
+):
+    created = await async_client.post(
+        "/api/automation/v1/drafts",
+        json={"endpoint": "/v1/preset/prompt", "draft": {"name": "Incomplete"}},
+    )
+    draft_id = created.json()["id"]
+
+    response = await async_client.post(f"/api/automation/v1/drafts/{draft_id}/dispatch")
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail["message"] == "Draft is not dispatchable"
+    assert detail["errors"]
+    draft = await async_session.get(AutomationDraft, uuid.UUID(draft_id))
+    assert draft is not None
+    assert draft.materialized_automation_id is None
+
+
+async def test_dispatchable_prompt_draft_materializes_disabled_draft_and_manual_run(
+    async_client, async_session, draft_file_store
+):
+    created = await async_client.post(
+        "/api/automation/v1/drafts",
+        json={
+            "endpoint": "/v1/preset/prompt",
+            "draft": {
+                "name": "Runnable draft",
+                "prompt": "Write a short greeting.",
+                "trigger": {"type": "cron", "schedule": "0 9 * * *"},
+            },
+        },
+    )
+    assert created.status_code == 201
+    assert created.json()["dispatchable"] is True
+
+    response = await async_client.post(
+        f"/api/automation/v1/drafts/{created.json()['id']}/dispatch",
+        headers={"X-OpenHands-Telemetry-Distinct-Id": "ph-draft-test"},
+    )
+
+    assert response.status_code == 201
+    run_data = response.json()
+    assert run_data["status"] == "PENDING"
+    assert run_data["trigger_source"] == "manual"
+
+    draft = await async_session.get(AutomationDraft, uuid.UUID(created.json()["id"]))
+    assert draft is not None
+    assert draft.last_test_run_id == uuid.UUID(run_data["id"])
+    assert draft.materialized_automation_id is not None
+
+    automation = await async_session.get(Automation, draft.materialized_automation_id)
+    assert automation is not None
+    assert automation.enabled is False
+    assert automation.lifecycle_status == AutomationLifecycleStatus.DRAFT
+    assert automation.prompt == "Write a short greeting."
+    assert automation.tarball_path.startswith("oh-internal://uploads/")
+
+    run = await async_session.get(AutomationRun, uuid.UUID(run_data["id"]))
+    assert run is not None
+    assert run.automation_id == automation.id
+    assert run.trigger_source == "manual"
+    assert draft_file_store.write_stream.await_count == 1

--- a/tests/test_draft_router.py
+++ b/tests/test_draft_router.py
@@ -10,8 +10,8 @@ from openhands.automation.app import app
 from openhands.automation.models import (
     Automation,
     AutomationDraft,
-    AutomationLifecycleStatus,
     AutomationRun,
+    AutomationState,
 )
 from openhands.automation.storage import get_file_store
 
@@ -152,7 +152,7 @@ async def test_dispatchable_prompt_draft_materializes_disabled_draft_and_manual_
     automation = await async_session.get(Automation, draft.materialized_automation_id)
     assert automation is not None
     assert automation.enabled is False
-    assert automation.lifecycle_status == AutomationLifecycleStatus.DRAFT
+    assert automation.lifecycle_status == AutomationState.DRAFT
     assert automation.prompt == "Write a short greeting."
     assert automation.tarball_path.startswith("oh-internal://uploads/")
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1695,10 +1695,10 @@ class TestDispatchAutomation:
         assert response.status_code == 404
         assert "Automation not found" in response.json()["detail"]
 
-    async def test_dispatch_disabled_automation_returns_reason(
+    async def test_dispatch_disabled_automation_creates_manual_run(
         self, async_client, async_session
     ):
-        """Dispatching a disabled automation returns its blocking reason."""
+        """Manual dispatch is allowed for inactive automations."""
         automation = Automation(
             user_id=TEST_USER_ID,
             org_id=TEST_ORG_ID,
@@ -1717,11 +1717,11 @@ class TestDispatchAutomation:
             f"/api/automation/v1/{automation.id}/dispatch"
         )
 
-        assert response.status_code == 409
-        detail = response.json()["detail"]
-        assert detail["message"] == "Automation is disabled"
-        assert detail["disabled_reason"] == "auth: Invalid API key"
-        assert detail["disabled_detail"] == {"kind": "auth", "threshold": 3}
+        assert response.status_code == 201
+        data = response.json()
+        assert data["automation_id"] == str(automation.id)
+        assert data["status"] == "PENDING"
+        assert data["trigger_source"] == "manual"
 
     async def test_dispatch_automation_deleted(self, async_client, async_session):
         """Dispatching a soft-deleted automation returns 404."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -9,9 +9,9 @@ from sqlalchemy import func, select
 
 from openhands.automation.models import (
     Automation,
-    AutomationLifecycleStatus,
     AutomationRun,
     AutomationRunStatus,
+    AutomationState,
 )
 from openhands.automation.scheduler import (
     POLL_INTERVAL_SECONDS,
@@ -491,7 +491,7 @@ class TestPollAndSchedule:
                 tarball_path="s3://bucket/code.tar.gz",
                 entrypoint="uv run main.py",
                 enabled=True,
-                lifecycle_status=AutomationLifecycleStatus.DRAFT,
+                lifecycle_status=AutomationState.DRAFT,
             )
             session.add(automation)
             await session.commit()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -7,7 +7,12 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from sqlalchemy import func, select
 
-from openhands.automation.models import Automation, AutomationRun, AutomationRunStatus
+from openhands.automation.models import (
+    Automation,
+    AutomationLifecycleStatus,
+    AutomationRun,
+    AutomationRunStatus,
+)
 from openhands.automation.scheduler import (
     POLL_INTERVAL_SECONDS,
     poll_and_schedule,
@@ -472,6 +477,28 @@ class TestPollAndSchedule:
         runs = await poll_and_schedule(async_session_factory)
 
         assert len(runs) == 0
+
+    async def test_poll_excludes_draft_even_if_enabled_flag_is_true(
+        self, async_session_factory
+    ):
+        """Draft lifecycle rows are never scheduled automatically."""
+        async with async_session_factory() as session:
+            automation = Automation(
+                user_id=TEST_USER_ID,
+                org_id=TEST_ORG_ID,
+                name="Draft Automation",
+                trigger={"type": "cron", "schedule": "* * * * *", "timezone": "UTC"},
+                tarball_path="s3://bucket/code.tar.gz",
+                entrypoint="uv run main.py",
+                enabled=True,
+                lifecycle_status=AutomationLifecycleStatus.DRAFT,
+            )
+            session.add(automation)
+            await session.commit()
+
+        runs = await poll_and_schedule(async_session_factory)
+
+        assert runs == []
 
     async def test_poll_excludes_recently_triggered(self, async_session_factory):
         """Recently triggered automations are not returned as due."""

--- a/tests/test_webhook_utils.py
+++ b/tests/test_webhook_utils.py
@@ -9,7 +9,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from openhands.automation.db import set_sqlite_mode
-from openhands.automation.models import Automation, Base
+from openhands.automation.models import Automation, AutomationLifecycleStatus, Base
 from openhands.automation.utils.webhook import get_event_automations, verify_signature
 
 
@@ -272,6 +272,47 @@ class TestGetEventAutomationsSqliteJsonFiltering:
 
             assert len(result) == 1
             assert result[0][0].id == enabled_automation.id
+        finally:
+            set_sqlite_mode(False)
+
+    @pytest.mark.asyncio
+    async def test_excludes_draft_automations(self, sqlite_session):
+        """Draft automations are not returned even if enabled is inconsistent."""
+        org_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+
+        set_sqlite_mode(True)
+
+        try:
+            active = Automation(
+                id=uuid.uuid4(),
+                name="Active Automation",
+                org_id=org_id,
+                user_id=user_id,
+                trigger={"type": "event", "source": "github", "on": "push"},
+                tarball_path="test.tar.gz",
+                entrypoint="main.py",
+                enabled=True,
+                lifecycle_status=AutomationLifecycleStatus.ACTIVE,
+            )
+            draft = Automation(
+                id=uuid.uuid4(),
+                name="Draft Automation",
+                org_id=org_id,
+                user_id=user_id,
+                trigger={"type": "event", "source": "github", "on": "push"},
+                tarball_path="test.tar.gz",
+                entrypoint="main.py",
+                enabled=True,
+                lifecycle_status=AutomationLifecycleStatus.DRAFT,
+            )
+
+            sqlite_session.add_all([active, draft])
+            await sqlite_session.commit()
+
+            result = await get_event_automations(org_id, "github", sqlite_session)
+
+            assert [automation.id for automation, _ in result] == [active.id]
         finally:
             set_sqlite_mode(False)
 

--- a/tests/test_webhook_utils.py
+++ b/tests/test_webhook_utils.py
@@ -9,7 +9,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from openhands.automation.db import set_sqlite_mode
-from openhands.automation.models import Automation, AutomationLifecycleStatus, Base
+from openhands.automation.models import Automation, AutomationState, Base
 from openhands.automation.utils.webhook import get_event_automations, verify_signature
 
 
@@ -293,7 +293,7 @@ class TestGetEventAutomationsSqliteJsonFiltering:
                 tarball_path="test.tar.gz",
                 entrypoint="main.py",
                 enabled=True,
-                lifecycle_status=AutomationLifecycleStatus.ACTIVE,
+                lifecycle_status=AutomationState.ACTIVE,
             )
             draft = Automation(
                 id=uuid.uuid4(),
@@ -304,7 +304,7 @@ class TestGetEventAutomationsSqliteJsonFiltering:
                 tarball_path="test.tar.gz",
                 entrypoint="main.py",
                 enabled=True,
-                lifecycle_status=AutomationLifecycleStatus.DRAFT,
+                lifecycle_status=AutomationState.DRAFT,
             )
 
             sqlite_session.add_all([active, draft])


### PR DESCRIPTION
## Summary

Implements backend support for OSS-10472 automation drafts, lifecycle state, and manual dispatch testing.

- Adds `AutomationState` (`ACTIVE`, `INACTIVE`, `DRAFT`) and `AutomationRun.trigger_source` (`manual`, `cron`, `event`).
- Adds persisted `AutomationDraft` records for incomplete setup UI state.
- Adds `/api/automation/v1/drafts` CRUD endpoints plus `/dispatch` for eligible draft test runs.
- Materializes dispatchable drafts into disabled `DRAFT` automations for manual test runs.
- Keeps the draft row as the source of truth while editing, even after materialization.
- Reuses the same materialized `DRAFT` automation row on each successful draft dispatch, overwriting it from the current valid draft body.
- Allows manual dispatch for inactive/draft automations while keeping scheduler and webhook/event paths limited to active automations.
- Updates git sync serialization/import for lifecycle state.
- Adds `automationDrafts` capability discovery flag.

Fixes https://github.com/OpenHands/automation/issues/434

## Draft lifecycle specification

### Source of truth

`automation_drafts` is the source of truth while the user is in the draft/editing flow. A materialized automation row is an executable projection used for test dispatch, not the canonical draft state.

This matters because a draft can be valid, dispatched once, and then edited back into an incomplete state. In that case, future dispatch must validate the current draft body and fail if incomplete. It must not silently run the older materialized automation config.

### Materialization

When a complete draft is dispatched:

1. The draft body is validated against the endpoint-specific final creation schema.
2. If no materialized row exists, the service creates a linked `automations` row.
3. If a materialized row already exists and is not deleted, the service reuses that same row.
4. The materialized row is overwritten from the current valid draft body.
5. The materialized row is marked `enabled = false` and `lifecycle_status = DRAFT`.
6. A manual run is created against that materialized automation id.
7. The draft row remains in place and records `last_test_run_id`.

The materialized row is updated on successful dispatch, not on every edit.

### Editing after materialization

Editing a draft after it has been materialized updates only the draft entry:

- `automation_drafts.draft_body`
- `automation_drafts.validation_errors`
- `automation_drafts.dispatchable`
- `automation_drafts.updated_at`

The linked materialized automation is left untouched until the user explicitly dispatches the draft again and the draft fully validates.

### Incomplete drafts after a previous dispatch

A draft is allowed to become incomplete again after a previous successful test dispatch.

When that happens:

- the draft remains saved,
- `dispatchable` becomes false,
- validation errors are returned on dispatch,
- the older materialized automation remains only as historical execution context for previous runs,
- the older materialized automation is not treated as current source of truth.

### Delete semantics

Deleting a draft ends the draft flow. The intended behavior is:

- soft-delete the draft row by setting `automation_drafts.deleted_at`,
- also soft-delete the linked materialized automation if it still has `lifecycle_status = DRAFT`,
- preserve historical run rows that point at the materialized automation id,
- prevent the test artifact from appearing in normal automation views or being reused.

### Publish/finalize semantics

Publishing or finalizing a draft should be an explicit product transition, separate from test dispatch. At that point, source of truth moves from `automation_drafts` to a normal `automations` row with `lifecycle_status = ACTIVE` or `INACTIVE`.

## Validation model

Draft bodies are stored as JSON, but not arbitrary unstructured JSON. The service validates and normalizes draft bodies with endpoint-specific partial Pydantic schemas for:

- `/v1`
- `/v1/preset/prompt`
- `/v1/preset/plugin`

This allows incomplete drafts to be saved while still rejecting unknown or endpoint-mismatched fields early.

Final dispatchability is still determined by validating against the real final creation schemas.

## Alternatives considered

### Store drafts directly in `automations`

This makes draft test runs easy because every draft is already an automation row. However, it requires execution-critical fields to become nullable or overloaded, and it forces scheduler, dispatcher, serialization, and response code paths to handle incomplete automation rows.

### Use only `enabled = false`

This avoids a lifecycle column, but it collapses two different concepts: a real automation disabled by the user and a materialized draft automation used only for test dispatch. That ambiguity leaks into UI, dispatch, git sync, cleanup, analytics, and future state transitions.

### Store drafts as arbitrary JSON only

This is flexible, but it allows endpoint drift and arbitrary payloads. Errors surface late, and clients lose reliable field-level validation for setup forms.

### Dispatch directly from draft JSON

This avoids materialization, but it conflicts with the current run model and dispatcher contract: runs require an `automation_id`, and execution config is loaded from `Automation`. Changing that path would be wider and riskier.

## Tests

- `uv run pre-commit run --all-files --show-diff-on-failure`
- `uv run pytest tests/test_draft_router.py tests/test_capabilities_router.py tests/test_dispatcher.py -q` (`72 passed`)
- `uv run pytest tests/ -q --ignore=tests/integration` (`1720 passed, 7 skipped`)
- `uv run alembic heads` (`023 (head)`)
- temporary SQLite `uv run alembic upgrade head`

_This PR description was updated by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/13bfb65f-3c18-4f3a-bf37-848e96a85cef)
