### PR TITLE
docs(codereview): require design docs for deep, high-risk PRs

### DIFF
--- a/.agents/skills/custom-codereview-guide.md
+++ b/.agents/skills/custom-codereview-guide.md
@@ -34,7 +34,9 @@ of minutes, for example:
 
 - a new or changed automation contract, webhook/event payload, or dispatch API;
 - a new module or subsystem, or a cross-cutting refactor or migration;
-- a behavior change in core logic (scheduling, run history, dispatch flow).
+- a behavior change in core logic (scheduling, run history, dispatch flow); or
+- a large diff (roughly 500+ lines changed) whose intent a reviewer cannot hold
+  in their head at once, even if no single hunk is complex.
 
 Skip it for trivial PRs — a typo, a one-line guard, a config or dependency
 bump, a docs tweak, a small localized bug fix. If the diff is its own

--- a/.agents/skills/custom-codereview-guide.md
+++ b/.agents/skills/custom-codereview-guide.md
@@ -20,6 +20,40 @@ A review that says "Worth merging" but is submitted as COMMENTED does not
 satisfy the repository's required review gate and leaves the PR blocked
 indefinitely. Always match your submission action to your verdict.
 
+## Design Docs for Deep PRs
+
+A diff shows what changed line by line, not the design: the shape of the
+change, the API before and after, and why this approach. For a *deep* PR,
+expect a short design doc. The `pr-design-doc` skill in
+`.agents/skills/pr-design-doc/` produces a self-contained `.pr/` HTML page
+(big picture plus before/after, grounded to real code) linked from the PR
+description.
+
+A PR is "deep" when a reviewer cannot fully judge it from the diff in a couple
+of minutes, for example:
+
+- a new or changed automation contract, webhook/event payload, or dispatch API;
+- a new module or subsystem, or a cross-cutting refactor or migration;
+- a behavior change in core logic (scheduling, run history, dispatch flow).
+
+Skip it for trivial PRs — a typo, a one-line guard, a config or dependency
+bump, a docs tweak, a small localized bug fix. If the diff is its own
+explanation, do not ask for a page.
+
+When a deep PR ships without a design doc, weigh the omission against the
+change's risk assessment:
+
+- **🔴 HIGH risk and deep, no design doc:** withhold approval. Submit the
+  review as COMMENTED and ask for a design doc (or an equivalent write-up in
+  the PR description) so a human can judge the proposal before merge.
+- **🟡 MEDIUM risk and deep, no design doc:** use judgment. Prefer to withhold
+  approval and request one when the change is hard to reconstruct from the
+  diff; a MEDIUM change that is small and self-evident does not need a page.
+- **🟢 LOW risk:** never block on a missing design doc.
+
+A design doc is a review aid, not a merge gate by itself. A well-written doc
+does not excuse real correctness, security, or architecture problems.
+
 ## Repository Context
 
 This repository uses GitHub branch protection rules that require at least one


### PR DESCRIPTION
## Why

The automation repository already provides the `pr-design-doc` skill, but its automated review guide does not say when reviewers should expect design context. This follow-up makes that expectation explicit for deep, high-risk scheduling, webhook, event, and dispatch changes while exempting small or self-explanatory diffs.

## Summary

- Define practical deep-PR signals for automation contracts, webhook/event payloads, dispatch APIs, new subsystems, migrations, core behavior, and hard-to-reconstruct large changes.
- Tell the reviewer not to approve when important design context is missing, scaled by risk.
- Keep design docs advisory for low-risk or self-explanatory changes and preserve correctness, security, and architecture review as the primary gates.

## Issue Number

Fixes #443

## How to Test

From the PR head, the following lightweight validation passed:

```bash
git diff --check origin/main...pr-441
grep -q '^triggers:' .agents/skills/custom-codereview-guide.md
```

The PR's required description and title checks pass. Review the new decision matrix against `.agents/skills/pr-design-doc/SKILL.md` and the repository's required approval-review policy.

## Video/Screenshots

Not applicable. This changes repository-local Markdown review guidance and has no product UI.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Review identified one lifecycle concern still requiring author action: same-repository `.pr/` artifacts are removed as soon as an automated approval is submitted, which can make a branch-linked design doc disappear before a human maintainer reads it. The policy should require durable equivalent context in the PR description before approval, or otherwise reconcile cleanup timing.

---

_This PR description was updated by an AI agent (OpenHands) on behalf of @enyst._
