### PR TITLE
fix(ci): pull MinIO test image from Quay

### DIFF
--- a/tests/test_storage_s3_integration.py
+++ b/tests/test_storage_s3_integration.py
@@ -20,6 +20,9 @@ from openhands.automation.storage import ObjectNotFoundError, S3FileStore
 from openhands.automation.storage.google_cloud import FileSizeLimitExceeded
 
 
+MINIO_IMAGE = "quay.io/minio/minio:RELEASE.2022-12-02T19-19-22Z"
+
+
 @pytest.fixture(scope="module")
 def minio_container():
     """Start a MinIO container for integration tests.
@@ -27,7 +30,7 @@ def minio_container():
     This fixture is module-scoped for efficiency - the container is
     reused across all tests in the module.
     """
-    with MinioContainer() as minio:
+    with MinioContainer(image=MINIO_IMAGE) as minio:
         yield minio
 
 


### PR DESCRIPTION
## Why

The unit-test workflow can no longer start the MinIO-backed S3 integration tests because Docker Hub now returns 404 for `minio/minio`, including the tag used by Testcontainers. This produced 17 setup errors in otherwise passing runs on [PR 437](https://github.com/OpenHands/automation/pull/437) and [PR 446](https://github.com/OpenHands/automation/pull/446).

## Summary

Override Testcontainers' legacy Docker Hub default with the same official MinIO release hosted on Quay. The release tag and test behavior stay unchanged; only the image registry changes.

## Issue Number

N/A — shared CI dependency outage.

## How to Test

- Confirmed Docker Hub returns 404 for `minio/minio:RELEASE.2022-12-02T19-19-22Z`.
- Confirmed Quay publishes the identical release tag.
- Verified `MinioContainer` receives the explicit Quay image reference.
- Ran Ruff format/check, Python compilation, and `git diff --check` successfully.
- Full container execution is left to CI because the local environment cannot access the Docker socket.

HUMAN: I reviewed the failed workflow logs from both affected PRs and verified the replacement image tag.



## Recorded evidence

Before: [PR #437 unit-test job](https://github.com/OpenHands/automation/actions/runs/34567126104/job/103554719509) has 17 MinIO setup errors because Docker Hub returns image 404. After: [composed PR #449 unit-test job](https://github.com/OpenHands/automation/actions/runs/34762515180/job/103737703292) pulls the same release from Quay and reports 1,734 passed, 7 skipped. The passing job belongs to #449, which includes this unchanged image repair; #447 itself has no current unit-test job. This is integration evidence for the image repair, not a changed Canvas interface.
