### PR TITLE
fix: normalize async Postgres URLs for alembic

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -15,7 +15,8 @@ SQLite mode:
 
 Note: Uses pg8000 (sync driver) while the application uses asyncpg (async driver).
 This is intentional - Alembic runs synchronously, and both drivers produce
-identical DDL/schema operations.
+identical DDL/schema operations. An AUTOMATION_DB_URL naming an async driver is
+rewritten to its sync equivalent by normalize_url_for_alembic().
 """
 
 import os
@@ -23,7 +24,10 @@ import os
 from alembic import context
 from sqlalchemy import create_engine, text
 
-from openhands.automation.db import _build_pg8000_connect_args
+from openhands.automation.db import (
+    _build_pg8000_connect_args,
+    normalize_url_for_alembic,
+)
 from openhands.automation.models import Base
 
 
@@ -66,11 +70,13 @@ def get_engine(database_name=DB_NAME):
     """
     # SQLite or explicit PostgreSQL URL
     if DB_URL:
-        url = DB_URL
-        # For SQLite, remove async driver prefix if present (Alembic is sync)
-        if url.startswith("sqlite+aiosqlite"):
-            url = url.replace("sqlite+aiosqlite", "sqlite", 1)
-        return create_engine(url, pool_pre_ping=True)
+        url = normalize_url_for_alembic(DB_URL)
+        connect_args = (
+            _build_pg8000_connect_args(DB_SSL_MODE)
+            if url.startswith("postgresql+pg8000")
+            else {}
+        )
+        return create_engine(url, connect_args=connect_args, pool_pre_ping=True)
 
     # GCP Cloud SQL
     if GCP_DB_INSTANCE:
@@ -104,9 +110,7 @@ def get_engine(database_name=DB_NAME):
 
 def run_migrations_offline():
     if DB_URL:
-        url = DB_URL
-        if url.startswith("sqlite+aiosqlite"):
-            url = url.replace("sqlite+aiosqlite", "sqlite", 1)
+        url = normalize_url_for_alembic(DB_URL)
     else:
         url = f"postgresql+pg8000://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 

--- a/openhands/automation/app.py
+++ b/openhands/automation/app.py
@@ -84,7 +84,7 @@ async def lifespan(app: FastAPI):
         from alembic import command
         from alembic.config import Config
 
-        from openhands.automation.db import normalize_sqlite_url_for_alembic
+        from openhands.automation.db import normalize_url_for_alembic
 
         # Find migrations folder relative to this package.
         # When installed via pip/uvx, migrations are bundled inside
@@ -108,7 +108,7 @@ async def lifespan(app: FastAPI):
         alembic_cfg = Config()
         alembic_cfg.set_main_option("script_location", str(migrations_path))
         # Set the database URL for Alembic to use (sync version)
-        db_url = normalize_sqlite_url_for_alembic(settings.db_url)
+        db_url = normalize_url_for_alembic(settings.db_url)
         alembic_cfg.set_main_option("sqlalchemy.url", db_url)
 
         # Run migrations synchronously (Alembic doesn't support async)

--- a/openhands/automation/db.py
+++ b/openhands/automation/db.py
@@ -66,14 +66,22 @@ def is_sqlite_url(url: str) -> bool:
     return url.startswith("sqlite")
 
 
