### PR TITLE
ci: enforce minimum 76% coverage on unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
                     --cov=openhands/automation \
                     --cov-report=term-missing \
                     --cov-report=xml:coverage.xml \
-                    --cov-fail-under=0 \
+                    --cov-fail-under=65 \
                     tests/
 
             - name: Pytest coverage PR comment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
                     --cov=openhands/automation \
                     --cov-report=term-missing \
                     --cov-report=xml:coverage.xml \
-                    --cov-fail-under=65 \
+                    --cov-fail-under=76 \
                     tests/
 
             - name: Pytest coverage PR comment


### PR DESCRIPTION
HUMAN:

Current tests show a coverage of 76%. This is the baseline

AGENT:

## Summary

Establishes a coverage baseline as a merge gate for the automation unit test suite.

- Changes `--cov-fail-under` from `0` to `65` in `.github/workflows/tests.yml`.
- Coverage was already being **measured** (`pytest-cov`) and **reported** on PRs (via `pytest-coverage-comment`), but the previous threshold of `0` never failed CI, so coverage regressions went ungated.
- `65%` is a conservative floor based on the current measured coverage (~67–68% locally; slightly higher in CI where the testcontainers/Docker-dependent tests run). It can be ratcheted up over time.

## Why

A PR could previously drop coverage from 68% to 5% and still pass CI. This sets a floor so coverage only moves in the right direction, while keeping the existing PR coverage comment for visibility.

## Test plan

- [ ] CI `unit-tests` job passes on this PR (confirms `main` is at or above 65%).

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._