### PR TITLE
refactor: store automation drafts in automations table

### DIFF
--- a/migrations/versions/022_add_automation_drafts.py
+++ b/migrations/versions/022_add_automation_drafts.py
@@ -52,72 +52,46 @@ def upgrade() -> None:
         ["status", "trigger_source"],
     )
 
-    op.create_table(
-        "automation_drafts",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("user_id", sa.Uuid(), nullable=False),
-        sa.Column("org_id", sa.Uuid(), nullable=False),
-        sa.Column("endpoint", sa.String(length=64), nullable=False),
-        sa.Column("name", sa.String(length=500), nullable=True),
-        sa.Column("draft_body", sa.JSON(), nullable=False),
-        sa.Column("validation_errors", sa.JSON(), nullable=True),
-        sa.Column("dispatchable", sa.Boolean(), nullable=False, server_default="false"),
-        sa.Column("source_automation_id", sa.Uuid(), nullable=True),
-        sa.Column("materialized_automation_id", sa.Uuid(), nullable=True),
-        sa.Column("last_test_run_id", sa.Uuid(), nullable=True),
-        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column(
-            "created_at",
-            sa.DateTime(timezone=True),
-            server_default=sa.text("CURRENT_TIMESTAMP"),
-            nullable=False,
-        ),
-        sa.Column(
-            "updated_at",
-            sa.DateTime(timezone=True),
-            server_default=sa.text("CURRENT_TIMESTAMP"),
-            nullable=False,
-        ),
-        sa.ForeignKeyConstraint(
-            ["source_automation_id"], ["automations.id"], ondelete="SET NULL"
-        ),
-        sa.ForeignKeyConstraint(
-            ["materialized_automation_id"], ["automations.id"], ondelete="SET NULL"
-        ),
-        sa.ForeignKeyConstraint(
-            ["last_test_run_id"], ["automation_runs.id"], ondelete="SET NULL"
-        ),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index("ix_automation_drafts_user_id", "automation_drafts", ["user_id"])
-    op.create_index("ix_automation_drafts_org_id", "automation_drafts", ["org_id"])
+    with op.batch_alter_table("automations") as batch_op:
+        batch_op.alter_column(
+            "name", existing_type=sa.String(length=500), nullable=True
+        )
+        batch_op.alter_column("trigger", existing_type=sa.JSON(), nullable=True)
+        batch_op.alter_column("tarball_path", existing_type=sa.Text(), nullable=True)
+        batch_op.alter_column("entrypoint", existing_type=sa.Text(), nullable=True)
+        batch_op.add_column(
+            sa.Column("draft_endpoint", sa.String(length=64), nullable=True)
+        )
+        batch_op.add_column(sa.Column("draft_body", sa.JSON(), nullable=True))
+        batch_op.add_column(sa.Column("validation_errors", sa.JSON(), nullable=True))
+        batch_op.add_column(
+            sa.Column(
+                "dispatchable",
+                sa.Boolean(),
+                nullable=False,
+                server_default="false",
+            )
+        )
+        batch_op.add_column(sa.Column("source_automation_id", sa.Uuid(), nullable=True))
+        batch_op.add_column(sa.Column("last_test_run_id", sa.Uuid(), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_automations_source_automation_id",
+            "automations",
+            ["source_automation_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
     op.create_index(
-        "ix_automation_drafts_deleted_at", "automation_drafts", ["deleted_at"]
+        "ix_automations_org_lifecycle_updated_at",
+        "automations",
+        ["org_id", "lifecycle_status", "updated_at"],
     )
     op.create_index(
-        "ix_automation_drafts_org_updated_at",
-        "automation_drafts",
-        ["org_id", "updated_at"],
+        "ix_automations_source_automation_id", "automations", ["source_automation_id"]
     )
     op.create_index(
-        "ix_automation_drafts_org_deleted_at",
-        "automation_drafts",
-        ["org_id", "deleted_at"],
-    )
-    op.create_index(
-        "ix_automation_drafts_source_automation_id",
-        "automation_drafts",
-        ["source_automation_id"],
-    )
-    op.create_index(
-        "ix_automation_drafts_materialized_automation_id",
-        "automation_drafts",
-        ["materialized_automation_id"],
-    )
-    op.create_index(
-        "ix_automation_drafts_last_test_run_id",
-        "automation_drafts",
-        ["last_test_run_id"],
+        "ix_automations_last_test_run_id", "automations", ["last_test_run_id"]
     )
 
     if _is_sqlite():
@@ -132,28 +106,31 @@ def upgrade() -> None:
         "'How the run was created: manual, cron, event, or NULL for legacy rows.'"
     )
     op.execute(
-        "COMMENT ON TABLE automation_drafts IS "
-        "'Incomplete or complete automation setup drafts saved by setup UIs.'"
+        "COMMENT ON COLUMN automations.draft_body IS "
+        "'Partial setup request body for DRAFT automation rows.'"
     )
 
 
 def downgrade() -> None:
-    op.drop_index(
-        "ix_automation_drafts_last_test_run_id", table_name="automation_drafts"
-    )
-    op.drop_index(
-        "ix_automation_drafts_materialized_automation_id",
-        table_name="automation_drafts",
-    )
-    op.drop_index(
-        "ix_automation_drafts_source_automation_id", table_name="automation_drafts"
-    )
-    op.drop_index("ix_automation_drafts_org_deleted_at", table_name="automation_drafts")
-    op.drop_index("ix_automation_drafts_org_updated_at", table_name="automation_drafts")
-    op.drop_index("ix_automation_drafts_deleted_at", table_name="automation_drafts")
-    op.drop_index("ix_automation_drafts_org_id", table_name="automation_drafts")
-    op.drop_index("ix_automation_drafts_user_id", table_name="automation_drafts")
-    op.drop_table("automation_drafts")
+    op.drop_index("ix_automations_last_test_run_id", table_name="automations")
+    op.drop_index("ix_automations_source_automation_id", table_name="automations")
+    op.drop_index("ix_automations_org_lifecycle_updated_at", table_name="automations")
+    with op.batch_alter_table("automations") as batch_op:
+        batch_op.drop_constraint(
+            "fk_automations_source_automation_id", type_="foreignkey"
+        )
+        batch_op.drop_column("last_test_run_id")
+        batch_op.drop_column("source_automation_id")
+        batch_op.drop_column("dispatchable")
+        batch_op.drop_column("validation_errors")
+        batch_op.drop_column("draft_body")
+        batch_op.drop_column("draft_endpoint")
+        batch_op.alter_column("entrypoint", existing_type=sa.Text(), nullable=False)
+        batch_op.alter_column("tarball_path", existing_type=sa.Text(), nullable=False)
+        batch_op.alter_column("trigger", existing_type=sa.JSON(), nullable=False)
+        batch_op.alter_column(
+            "name", existing_type=sa.String(length=500), nullable=False
+        )
 
     op.drop_index(
         "ix_automation_runs_status_trigger_source", table_name="automation_runs"

--- a/openhands/automation/dispatcher.py
+++ b/openhands/automation/dispatcher.py
@@ -45,6 +45,7 @@ from openhands.automation.models import (
 from openhands.automation.telemetry import capture_automation_event
 from openhands.automation.utils import log_extra
 from openhands.automation.utils.api_key import APIKeyError
+from openhands.automation.utils.automation_shape import require_dispatch_fields
 from openhands.automation.utils.kv import create_kv_token
 from openhands.automation.utils.run import (
     disable_automation,
@@ -211,7 +212,6 @@ async def _execute_run(
     run_id = str(run.id)
     automation = run.automation
     automation_id = str(automation.id)
-    tarball_path = automation.tarball_path
     backend = get_backend(run)
 
     def _log_ctx(sandbox_id: str | None = None) -> dict[str, Any]:
@@ -261,6 +261,12 @@ async def _execute_run(
                 "automation_disabled": automation_disabled,
             },
         )
+
+    try:
+        tarball_path, entrypoint = require_dispatch_fields(automation)
+    except ValueError as exc:
+        await _fail(str(exc), disable=False)
+        return
 
     # 1. Calculate effective timeout (doesn't depend on ctx). This same value
     # drives both the bash command timeout and the watchdog cleanup deadline.
@@ -424,7 +430,7 @@ async def _execute_run(
             client=client,
             agent_url=ctx.agent_url,
             session_key=ctx.session_key,
-            entrypoint=automation.entrypoint,
+            entrypoint=entrypoint,
             tarball_source=tarball_source,
             work_dir=work_dir,
             env_vars=env_vars,

--- a/openhands/automation/draft_router.py
+++ b/openhands/automation/draft_router.py
@@ -1,8 +1,8 @@
 """Server-backed automation drafts.
 
-Draft rows hold partial setup UI state. A draft is materialized into a disabled
-Automation only when it validates and the user manually dispatches it for a test
-run.
+Drafts are stored as DRAFT rows in the automations table. When a draft validates
+and is manually dispatched, the executable fields are written onto the same row
+so the run can keep using automation_runs.automation_id.
 """
 
 import logging
@@ -33,7 +33,6 @@ from openhands.automation.db import get_session
 from openhands.automation.git_sync import mark_git_sync_dirty
 from openhands.automation.models import (
     Automation,
-    AutomationDraft,
     AutomationState,
     TarballUpload,
     UploadStatus,
@@ -66,11 +65,17 @@ from openhands.automation.telemetry import (
     get_request_telemetry_context,
 )
 from openhands.automation.utils import utcnow
+from openhands.automation.utils.automation_shape import (
+    assert_executable_automation_shape,
+)
 from openhands.automation.utils.model_profiles import (
     resolve_model_profile_for_user,
     validate_model_profile_for_user,
 )
-from openhands.automation.utils.run import create_pending_run
+from openhands.automation.utils.run import (
+    create_pending_run,
+    skip_pending_runs_for_disabled_automation,
+)
 from openhands.automation.utils.tarball_validation import (
     build_internal_url,
     build_upload_storage_path,
@@ -104,12 +109,13 @@ async def _assert_org_automation_exists(
 
 async def _get_org_draft(
     session: AsyncSession, draft_id: uuid.UUID, org_id: uuid.UUID
-) -> AutomationDraft:
+) -> Automation:
     result = await session.execute(
-        select(AutomationDraft).where(
-            AutomationDraft.id == draft_id,
-            AutomationDraft.org_id == org_id,
-            AutomationDraft.deleted_at.is_(None),
+        select(Automation).where(
+            Automation.id == draft_id,
+            Automation.org_id == org_id,
+            Automation.lifecycle_status == AutomationState.DRAFT,
+            Automation.deleted_at.is_(None),
         )
     )
     draft = result.scalars().first()
@@ -209,16 +215,43 @@ async def _validate_draft_body(
 
 
 async def _refresh_validation(
-    draft: AutomationDraft,
+    draft: Automation,
     user: AuthenticatedUser,
     session: AsyncSession,
 ) -> BaseModel | None:
+    if draft.draft_endpoint is None:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Draft is missing its target endpoint",
+        )
     parsed, errors = await _validate_draft_body(
-        draft.endpoint, draft.draft_body, user, session
+        draft.draft_endpoint, draft.draft_body or {}, user, session
     )
     draft.validation_errors = _errors_to_json(errors) if errors else None
     draft.dispatchable = not errors
     return parsed if not errors else None
+
+
+def _draft_response(draft: Automation) -> AutomationDraftResponse:
+    return AutomationDraftResponse.model_validate(
+        {
+            "id": draft.id,
+            "user_id": draft.user_id,
+            "org_id": draft.org_id,
+            "endpoint": draft.draft_endpoint,
+            "name": draft.name,
+            "draft": draft.draft_body or {},
+            "validation_errors": draft.validation_errors,
+            "dispatchable": draft.dispatchable,
+            "source_automation_id": draft.source_automation_id,
+            "materialized_automation_id": (
+                draft.id if draft.last_test_run_id is not None else None
+            ),
+            "last_test_run_id": draft.last_test_run_id,
+            "created_at": draft.created_at,
+            "updated_at": draft.updated_at,
+        }
+    )
 
 
 async def _write_generated_tarball(
@@ -380,7 +413,7 @@ async def _materialize_plugin_draft(
 
 
 async def _materialize_draft(
-    draft: AutomationDraft,
+    draft: Automation,
     parsed: BaseModel,
     user: AuthenticatedUser,
     request: Request,
@@ -399,12 +432,6 @@ async def _materialize_draft(
             detail="Unsupported draft endpoint",
         )
 
-    automation: Automation | None = None
-    if draft.materialized_automation_id is not None:
-        existing = await session.get(Automation, draft.materialized_automation_id)
-        if existing is not None and existing.deleted_at is None:
-            automation = existing
-
     values.update(
         {
             "enabled": False,
@@ -414,24 +441,17 @@ async def _materialize_draft(
             "disabled_at": None,
         }
     )
-    if automation is None:
-        automation = Automation(
-            id=uuid.uuid4(),
-            user_id=user.user_id,
-            org_id=user.org_id,
-            telemetry_distinct_id=get_request_telemetry_context(
-                request
-            ).frontend_distinct_id,
-            **values,
-        )
-        session.add(automation)
-        draft.materialized_automation_id = automation.id
-    else:
-        for field, value in values.items():
-            setattr(automation, field, value)
+    for field, value in values.items():
+        setattr(draft, field, value)
+    telemetry_context = get_request_telemetry_context(request).frontend_distinct_id
+    if telemetry_context is not None:
+        draft.telemetry_distinct_id = telemetry_context
+    await assert_executable_automation_shape(
+        draft, user, session, message="Draft is not dispatchable"
+    )
     await session.flush()
-    await mark_git_sync_dirty(session, automation)
-    return automation
+    await mark_git_sync_dirty(session, draft)
+    return draft
 
 
 @router.post("", status_code=status.HTTP_201_CREATED)
@@ -444,11 +464,13 @@ async def create_draft(
         await _assert_org_automation_exists(
             session, body.source_automation_id, user.org_id
         )
-    draft = AutomationDraft(
+    draft = Automation(
         user_id=user.user_id,
         org_id=user.org_id,
-        endpoint=body.endpoint,
         name=_draft_name(body.name, body.draft),
+        enabled=False,
+        lifecycle_status=AutomationState.DRAFT,
+        draft_endpoint=body.endpoint,
         draft_body=body.draft,
         source_automation_id=body.source_automation_id,
     )
@@ -457,7 +479,7 @@ async def create_draft(
     await _refresh_validation(draft, user, session)
     await session.flush()
     await session.refresh(draft)
-    return AutomationDraftResponse.model_validate(draft)
+    return _draft_response(draft)
 
 
 @router.get("")
@@ -467,22 +489,19 @@ async def list_drafts(
     user: AuthenticatedUser = Depends(_require_view_automations),
     session: AsyncSession = Depends(get_session),
 ) -> AutomationDraftListResponse:
-    base_query = select(AutomationDraft).where(
-        AutomationDraft.org_id == user.org_id,
-        AutomationDraft.deleted_at.is_(None),
+    base_query = select(Automation).where(
+        Automation.org_id == user.org_id,
+        Automation.lifecycle_status == AutomationState.DRAFT,
+        Automation.deleted_at.is_(None),
     )
     total = (
         await session.execute(select(func.count()).select_from(base_query.subquery()))
     ).scalar() or 0
     result = await session.execute(
-        base_query.order_by(AutomationDraft.updated_at.desc())
-        .offset(offset)
-        .limit(limit)
+        base_query.order_by(Automation.updated_at.desc()).offset(offset).limit(limit)
     )
     return AutomationDraftListResponse(
-        drafts=[
-            AutomationDraftResponse.model_validate(draft) for draft in result.scalars()
-        ],
+        drafts=[_draft_response(draft) for draft in result.scalars()],
         total=total,
     )
 
@@ -494,7 +513,7 @@ async def get_draft(
     session: AsyncSession = Depends(get_session),
 ) -> AutomationDraftResponse:
     draft = await _get_org_draft(session, draft_id, user.org_id)
-    return AutomationDraftResponse.model_validate(draft)
+    return _draft_response(draft)
 
 
 @router.patch("/{draft_id}")
@@ -506,15 +525,15 @@ async def update_draft(
 ) -> AutomationDraftResponse:
     draft = await _get_org_draft(session, draft_id, user.org_id)
     if body.endpoint is not None:
-        draft.endpoint = body.endpoint
+        draft.draft_endpoint = body.endpoint
     if body.draft is not None:
         draft.draft_body = body.draft
     if body.name is not None or body.draft is not None:
-        draft.name = _draft_name(body.name, draft.draft_body)
+        draft.name = _draft_name(body.name, draft.draft_body or {})
     await _refresh_validation(draft, user, session)
     await session.flush()
     await session.refresh(draft)
-    return AutomationDraftResponse.model_validate(draft)
+    return _draft_response(draft)
 
 
 @router.delete("/{draft_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -524,8 +543,18 @@ async def delete_draft(
     session: AsyncSession = Depends(get_session),
 ) -> None:
     draft = await _get_org_draft(session, draft_id, user.org_id)
-    draft.deleted_at = utcnow()
+    deleted_at = utcnow()
+    draft.enabled = False
+    draft.deleted_at = deleted_at
+    await skip_pending_runs_for_disabled_automation(
+        session,
+        draft.id,
+        reason="Automation draft deleted by user",
+        completed_at=deleted_at,
+        include_manual=True,
+    )
     await session.flush()
+    await mark_git_sync_dirty(session, draft)
 
 
 @router.post("/{draft_id}/dispatch", status_code=status.HTTP_201_CREATED)

--- a/openhands/automation/git_sync/loop.py
+++ b/openhands/automation/git_sync/loop.py
@@ -157,6 +157,9 @@ async def mark_git_sync_dirty(session: AsyncSession, automation: Automation) -> 
 async def _mark_git_sync_dirty_inner(
     session: AsyncSession, automation: Automation
 ) -> None:
+    if automation.lifecycle_status == AutomationState.DRAFT:
+        return
+
     result = await session.execute(
         select(AutomationGitSyncState).where(
             AutomationGitSyncState.automation_id == automation.id
@@ -788,6 +791,7 @@ async def _backfill_missing_states(session: AsyncSession) -> int:
             await session.execute(
                 select(Automation).where(
                     Automation.deleted_at.is_(None),
+                    Automation.lifecycle_status != AutomationState.DRAFT,
                     ~select(AutomationGitSyncState.automation_id)
                     .where(AutomationGitSyncState.automation_id == Automation.id)
                     .exists(),
@@ -873,7 +877,11 @@ async def _export_dirty_automations(
         automation = await session.get(Automation, state.automation_id)
         directory = sync_root / state.slug
 
-        if automation is None or automation.deleted_at is not None:
+        if (
+            automation is None
+            or automation.deleted_at is not None
+            or automation.lifecycle_status == AutomationState.DRAFT
+        ):
             if directory.exists():
                 await asyncio.to_thread(_remove_exported_automation, directory)
                 changed = True

--- a/openhands/automation/models.py
+++ b/openhands/automation/models.py
@@ -65,7 +65,7 @@ class Automation(Base):
     id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
     user_id: Mapped[uuid.UUID] = mapped_column(Uuid, nullable=False, index=True)
     org_id: Mapped[uuid.UUID] = mapped_column(Uuid, nullable=False, index=True)
-    name: Mapped[str] = mapped_column(String(500), nullable=False)
+    name: Mapped[str | None] = mapped_column(String(500), nullable=True)
     telemetry_distinct_id: Mapped[str | None] = mapped_column(
         String(256), nullable=True
     )
@@ -84,16 +84,16 @@ class Automation(Base):
 
     # Trigger config — for MVP, only cron is supported.
     # Uses generic JSON type for cross-database compatibility (PostgreSQL + SQLite)
-    trigger: Mapped[dict] = mapped_column(JSON, nullable=False)
+    trigger: Mapped[dict | None] = mapped_column(JSON, nullable=True)
 
     # Path to SDK code tarball (e.g., S3 or GCS URL)
-    tarball_path: Mapped[str] = mapped_column(Text, nullable=False)
+    tarball_path: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Relative path inside tarball to setup script (e.g., setup.sh)
     setup_script_path: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Command to execute the automation (e.g., "uv run script.py")
-    entrypoint: Mapped[str] = mapped_column(Text, nullable=False)
+    entrypoint: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Maximum execution time in seconds (None = use system default)
     timeout: Mapped[int | None] = mapped_column(nullable=True)
@@ -116,6 +116,22 @@ class Automation(Base):
         server_default=AutomationState.ACTIVE.value,
         index=True,
     )
+
+    # Draft setup metadata. Drafts are stored directly in this table so runs
+    # can continue to reference automation_runs.automation_id. These fields are
+    # populated only while lifecycle_status is DRAFT.
+    draft_endpoint: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    draft_body: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    validation_errors: Mapped[list[dict[str, Any]] | None] = mapped_column(
+        JSON, nullable=True
+    )
+    dispatchable: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+    source_automation_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("automations.id", ondelete="SET NULL"), nullable=True
+    )
+    last_test_run_id: Mapped[uuid.UUID | None] = mapped_column(Uuid, nullable=True)
 
     # Current disabled-state metadata. AutomationDisableEvent keeps history.
     disabled_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -159,6 +175,17 @@ class Automation(Base):
         "AutomationDisableEvent",
         back_populates="automation",
         cascade="all, delete-orphan",
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_automations_org_lifecycle_updated_at",
+            "org_id",
+            "lifecycle_status",
+            "updated_at",
+        ),
+        Index("ix_automations_source_automation_id", "source_automation_id"),
+        Index("ix_automations_last_test_run_id", "last_test_run_id"),
     )
 
 
@@ -273,68 +300,6 @@ class AutomationRun(Base):
         Index("ix_automation_runs_status_created_at", "status", "created_at"),
         Index("ix_automation_runs_status_timeout_at", "status", "timeout_at"),
         Index("ix_automation_runs_status_trigger_source", "status", "trigger_source"),
-    )
-
-
-class AutomationDraft(Base):
-    """Editable automation setup state, including incomplete form drafts."""
-
-    __tablename__ = "automation_drafts"
-
-    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
-    user_id: Mapped[uuid.UUID] = mapped_column(Uuid, nullable=False, index=True)
-    org_id: Mapped[uuid.UUID] = mapped_column(Uuid, nullable=False, index=True)
-
-    # Creation endpoint this draft body targets: /v1, /v1/preset/prompt, etc.
-    endpoint: Mapped[str] = mapped_column(String(64), nullable=False)
-    name: Mapped[str | None] = mapped_column(String(500), nullable=True)
-
-    # Partial request body owned by the setup UI. It may be incomplete and is
-    # only promoted to an Automation after full endpoint-schema validation.
-    draft_body: Mapped[dict[str, Any]] = mapped_column(
-        JSON, nullable=False, default=dict
-    )
-    validation_errors: Mapped[list[dict[str, Any]] | None] = mapped_column(
-        JSON, nullable=True
-    )
-    dispatchable: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=False, server_default=text("false")
-    )
-
-    source_automation_id: Mapped[uuid.UUID | None] = mapped_column(
-        Uuid, ForeignKey("automations.id", ondelete="SET NULL"), nullable=True
-    )
-    materialized_automation_id: Mapped[uuid.UUID | None] = mapped_column(
-        Uuid, ForeignKey("automations.id", ondelete="SET NULL"), nullable=True
-    )
-    last_test_run_id: Mapped[uuid.UUID | None] = mapped_column(
-        Uuid, ForeignKey("automation_runs.id", ondelete="SET NULL"), nullable=True
-    )
-
-    deleted_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True, index=True
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
-        server_default=text("CURRENT_TIMESTAMP"),
-        nullable=False,
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
-        server_default=text("CURRENT_TIMESTAMP"),
-        onupdate=utcnow,
-        nullable=False,
-    )
-
-    __table_args__ = (
-        Index("ix_automation_drafts_org_updated_at", "org_id", "updated_at"),
-        Index("ix_automation_drafts_org_deleted_at", "org_id", "deleted_at"),
-        Index("ix_automation_drafts_source_automation_id", "source_automation_id"),
-        Index(
-            "ix_automation_drafts_materialized_automation_id",
-            "materialized_automation_id",
-        ),
-        Index("ix_automation_drafts_last_test_run_id", "last_test_run_id"),
     )
 
 

--- a/openhands/automation/preset_router.py
+++ b/openhands/automation/preset_router.py
@@ -58,6 +58,9 @@ from openhands.automation.telemetry import (
     get_request_telemetry_context,
 )
 from openhands.automation.utils import utcnow
+from openhands.automation.utils.automation_shape import (
+    assert_executable_automation_shape,
+)
 from openhands.automation.utils.model_profiles import resolve_model_profile_for_user
 from openhands.automation.utils.tarball_validation import (
     build_internal_url,
@@ -586,10 +589,16 @@ async def create_automation_from_prompt(
                 request
             ).frontend_distinct_id,
         )
+        if lifecycle_status == ModelAutomationState.ACTIVE:
+            await assert_executable_automation_shape(
+                automation, user, session, message="Automation cannot be enabled"
+            )
         session.add(automation)
         await session.flush()
         await session.refresh(automation)
         await mark_git_sync_dirty(session, automation)
+    except HTTPException:
+        raise
     except Exception as e:
         # Clean up orphaned upload on automation creation failure
         try:
@@ -1029,10 +1038,16 @@ async def create_automation_from_plugin(
                 request
             ).frontend_distinct_id,
         )
+        if lifecycle_status == ModelAutomationState.ACTIVE:
+            await assert_executable_automation_shape(
+                automation, user, session, message="Automation cannot be enabled"
+            )
         session.add(automation)
         await session.flush()
         await session.refresh(automation)
         await mark_git_sync_dirty(session, automation)
+    except HTTPException:
+        raise
     except Exception as e:
         # Clean up orphaned upload on automation creation failure
         try:

--- a/openhands/automation/router.py
+++ b/openhands/automation/router.py
@@ -55,6 +55,9 @@ from openhands.automation.utils.api_key import (
     APIKeyError,
     get_api_key_for_automation_run,
 )
+from openhands.automation.utils.automation_shape import (
+    assert_executable_automation_shape,
+)
 from openhands.automation.utils.callback_error import format_callback_error
 from openhands.automation.utils.conversation_outcome import (
     fetch_latest_finish_tool_response_for_run,
@@ -194,6 +197,11 @@ async def create_automation(
             request
         ).frontend_distinct_id,
     )
+    if lifecycle_status == ModelAutomationState.ACTIVE:
+        await assert_executable_automation_shape(
+            auto, user, session, message="Automation cannot be enabled"
+        )
+
     session.add(auto)
     await session.flush()
     await session.refresh(auto)
@@ -344,6 +352,11 @@ async def update_automation(
         if auto.preset_metadata is not None:
             auto.preset_metadata = {**auto.preset_metadata, "prompt": auto.prompt}
 
+    if auto.lifecycle_status == ModelAutomationState.ACTIVE:
+        await assert_executable_automation_shape(
+            auto, user, session, message="Automation cannot be enabled"
+        )
+
     if skip_pending_reason is not None:
         await skip_pending_runs_for_disabled_automation(
             session,
@@ -431,6 +444,11 @@ async def download_automation_tarball(
     - 404 if the automation has no accessible tarball.
     """
     auto = await _get_org_automation(session, automation_id, user.org_id)
+    if not auto.tarball_path:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Automation has no tarball yet",
+        )
 
     upload_id = parse_internal_upload_id(auto.tarball_path)
     if upload_id is not None:
@@ -499,6 +517,9 @@ async def dispatch_automation(
     """
     auto = await _get_org_automation(session, automation_id, user.org_id)
     await _assert_can_manage(auto, user)
+    await assert_executable_automation_shape(
+        auto, user, session, message="Automation is not dispatchable"
+    )
     run = await create_pending_run(
         session,
         auto,

--- a/openhands/automation/schemas.py
+++ b/openhands/automation/schemas.py
@@ -796,13 +796,13 @@ class AutomationResponse(BaseModel):
     org_id: uuid.UUID
     model: str | None
 
-    name: str
+    name: str | None
     prompt: str | None
     preset_metadata: dict | None = None
-    trigger: dict
-    tarball_path: str
+    trigger: dict | None
+    tarball_path: str | None
     setup_script_path: str | None
-    entrypoint: str
+    entrypoint: str | None
     timeout: int | None
     keep_alive: bool | None
     enabled: bool

--- a/openhands/automation/utils/automation_shape.py
+++ b/openhands/automation/utils/automation_shape.py
@@ -1,0 +1,146 @@
+"""Validation helpers for executable automation definitions."""
+
+from fastapi import HTTPException, status
+from pydantic import TypeAdapter, ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from openhands.automation.auth import AuthenticatedUser
+from openhands.automation.models import Automation
+from openhands.automation.schemas import (
+    DraftValidationError,
+    Trigger,
+    validate_command_string,
+)
+from openhands.automation.utils.model_profiles import validate_model_profile_for_user
+from openhands.automation.utils.tarball_validation import validate_tarball_path
+
+
+_TRIGGER_ADAPTER = TypeAdapter(Trigger)
+
+
+def _field_required(field: str) -> DraftValidationError:
+    return DraftValidationError(
+        field=field,
+        code="field_required",
+        message="Field required for an executable automation",
+    )
+
+
+def _shape_error(field: str, message: str) -> DraftValidationError:
+    return DraftValidationError(field=field, code="invalid", message=message)
+
+
+def _pydantic_errors(
+    e: ValidationError, field_prefix: str
+) -> list[DraftValidationError]:
+    errors: list[DraftValidationError] = []
+    for err in e.errors():
+        loc = err.get("loc", ())
+        path = field_prefix
+        if loc:
+            path += "." + ".".join(str(part) for part in loc if part != "tagged-union")
+        errors.append(
+            DraftValidationError(
+                field=path,
+                code=str(err.get("type", "invalid")),
+                message=str(err.get("msg", "Invalid value")),
+            )
+        )
+    return errors
+
+
+async def validate_executable_automation_shape(
+    automation: Automation,
+    user: AuthenticatedUser,
+    session: AsyncSession,
+) -> list[DraftValidationError]:
+    """Return validation errors that prevent an automation from executing.
+
+    DRAFT rows may be partial, but any row that is enabled or dispatched must
+    have the executable shape the dispatcher expects.
+    """
+    errors: list[DraftValidationError] = []
+
+    if not automation.name or not automation.name.strip():
+        errors.append(_field_required("name"))
+
+    if automation.trigger is None:
+        errors.append(_field_required("trigger"))
+    else:
+        try:
+            _TRIGGER_ADAPTER.validate_python(automation.trigger)
+        except ValidationError as e:
+            errors.extend(_pydantic_errors(e, "trigger"))
+
+    if not automation.tarball_path:
+        errors.append(_field_required("tarball_path"))
+    else:
+        try:
+            await validate_tarball_path(
+                tarball_path=automation.tarball_path,
+                user_id=user.user_id,
+                org_id=user.org_id,
+                session=session,
+            )
+        except HTTPException as e:
+            errors.append(
+                DraftValidationError(
+                    field="tarball_path",
+                    code=f"tarball_path_{e.status_code}",
+                    message=str(e.detail),
+                )
+            )
+
+    if not automation.entrypoint:
+        errors.append(_field_required("entrypoint"))
+    else:
+        try:
+            validate_command_string(
+                automation.entrypoint, "entrypoint", allow_none=False
+            )
+        except ValueError as e:
+            errors.append(_shape_error("entrypoint", str(e)))
+
+    if automation.setup_script_path is not None:
+        try:
+            validate_command_string(automation.setup_script_path, "setup_script_path")
+        except ValueError as e:
+            errors.append(_shape_error("setup_script_path", str(e)))
+
+    try:
+        validate_model_profile_for_user(automation.model, user)
+    except HTTPException as e:
+        errors.append(
+            DraftValidationError(
+                field="model",
+                code="model_profile_not_found",
+                message=str(e.detail),
+            )
+        )
+
+    return errors
+
+
+async def assert_executable_automation_shape(
+    automation: Automation,
+    user: AuthenticatedUser,
+    session: AsyncSession,
+    *,
+    message: str = "Automation is not executable",
+) -> None:
+    errors = await validate_executable_automation_shape(automation, user, session)
+    if errors:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "message": message,
+                "errors": [error.model_dump() for error in errors],
+            },
+        )
+
+
+def require_dispatch_fields(automation: Automation) -> tuple[str, str]:
+    """Return dispatcher-critical fields after validation has made them non-null."""
+    if automation.tarball_path is None or automation.entrypoint is None:
+        raise ValueError("Automation is missing executable dispatch fields")
+    return automation.tarball_path, automation.entrypoint

--- a/tests/test_draft_router.py
+++ b/tests/test_draft_router.py
@@ -9,7 +9,6 @@ import pytest
 from openhands.automation.app import app
 from openhands.automation.models import (
     Automation,
-    AutomationDraft,
     AutomationRun,
     AutomationState,
 )
@@ -59,9 +58,10 @@ async def test_create_incomplete_draft_saves_partial_body(async_client, async_se
     assert data["dispatchable"] is False
     assert data["validation_errors"]
 
-    draft = await async_session.get(AutomationDraft, uuid.UUID(data["id"]))
+    draft = await async_session.get(Automation, uuid.UUID(data["id"]))
     assert draft is not None
-    assert draft.materialized_automation_id is None
+    assert draft.lifecycle_status == AutomationState.DRAFT
+    assert draft.tarball_path is None
 
 
 async def test_raw_draft_with_missing_upload_is_not_dispatchable(
@@ -92,9 +92,10 @@ async def test_raw_draft_with_missing_upload_is_not_dispatchable(
         }
     ]
 
-    draft = await async_session.get(AutomationDraft, uuid.UUID(data["id"]))
+    draft = await async_session.get(Automation, uuid.UUID(data["id"]))
     assert draft is not None
-    assert draft.materialized_automation_id is None
+    assert draft.lifecycle_status == AutomationState.DRAFT
+    assert draft.tarball_path is None
 
 
 async def test_incomplete_draft_dispatch_returns_validation_errors(
@@ -112,9 +113,31 @@ async def test_incomplete_draft_dispatch_returns_validation_errors(
     detail = response.json()["detail"]
     assert detail["message"] == "Draft is not dispatchable"
     assert detail["errors"]
-    draft = await async_session.get(AutomationDraft, uuid.UUID(draft_id))
+    draft = await async_session.get(Automation, uuid.UUID(draft_id))
     assert draft is not None
-    assert draft.materialized_automation_id is None
+    assert draft.lifecycle_status == AutomationState.DRAFT
+    assert draft.tarball_path is None
+
+
+async def test_incomplete_draft_cannot_be_enabled(async_client):
+    created = await async_client.post(
+        "/api/automation/v1/drafts",
+        json={"endpoint": "/v1/preset/prompt", "draft": {"name": "Incomplete"}},
+    )
+    draft_id = created.json()["id"]
+
+    response = await async_client.patch(
+        f"/api/automation/v1/{draft_id}", json={"lifecycle_status": "ACTIVE"}
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail["message"] == "Automation cannot be enabled"
+    assert {error["field"] for error in detail["errors"]} >= {
+        "trigger",
+        "tarball_path",
+        "entrypoint",
+    }
 
 
 async def test_dispatchable_prompt_draft_materializes_disabled_draft_and_manual_run(
@@ -144,12 +167,12 @@ async def test_dispatchable_prompt_draft_materializes_disabled_draft_and_manual_
     assert run_data["status"] == "PENDING"
     assert run_data["trigger_source"] == "manual"
 
-    draft = await async_session.get(AutomationDraft, uuid.UUID(created.json()["id"]))
+    draft = await async_session.get(Automation, uuid.UUID(created.json()["id"]))
     assert draft is not None
     assert draft.last_test_run_id == uuid.UUID(run_data["id"])
-    assert draft.materialized_automation_id is not None
+    assert draft.lifecycle_status == AutomationState.DRAFT
 
-    automation = await async_session.get(Automation, draft.materialized_automation_id)
+    automation = draft
     assert automation is not None
     assert automation.enabled is False
     assert automation.lifecycle_status == AutomationState.DRAFT


### PR DESCRIPTION
## Summary
- Store setup drafts as `DRAFT` rows in the existing `automations` table instead of a separate `automation_drafts` table.
- Move draft metadata (`draft_endpoint`, `draft_body`, validation state, source automation, last test run) onto `automations` and make execution-only fields nullable for incomplete drafts.
- Add centralized executable-shape validation and enforce it before enabling or manually dispatching automations.
- Keep draft test runs linked through `automation_runs.automation_id` by materializing executable fields onto the same draft row.
- Skip `DRAFT` rows in git sync so incomplete setup state is not exported as runnable automation definitions.

## Validation
- `uv run ruff check openhands/automation/models.py openhands/automation/draft_router.py openhands/automation/router.py openhands/automation/preset_router.py openhands/automation/dispatcher.py openhands/automation/git_sync/loop.py openhands/automation/utils/automation_shape.py tests/test_draft_router.py`
- `AUTOMATION_DB_URL="sqlite:///$tmpdb" uv run alembic upgrade head`
- `uv run pytest tests/ -q --ignore=tests/integration` — 1591 passed, 7 skipped

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/86d081af-31ff-44c8-8f88-996860769c79)