-def normalize_sqlite_url_for_alembic(url: str) -> str:
-    """Convert async SQLite URL to sync version for Alembic.
+ALEMBIC_SYNC_DRIVERS = {
+    "sqlite+aiosqlite": "sqlite",
+    "postgresql+asyncpg": "postgresql+pg8000",
+}
 
-    Alembic doesn't support async drivers, so we need to convert
-    sqlite+aiosqlite:// URLs to plain sqlite:// URLs.
+
+def normalize_url_for_alembic(url: str) -> str:
+    """Convert an async database URL to the sync driver Alembic uses.
+
+    Alembic runs synchronously and cannot drive aiosqlite or asyncpg, so
+    sqlite+aiosqlite:// becomes sqlite:// and postgresql+asyncpg:// becomes
+    postgresql+pg8000://. Any other URL is returned unchanged.
     """
-    if url.startswith("sqlite+aiosqlite"):
-        return url.replace("sqlite+aiosqlite", "sqlite", 1)
+    for async_driver, sync_driver in ALEMBIC_SYNC_DRIVERS.items():
+        if url.startswith(async_driver):
+            return url.replace(async_driver, sync_driver, 1)
     return url
 
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -14,7 +14,7 @@ from openhands.automation.db import (
     _build_pg8000_connect_args,
     _create_sqlite_engine,
     is_sqlite_url,
-    normalize_sqlite_url_for_alembic,
+    normalize_url_for_alembic,
     set_sqlite_mode,
     using_sqlite,
 )
@@ -173,38 +173,54 @@ class TestPostgresSslMode:
         assert captured["kwargs"]["pool_pre_ping"] is True
 
 
-class TestNormalizeSqliteUrlForAlembic:
-    """Tests for normalize_sqlite_url_for_alembic helper function."""
+class TestNormalizeUrlForAlembic:
+    """Tests for normalize_url_for_alembic helper function."""
 
     def test_converts_aiosqlite_to_sqlite(self):
         """Converts sqlite+aiosqlite:// to sqlite://."""
         url = "sqlite+aiosqlite:///test.db"
-        assert normalize_sqlite_url_for_alembic(url) == "sqlite:///test.db"
+        assert normalize_url_for_alembic(url) == "sqlite:///test.db"
 
     def test_converts_aiosqlite_with_absolute_path(self):
         """Converts sqlite+aiosqlite with absolute path."""
         url = "sqlite+aiosqlite:////data/automations.db"
-        assert normalize_sqlite_url_for_alembic(url) == "sqlite:////data/automations.db"
+        assert normalize_url_for_alembic(url) == "sqlite:////data/automations.db"
 
     def test_preserves_plain_sqlite_url(self):
         """Plain sqlite:// URL is unchanged."""
         url = "sqlite:///test.db"
-        assert normalize_sqlite_url_for_alembic(url) == "sqlite:///test.db"
+        assert normalize_url_for_alembic(url) == "sqlite:///test.db"
 
     def test_preserves_postgresql_url(self):
         """PostgreSQL URLs are unchanged."""
         url = "postgresql://user:pass@host/db"
-        assert normalize_sqlite_url_for_alembic(url) == url
+        assert normalize_url_for_alembic(url) == url
 
-    def test_preserves_postgresql_asyncpg_url(self):
-        """PostgreSQL+asyncpg URLs are unchanged."""
+    def test_converts_asyncpg_to_pg8000(self):
+        """Converts postgresql+asyncpg:// to postgresql+pg8000://."""
         url = "postgresql+asyncpg://user:pass@host/db"
-        assert normalize_sqlite_url_for_alembic(url) == url
+        assert normalize_url_for_alembic(url) == "postgresql+pg8000://user:pass@host/db"
+
+    def test_converts_only_the_asyncpg_driver_prefix(self):
+        """A password containing the driver name is left alone."""
+        url = "postgresql+asyncpg://user:postgresql+asyncpg@host/db"
+        assert normalize_url_for_alembic(url) == (
+            "postgresql+pg8000://user:postgresql+asyncpg@host/db"
+        )
+
+    def test_preserves_postgresql_psycopg_url(self):
+        """Other PostgreSQL drivers are unchanged."""
+        url = "postgresql+psycopg2://user:pass@host/db"
+        assert normalize_url_for_alembic(url) == url
 
     def test_handles_memory_database(self):
         """Memory database URL is converted correctly."""
         url = "sqlite+aiosqlite:///:memory:"
-        assert normalize_sqlite_url_for_alembic(url) == "sqlite:///:memory:"
+        assert normalize_url_for_alembic(url) == "sqlite:///:memory:"
+
+    def test_preserves_empty_url(self):
+        """Empty URL is unchanged."""
+        assert normalize_url_for_alembic("") == ""
 
 
 class TestSqliteMigrations:
@@ -270,7 +286,7 @@ class TestSqliteMigrations:
         """Auto-migration on startup creates all required tables.
 
         This tests the auto-migration behavior added in app.py for SQLite,
-        using the normalize_sqlite_url_for_alembic helper function.
+        using the normalize_url_for_alembic helper function.
         """
         import subprocess
 
@@ -281,7 +297,7 @@ class TestSqliteMigrations:
         try:
             # Test the URL normalization helper
             async_url = f"sqlite+aiosqlite:///{db_path}"
-            sync_url = normalize_sqlite_url_for_alembic(async_url)
+            sync_url = normalize_url_for_alembic(async_url)
             assert sync_url == f"sqlite:///{db_path}"
 
             # Run migrations using subprocess to avoid env.py PostgreSQL defaults


### PR DESCRIPTION
HUMAN:

Reproduced against a self-hosted deployment on Kubernetes with a CloudNativePG Postgres and `AUTOMATION_DB_URL=postgresql+asyncpg://…`: `alembic upgrade head` fails with `MissingGreenlet`, and hand-rewriting the URL to `postgresql+pg8000://` makes it pass. Ran `uv run pytest tests/test_db.py` and pre-commit locally on this branch.

AGENT:

## Problem

`AUTOMATION_DB_URL` is the documented way to point a self-hosted deployment at a
database, and the Postgres form of it is `postgresql+asyncpg://…` — that is what
the agent-canvas Helm chart sets, and what `db.py` expects for the application
engine.

Alembic cannot use it. `migrations/env.py` `get_engine()` reads
`AUTOMATION_DB_URL` from the environment and passes it straight to the **sync**
`sqlalchemy.create_engine()`, normalizing only the SQLite prefix:

```python
if DB_URL:
    url = DB_URL
    if url.startswith("sqlite+aiosqlite"):
        url = url.replace("sqlite+aiosqlite", "sqlite", 1)
    return create_engine(url, pool_pre_ping=True)
```

With an asyncpg URL, `alembic upgrade head` fails:

```
sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called;
can't call await_only() here.
```

Rewriting the URL by hand to `postgresql+pg8000://…` makes the same command
succeed, which is the shape of the fix: pg8000 is already a dependency and is
already the driver `env.py` uses for its host/port and Cloud SQL paths.

## Fix

- `db.py`: `normalize_sqlite_url_for_alembic()` becomes
  `normalize_url_for_alembic()`, driven by a small `ALEMBIC_SYNC_DRIVERS` map —
  `sqlite+aiosqlite` → `sqlite` (unchanged behaviour) and
  `postgresql+asyncpg` → `postgresql+pg8000`. Only a leading driver prefix is
  rewritten, so a URL whose password happens to contain the driver name is left
  alone. Every other URL passes through untouched.
- `migrations/env.py`: `get_engine()` and `run_migrations_offline()` both run a
  configured `AUTOMATION_DB_URL` through the normalizer. A URL that resolves to
  pg8000 now also gets `_build_pg8000_connect_args(DB_SSL_MODE)`, so
  `AUTOMATION_DB_SSL_MODE` finally applies to the URL path the same way it
  already applies to the host/port path.
- `app.py`: uses the renamed helper when it sets `sqlalchemy.url`.

The helper is renamed rather than aliased, because an alias could not stay
backward compatible: the old name's contract was "asyncpg URLs are unchanged",
which is precisely the bug. Both call sites and the tests are updated; nothing
outside this repo imports it.

## Verification

- `uv run pytest tests/test_db.py` — 30 passed. The normalizer suite gained
  cases for asyncpg → pg8000, prefix-only rewriting, a non-async Postgres
  driver, and the empty string.
- Full unit suite and `pre-commit` (ruff format, ruff lint, pycodestyle,
  pyright) clean on the changed files.
- `AUTOMATION_DB_URL=postgresql+asyncpg://… alembic upgrade head --sql` renders
  Postgres DDL, and the previously failing online path now builds a pg8000
  engine instead of an asyncpg one.

`migrations/env.py` executes `run_migrations_online()` at import time, so it has
no direct unit test; the behaviour is covered through the shared helper.

No schema change, no new dependency, no behaviour change for SQLite or for
deployments configured via `AUTOMATION_DB_HOST`/`AUTOMATION_DB_PORT`.

